### PR TITLE
IWD2::CG: adjusts skill points calculation

### DIFF
--- a/gemrb/GUIScripts/iwd2/Skills.py
+++ b/gemrb/GUIScripts/iwd2/Skills.py
@@ -131,8 +131,7 @@ def OpenSkillsWindow(chargen, level=0):
 		ClassColumn = BaseClass
 
 	PointsLeft = SkillPtsTable.GetValue (0, ClassColumn)
-	IntBonus = GemRB.GetPlayerStat (pc, IE_INT)/2 - 5 # intelligence bonus
-	PointsLeft += IntBonus
+
 	# at least 1 skillpoint / level advanced
 	if PointsLeft < 1:
 		PointsLeft = 1
@@ -151,8 +150,15 @@ def OpenSkillsWindow(chargen, level=0):
 		if Level < 2: PointsLeft += 2
 		else: PointsLeft += 1
 
-	# now multiply them for all the gained levels (or the cg special)
-	PointsLeft *= LevelDiff
+	IntBonus = GemRB.GetPlayerStat (pc, IE_INT)/2 - 5 # intelligence bonus
+
+	if chargen:
+		PointsLeft *= 2
+	else:
+		PointsLeft *= LevelDiff
+
+	PointsLeft += IntBonus * LevelDiff
+
 	PointsLeft += GemRB.GetPlayerStat (pc, IE_UNUSED_SKILLPTS)
 
 	SkillTable = GemRB.LoadTable("skills")


### PR DESCRIPTION
When creating a new PC, there were more skill points available than there were supposed to be.

This changes the partial formula from:

(class pts + human pts + int bonus pts) * 4

to:

(class pts + human pts) * 2 + int bonus pts * 4

This returns values equal to the original game.