### PR TITLE
SDL20GLVideo plugin uses GemRBPath to look for shader sources.

### DIFF
--- a/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
@@ -147,7 +147,7 @@ bool GLVideoDriver::createPrograms()
 	float matrix[16];
 	Matrix::SetIdentityM(matrix);
 
-	program32 = GLSLProgram::CreateFromFiles("Shaders/Sprite.glslv", "Shaders/Sprite32.glslf");
+	program32 = GLSLProgram::CreateFromFiles(std::string(core->GemRBPath) + "/Shaders/Sprite.glslv", std::string(core->GemRBPath) + "/Shaders/Sprite32.glslf");
 	if (!program32)
 	{
 		msg = GLSLProgram::GetLastError();
@@ -158,7 +158,7 @@ bool GLVideoDriver::createPrograms()
 	program32->SetUniformValue("s_texture", 1, 0);
 	program32->SetUniformMatrixValue("u_matrix", 4, 1, matrix);
 	
-	programPal = GLSLProgram::CreateFromFiles("Shaders/Sprite.glslv", "Shaders/SpritePal.glslf");
+	programPal = GLSLProgram::CreateFromFiles(std::string(core->GemRBPath) + "/Shaders/Sprite.glslv", std::string(core->GemRBPath) + "/Shaders/SpritePal.glslf");
 	if (!programPal)
 	{
 		msg = GLSLProgram::GetLastError();
@@ -171,7 +171,7 @@ bool GLVideoDriver::createPrograms()
 	programPal->SetUniformValue("s_mask", 1, 2);
 	programPal->SetUniformMatrixValue("u_matrix", 4, 1, matrix);
 
-	programPalGrayed = GLSLProgram::CreateFromFiles("Shaders/Sprite.glslv", "Shaders/SpritePalGrayed.glslf");
+	programPalGrayed = GLSLProgram::CreateFromFiles(std::string(core->GemRBPath) + "/Shaders/Sprite.glslv", std::string(core->GemRBPath) + "/Shaders/SpritePalGrayed.glslf");
 	if (!programPalGrayed)
 	{
 		msg = GLSLProgram::GetLastError();
@@ -184,7 +184,7 @@ bool GLVideoDriver::createPrograms()
 	programPal->SetUniformValue("s_mask", 1, 2);
 	programPalGrayed->SetUniformMatrixValue("u_matrix", 4, 1, matrix);
 
-	programPalSepia = GLSLProgram::CreateFromFiles("Shaders/Sprite.glslv", "Shaders/SpritePalSepia.glslf");
+	programPalSepia = GLSLProgram::CreateFromFiles(std::string(core->GemRBPath) + "/Shaders/Sprite.glslv", std::string(core->GemRBPath) + "/Shaders/SpritePalSepia.glslf");
 	if (!programPalSepia)
 	{
 		msg = GLSLProgram::GetLastError();
@@ -197,7 +197,7 @@ bool GLVideoDriver::createPrograms()
 	programPal->SetUniformValue("s_mask", 1, 2);;
 	programPalSepia->SetUniformMatrixValue("u_matrix", 4, 1, matrix);
 	
-	programEllipse = GLSLProgram::CreateFromFiles("Shaders/Ellipse.glslv", "Shaders/Ellipse.glslf");
+	programEllipse = GLSLProgram::CreateFromFiles(std::string(core->GemRBPath) + "/Shaders/Ellipse.glslv", std::string(core->GemRBPath) + "/Shaders/Ellipse.glslf");
 	if (!programEllipse)
 	{
 		msg = GLSLProgram::GetLastError();
@@ -207,7 +207,7 @@ bool GLVideoDriver::createPrograms()
 	programEllipse->Use();
 	programEllipse->SetUniformMatrixValue("u_matrix", 4, 1, matrix);
 
-	programRect = GLSLProgram::CreateFromFiles("Shaders/Rect.glslv", "Shaders/Rect.glslf");
+	programRect = GLSLProgram::CreateFromFiles(std::string(core->GemRBPath) + "/Shaders/Rect.glslv", std::string(core->GemRBPath) + "/Shaders/Rect.glslf");
 	if (!programRect)
 	{
 		msg = GLSLProgram::GetLastError();


### PR DESCRIPTION
The new SDL2.0 video plugin usually fails to find the shader files. With #22 installing the files to GemRB DATA_DIR, we can use the GemRBPath value as the folder where to look for shaders.
