### PR TITLE
IWD2::Skills: prevents scrolling beyond skill items

### DIFF
--- a/gemrb/GUIScripts/iwd2/Skills.py
+++ b/gemrb/GUIScripts/iwd2/Skills.py
@@ -99,8 +99,11 @@ def RedrawSkills():
 def ScrollBarPress():
 	global TopIndex
 
-	TopIndex = GemRB.GetVar("TopIndex")
-	RedrawSkills()
+	newTopIndex = GemRB.GetVar("TopIndex")
+	if newTopIndex + ButtonCount <= len(StatLowerLimit):
+		TopIndex = newTopIndex
+		RedrawSkills()
+
 	return
 
 def OnLoad():


### PR DESCRIPTION
The empty item line at the bottom is gone. In addition, this saves a Python exception.

`TopIndex` is used around the object without checking whether we should really go there by scrolling down.

Behaves a little more like IWD2, where you can move the scrollbar at the bottom parts without any updates.