### PR TITLE
Fix "reverse" scroll in SDL2 when too tall or wide

### DIFF
--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -1432,9 +1432,9 @@ end_function:
 /** Global Mouse Move Event */
 #if TARGET_OS_IPHONE
 // iOS will never have a mouse.
-void GameControl::OnGlobalMouseMove(unsigned short /*x*/, unsigned short /*y*/) {}
+void GameControl::OnGlobalMouseMove(short /*x*/, short /*y*/) {}
 #else
-void GameControl::OnGlobalMouseMove(unsigned short x, unsigned short y)
+void GameControl::OnGlobalMouseMove(short x, short y)
 {
 	if (ScreenFlags & SF_DISABLEMOUSE) {
 		return;

--- a/gemrb/core/GUI/GameControl.h
+++ b/gemrb/core/GUI/GameControl.h
@@ -151,7 +151,7 @@ public: //Events
 	/** Mouse Over Event */
 	void OnMouseOver(unsigned short x, unsigned short y);
 	/** Global Mouse Move Event */
-	void OnGlobalMouseMove(unsigned short x, unsigned short y);
+	void OnGlobalMouseMove(short x, short y);
 	/** Mouse Button Down */
 	void OnMouseDown(unsigned short x, unsigned short y, unsigned short Button,
 		unsigned short Mod);


### PR DESCRIPTION
when SDL2 scales the window to a different aspect ratio, it will pad
sides with black.
Since mouse cursor position was passed unsigned, the negative x and/or y
values generated when in the left and/or top padded areas was wrapped,
and scrolling went the wrong way.