### PR TITLE
Fix crash when unsing custom fonts (TTF).

### DIFF
--- a/gemrb/core/Palette.h
+++ b/gemrb/core/Palette.h
@@ -49,9 +49,10 @@ public:
 	Palette(const Color &color, const Color &back);
 
 	Palette(const Color* colours, bool alpha_=false) {
-		for (int i = 0; i < 256; ++i) {
-			col[i] = colours[i];
-		}
+		if(colours)
+			for (int i = 0; i < 256; ++i) {
+					col[i] = colours[i];
+			}
 		alpha = alpha_;
 		refcount = 1;
 		named = false;

--- a/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
@@ -240,7 +240,7 @@ Sprite2D* GLVideoDriver::CreatePalettedSprite(int w, int h, int bpp, void* pixel
 
 Sprite2D* GLVideoDriver::CreateSprite8(int w, int h, void* pixels, Palette* palette, bool cK, int index)
 {
-	return CreatePalettedSprite(w, h, 8, pixels, palette->col, cK, index);
+	return CreatePalettedSprite(w, h, 8, pixels, palette ? palette->col : NULL, cK, index);
 }
 
 void GLVideoDriver::GLBlitSprite(GLTextureSprite2D* spr, const Region& src, const Region& dst, Palette* attachedPal,


### PR DESCRIPTION
I was using "DejaVuSans.TTF" as substitue for "NORMAL", as a test case.
I got a crash during loading (referencing null pointer...).