### PR TITLE
Add Keywords field in the GemRB desktop.

### DIFF
--- a/gemrb.desktop
+++ b/gemrb.desktop
@@ -8,3 +8,4 @@ Icon=gemrb
 Terminal=true
 Exec=gemrb
 Categories=Game;RolePlaying;Emulator;
+Keywords=roleplay;rpg;adventure;game;2d;isometric;gemrb;infinite engine;black isle;


### PR DESCRIPTION
Debian packaging guidelines enforce the use of keywords in .desktop files, in order to better classify applications. This commit adds a few of them to the GemRB launcher.
