### PR TITLE
Sdl2 hacking

### DIFF
--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -150,6 +150,8 @@ doneFormat:
 		width, height, SDL_GetPixelFormatName(format));
 	backBuf = SDL_CreateRGBSurface( 0, width, height,
 									bpp, r, g, b, a );
+    // tmpBuf is here as a truly ugly hack, so we can copy backBuf to tmpBuf before blitting cursors, and then back again after the screen is presented.
+    tmpBuf = SDL_CreateRGBSurface( 0, width, height, bpp, r, g, b, a );
 	this->bpp = bpp;
 
 	if (!backBuf) {
@@ -329,9 +331,12 @@ void SDL20VideoDriver::showYUVFrame(unsigned char** buf, unsigned int *strides,
 
 int SDL20VideoDriver::SwapBuffers(void)
 {
-	int ret = SDLVideoDriver::SwapBuffers();
+    //this is not pretty. We make a complete copy of the backBuf into tmpBuf, then copy it back after SDLVideoDriver::SwapBuffers has blitted cursors and tooltips, and SDL_UpdateTexture has copied it to the screentexture.
+    SDL_BlitSurface(backBuf, NULL, tmpBuf, NULL);
+    int ret = SDLVideoDriver::SwapBuffers();
 
 	SDL_UpdateTexture(screenTexture, NULL, backBuf->pixels, backBuf->pitch);
+    SDL_BlitSurface(tmpBuf, NULL, backBuf, NULL);
 	/*
 	 Commenting this out because I get better performance (on iOS) with SDL_UpdateTexture
 	 Don't know how universal it is yet so leaving this in commented out just in case

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -62,8 +62,8 @@ int SDL20VideoDriver::CreateDisplay(int w, int h, int bpp, bool fs, const char* 
 	width = w, height = h;
 
 	Log(MESSAGE, "SDL 2 Driver", "Creating display");
-    // TODO: scale methods can be nearest or linear, and should be settable in config
-    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
+	// TODO: scale methods can be nearest or linear, and should be settable in config
+	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
 	Uint32 winFlags = SDL_WINDOW_SHOWN | SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE;
 #if TARGET_OS_IPHONE || ANDROID
 	// this allows the user to flip the device upsidedown if they wish and have the game rotate.
@@ -150,8 +150,8 @@ doneFormat:
 		width, height, SDL_GetPixelFormatName(format));
 	backBuf = SDL_CreateRGBSurface( 0, width, height,
 									bpp, r, g, b, a );
-    // tmpBuf is here as a truly ugly hack, so we can copy backBuf to tmpBuf before blitting cursors, and then back again after the screen is presented.
-    tmpBuf = SDL_CreateRGBSurface( 0, width, height, bpp, r, g, b, a );
+	// tmpBuf is here as a truly ugly hack, so we can copy backBuf to tmpBuf before blitting cursors, and then back again after the screen is presented.
+	tmpBuf = SDL_CreateRGBSurface( 0, width, height, bpp, r, g, b, a );
 	this->bpp = bpp;
 
 	if (!backBuf) {
@@ -331,12 +331,12 @@ void SDL20VideoDriver::showYUVFrame(unsigned char** buf, unsigned int *strides,
 
 int SDL20VideoDriver::SwapBuffers(void)
 {
-    //this is not pretty. We make a complete copy of the backBuf into tmpBuf, then copy it back after SDLVideoDriver::SwapBuffers has blitted cursors and tooltips, and SDL_UpdateTexture has copied it to the screentexture.
-    SDL_BlitSurface(backBuf, NULL, tmpBuf, NULL);
-    int ret = SDLVideoDriver::SwapBuffers();
+	//this is not pretty. We make a complete copy of the backBuf into tmpBuf, then copy it back after SDLVideoDriver::SwapBuffers has blitted cursors and tooltips, and SDL_UpdateTexture has copied it to the screentexture.
+	SDL_BlitSurface(backBuf, NULL, tmpBuf, NULL);
+	int ret = SDLVideoDriver::SwapBuffers();
 
 	SDL_UpdateTexture(screenTexture, NULL, backBuf->pixels, backBuf->pitch);
-    SDL_BlitSurface(tmpBuf, NULL, backBuf, NULL);
+	SDL_BlitSurface(tmpBuf, NULL, backBuf, NULL);
 	/*
 	 Commenting this out because I get better performance (on iOS) with SDL_UpdateTexture
 	 Don't know how universal it is yet so leaving this in commented out just in case
@@ -367,7 +367,7 @@ int SDL20VideoDriver::SwapBuffers(void)
 	 SDL_RenderFillRect(renderer, &dst);
 	 }
 	 */
-    SDL_RenderClear(renderer);
+	SDL_RenderClear(renderer);
 	SDL_RenderCopy(renderer, screenTexture, NULL, NULL);
 	SDL_RenderPresent( renderer );
 	return ret;
@@ -780,10 +780,10 @@ void SDL20VideoDriver::SetGamma(int brightness, int /*contrast*/)
 
 bool SDL20VideoDriver::SetFullscreenMode(bool set)
 {
-    Uint32 flags = 0;
-    if (set) {
-        flags = SDL_WINDOW_FULLSCREEN_DESKTOP;
-    }
+	Uint32 flags = 0;
+	if (set) {
+	flags = SDL_WINDOW_FULLSCREEN_DESKTOP;
+	}
 	if (SDL_SetWindowFullscreen(window, flags) == GEM_OK) {
 		fullscreen = set;
 		return true;

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -332,11 +332,15 @@ void SDL20VideoDriver::showYUVFrame(unsigned char** buf, unsigned int *strides,
 int SDL20VideoDriver::SwapBuffers(void)
 {
 	//this is not pretty. We make a complete copy of the backBuf into tmpBuf, then copy it back after SDLVideoDriver::SwapBuffers has blitted cursors and tooltips, and SDL_UpdateTexture has copied it to the screentexture.
-	SDL_BlitSurface(backBuf, NULL, tmpBuf, NULL);
+	if (Cursor[CursorIndex] && !(MouseFlags & (MOUSE_DISABLED | MOUSE_HIDDEN))) {
+		SDL_BlitSurface(backBuf, NULL, tmpBuf, NULL);
+	}
 	int ret = SDLVideoDriver::SwapBuffers();
 
 	SDL_UpdateTexture(screenTexture, NULL, backBuf->pixels, backBuf->pitch);
-	SDL_BlitSurface(tmpBuf, NULL, backBuf, NULL);
+	if (Cursor[CursorIndex] && !(MouseFlags & (MOUSE_DISABLED | MOUSE_HIDDEN))) {
+		SDL_BlitSurface(tmpBuf, NULL, backBuf, NULL);
+	}
 	/*
 	 Commenting this out because I get better performance (on iOS) with SDL_UpdateTexture
 	 Don't know how universal it is yet so leaving this in commented out just in case

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -62,7 +62,7 @@ int SDL20VideoDriver::CreateDisplay(int w, int h, int bpp, bool fs, const char* 
 	width = w, height = h;
 
 	Log(MESSAGE, "SDL 2 Driver", "Creating display");
-	Uint32 winFlags = SDL_WINDOW_SHOWN | SDL_WINDOW_OPENGL;
+	Uint32 winFlags = SDL_WINDOW_SHOWN | SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE;
 #if TARGET_OS_IPHONE || ANDROID
 	// this allows the user to flip the device upsidedown if they wish and have the game rotate.
 	// it also for some unknown reason is required for retina displays
@@ -72,7 +72,7 @@ int SDL20VideoDriver::CreateDisplay(int w, int h, int bpp, bool fs, const char* 
 	SDL_SetHintWithPriority(SDL_HINT_ORIENTATIONS, "LandscapeRight LandscapeLeft", SDL_HINT_DEFAULT);
 #endif
 	if (fullscreen) {
-		winFlags |= SDL_WINDOW_FULLSCREEN;
+		winFlags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 		//This is needed to remove the status bar on Android/iOS.
 		//since we are in fullscreen this has no effect outside Android/iOS
 		winFlags |= SDL_WINDOW_BORDERLESS;
@@ -772,7 +772,11 @@ void SDL20VideoDriver::SetGamma(int brightness, int /*contrast*/)
 
 bool SDL20VideoDriver::SetFullscreenMode(bool set)
 {
-	if (SDL_SetWindowFullscreen(window, (SDL_bool)set) == GEM_OK) {
+    Uint32 flags = 0;
+    if (set) {
+        flags = SDL_WINDOW_FULLSCREEN_DESKTOP;
+    }
+	if (SDL_SetWindowFullscreen(window, flags) == GEM_OK) {
 		fullscreen = set;
 		return true;
 	}

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -62,6 +62,8 @@ int SDL20VideoDriver::CreateDisplay(int w, int h, int bpp, bool fs, const char* 
 	width = w, height = h;
 
 	Log(MESSAGE, "SDL 2 Driver", "Creating display");
+    // TODO: scale methods can be nearest or linear, and should be settable in config
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
 	Uint32 winFlags = SDL_WINDOW_SHOWN | SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE;
 #if TARGET_OS_IPHONE || ANDROID
 	// this allows the user to flip the device upsidedown if they wish and have the game rotate.
@@ -360,6 +362,7 @@ int SDL20VideoDriver::SwapBuffers(void)
 	 SDL_RenderFillRect(renderer, &dst);
 	 }
 	 */
+    SDL_RenderClear(renderer);
 	SDL_RenderCopy(renderer, screenTexture, NULL, NULL);
 	SDL_RenderPresent( renderer );
 	return ret;

--- a/gemrb/plugins/SDLVideo/SDLVideo.h
+++ b/gemrb/plugins/SDLVideo/SDLVideo.h
@@ -50,8 +50,8 @@ class SDLVideoDriver : public Video {
 protected:
 	SDL_Surface* disp;
 	SDL_Surface* backBuf;
-    // tmpBuf is here as a truly ugly hack, so we can copy backBuf to tmpBuf before blitting cursors, and then back again after the screen is presented. Only applies for SDL2.
-    SDL_Surface* tmpBuf;
+	// tmpBuf is here as a truly ugly hack, so we can copy backBuf to tmpBuf before blitting cursors, and then back again after the screen is presented. Only applies for SDL2.
+	SDL_Surface* tmpBuf;
 	SDL_Surface* extra;
 	std::vector< Region> upd;//Regions of the Screen to Update in the next SwapBuffer operation.
 	unsigned long lastTime;

--- a/gemrb/plugins/SDLVideo/SDLVideo.h
+++ b/gemrb/plugins/SDLVideo/SDLVideo.h
@@ -50,6 +50,8 @@ class SDLVideoDriver : public Video {
 protected:
 	SDL_Surface* disp;
 	SDL_Surface* backBuf;
+    // tmpBuf is here as a truly ugly hack, so we can copy backBuf to tmpBuf before blitting cursors, and then back again after the screen is presented. Only applies for SDL2.
+    SDL_Surface* tmpBuf;
 	SDL_Surface* extra;
 	std::vector< Region> upd;//Regions of the Screen to Update in the next SwapBuffer operation.
 	unsigned long lastTime;


### PR DESCRIPTION
Trying to bring the SDL2 version up and above the SDL1 version:
- now uses windowed fullscreen, using SDL2's own scaling
- window can be resized, also using SDL2's own scaling
- cursor trails gone