### PR TITLE
Log full config path instead of the 16-char buffer that overflows.

### DIFF
--- a/gemrb/core/InterfaceConfig.cpp
+++ b/gemrb/core/InterfaceConfig.cpp
@@ -180,9 +180,9 @@ bool CFGConfig::InitWithINIData(DataStream* const cfgStream)
 	}
 
 	if (isValid) {
-		Log(WARNING, "Config", "attempting to replace config values with contents of %s", cfgStream->filename);
+		Log(WARNING, "Config", "attempting to replace config values with contents of %s", cfgStream->originalfile);
 	} else {
-		Log(MESSAGE, "Config", "attempting to initialize config with %s", cfgStream->filename);
+		Log(MESSAGE, "Config", "attempting to initialize config with %s", cfgStream->originalfile);
 	}
 
 	isValid = false;


### PR DESCRIPTION
The configuration file name is usually longer than 16 characters. When the configuration file stream is created, the originalFile member is copied to the filename member, which is a 16 char long buffer, and the terminating \0 is overwritten.

When logging the file name that has been used as the configuration file, an incorrect name is printed, the concatenation of the 16-char buffer and the original filename.