### PR TITLE
Replaced deprecated loadNibNamed

### DIFF
--- a/apple/CocoaWrapper/mac/CocoaWrapper.mm
+++ b/apple/CocoaWrapper/mac/CocoaWrapper.mm
@@ -123,7 +123,7 @@ using namespace GemRB;
 	// we configure this here so that when GemRB is launched though means such as Drag/Drop we dont show the config window
 
 	_showConfigWindow = YES; //still need to set this to YES in case an error occurs
-	[NSBundle loadNibNamed:@"GemRB" owner:self];
+	[[NSBundle mainBundle] loadNibNamed:@"GemRB" owner:self topLevelObjects:nil];
 
 	if (core == NULL) {
 		[_configWindow makeKeyAndOrderFront:nil];


### PR DESCRIPTION
`loadNibNamed:owner` was deprecated on OSX 10.8 and the code was failing during compilation.

I replaced with `loadNibNamed:owner:topLevelObjects:` is not deprecated so I replaced with it.
