### PR TITLE
Sdl2 input hacking

### DIFF
--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -737,7 +737,7 @@ int SDL20VideoDriver::ProcessEvent(const SDL_Event & event)
 		case SDL_KEYUP:
 			{
 				SDL_Keycode key = SDL_GetKeyFromScancode(event.key.keysym.scancode);
-				if (key > 32 && key < 127) {
+				if ((key >= 32 && key < 127) || key == 1073742053) {
 					// ignore keys that generate text. handeled by SDL_TEXTINPUT
 					break;
 				}

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -745,7 +745,7 @@ int SDL20VideoDriver::ProcessEvent(const SDL_Event & event)
 					// if key is literally just ctrl or shift -- skip it.
 					break;
 				}
-				if (SDL_GetModState() & KMOD_NUM && key >= 1073741908 && key <= 1073741927 && key != SDLK_KP_ENTER) {
+				if (SDL_GetModState() & KMOD_NUM && key >= SDLK_KP_DIVIDE && key <= SDLK_KP_EQUALS && key != SDLK_KP_ENTER) {
 					// ignore numpad keys (handled by SDL_TEXTINPUT) if KMOD_NUM. Always ignore numpad enter.
 					break;
 				}

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -734,10 +734,23 @@ int SDL20VideoDriver::ProcessEvent(const SDL_Event & event)
 				break;
 			}
 		case SDL_KEYDOWN:
+			{
+				SDL_Keycode key = SDL_GetKeyFromScancode(event.key.keysym.scancode);
+				if ((key == SDLK_SPACE) && SDL_GetModState() & KMOD_CTRL) {
+					core->PopupConsole();
+					break;
+				}
+				if ((key == SDLK_f) && SDL_GetModState() & KMOD_CTRL) {
+					// slight delay so one does not immediately re-toggle fullscreen
+					SDL_Delay(200);
+					ToggleFullscreenMode();
+					break;
+				}
+			}
 		case SDL_KEYUP:
 			{
 				SDL_Keycode key = SDL_GetKeyFromScancode(event.key.keysym.scancode);
-				if ((key >= 32 && key < 127) || key == 1073742053) {
+				if ((key >= 32 && key < 127) || key & (KMOD_SHIFT|KMOD_CTRL)) {
 					// ignore keys that generate text. handeled by SDL_TEXTINPUT
 					break;
 				}

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -736,25 +736,17 @@ int SDL20VideoDriver::ProcessEvent(const SDL_Event & event)
 		case SDL_KEYDOWN:
 			{
 				SDL_Keycode key = SDL_GetKeyFromScancode(event.key.keysym.scancode);
-				if ((key == SDLK_SPACE) && SDL_GetModState() & KMOD_CTRL) {
-					core->PopupConsole();
+				if (key == SDLK_LSHIFT || key == SDLK_RSHIFT || key == SDLK_LCTRL || key == SDLK_RCTRL) {
+					// if key is literally just ctrl or shift -- skip it.
 					break;
 				}
-				if ((key == SDLK_f) && SDL_GetModState() & KMOD_CTRL) {
-					// slight delay so one does not immediately re-toggle fullscreen
-					SDL_Delay(200);
-					ToggleFullscreenMode();
-					break;
-				}
-			}
-		case SDL_KEYUP:
-			{
-				SDL_Keycode key = SDL_GetKeyFromScancode(event.key.keysym.scancode);
-				if ((key >= 32 && key < 127) || key & (KMOD_SHIFT|KMOD_CTRL)) {
-					// ignore keys that generate text. handeled by SDL_TEXTINPUT
+				if (key >= 32 && key < 127 && !(SDL_GetModState() & KMOD_CTRL)) {
+					// ignore keys that generate text (these handeled by SDL_TEXTINPUT) as long as ctrl is not pressed.
+					// The ctrl clause is to permit hotkeys that use ctrl to pass through to default below.
 					break;
 				}
 			}
+		case SDL_KEYUP: // we let SDL_KEYUP pass directly to SDLVideo below, since SDL_TEXTINPUT feeds input directly as if it were pressed/keydown.
 		default:
 			return SDLVideoDriver::ProcessEvent(event);
 	}

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -746,7 +746,7 @@ int SDL20VideoDriver::ProcessEvent(const SDL_Event & event)
 					break;
 				}
 				if (SDL_GetModState() & KMOD_NUM && key >= SDLK_KP_DIVIDE && key <= SDLK_KP_EQUALS && key != SDLK_KP_ENTER) {
-					// ignore numpad keys (handled by SDL_TEXTINPUT) if KMOD_NUM. Always ignore numpad enter.
+					// ignore numpad keys (handled by SDL_TEXTINPUT) if KMOD_NUM. Never ignore numpad enter.
 					break;
 				}
 				if (key >= 32 && key < 127) {

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -736,13 +736,21 @@ int SDL20VideoDriver::ProcessEvent(const SDL_Event & event)
 		case SDL_KEYDOWN:
 			{
 				SDL_Keycode key = SDL_GetKeyFromScancode(event.key.keysym.scancode);
+				if (key == SDLK_SPACE && SDL_GetModState() & KMOD_CTRL) {
+					// special treatment: console popping is the only KEYDOWN event in SDLVideoDriver::ProcessEvent that uses a standard key (and therefore will never be hit). Therefore, implement this here also.
+					core->PopupConsole();
+					break;
+				}
 				if (key == SDLK_LSHIFT || key == SDLK_RSHIFT || key == SDLK_LCTRL || key == SDLK_RCTRL) {
 					// if key is literally just ctrl or shift -- skip it.
 					break;
 				}
-				if (key >= 32 && key < 127 && !(SDL_GetModState() & KMOD_CTRL)) {
-					// ignore keys that generate text (these handeled by SDL_TEXTINPUT) as long as ctrl is not pressed.
-					// The ctrl clause is to permit hotkeys that use ctrl to pass through to default below.
+				if (SDL_GetModState() & KMOD_NUM && key >= 1073741908 && key <= 1073741927 && key != SDLK_KP_ENTER) {
+					// ignore numpad keys (handled by SDL_TEXTINPUT) if KMOD_NUM. Always ignore numpad enter.
+					break;
+				}
+				if (key >= 32 && key < 127) {
+					// ignore keys that generate text (these are handeled by SDL_TEXTINPUT).
 					break;
 				}
 			}


### PR DESCRIPTION
The way the SDL2 code handles keypresses and so on interacts in some weird ways with the rest of the system. It is a bit muddled, I think, because so much is "shared" between the SDL1 and SDL2 paths (through SDLVideo), even when they way of doing things in SDL2 does not neatly map to SDL1.

This fixes the problems of strange/double input in text fields, and the fact that neither the console nor fullscreen could be toggled through keypresses ingame.
