### PR TITLE
set blend mode in SetSurfaceAlpha

### DIFF
--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -806,7 +806,10 @@ bool SDL20VideoDriver::ToggleGrabInput()
 
 bool SDL20VideoDriver::SetSurfaceAlpha(SDL_Surface* surface, unsigned short alpha)
 {
-	bool ret = SDL_SetSurfaceAlphaMod(surface, alpha);
+	bool ret = SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_BLEND);
+	if (ret == GEM_OK) {
+		ret = SDL_SetSurfaceAlphaMod(surface, alpha);
+	}
 	if (ret == GEM_OK) {
 		SDL_SetSurfaceRLE(surface, SDL_TRUE);
 	}


### PR DESCRIPTION
SDL_SetSurfaceBlendMode needs to be SDL_BLENDMODE_BLEND on the surface
in order for it to, well, blend.