### PR TITLE
GUI: makes scroll bar work with repeatable key strokes

### DIFF
--- a/gemrb/core/GUI/Button.cpp
+++ b/gemrb/core/GUI/Button.cpp
@@ -524,7 +524,7 @@ void Button::OnMouseUp(unsigned short x, unsigned short y,
 			return;
 	}
 
-	if ((Button&GEM_MB_NORMAL) == GEM_MB_ACTION) {
+	if (Button & GEM_MB_ACTION) {
 		if ((Mod & GEM_MOD_SHIFT) && ButtonOnShiftPress)
 			RunEventHandler( ButtonOnShiftPress );
 		else

--- a/gemrb/core/GUI/EventMgr.cpp
+++ b/gemrb/core/GUI/EventMgr.cpp
@@ -327,7 +327,10 @@ void EventMgr::MouseDown(unsigned short x, unsigned short y, unsigned short Butt
 void EventMgr::MouseUp(unsigned short x, unsigned short y, unsigned short Button,
 	unsigned short Mod)
 {
-	focusLock = NULL;
+	if((Button & GEM_MB_ONGOING_ACTION) == GEM_MB_ACTION) {
+		focusLock = NULL;
+	}
+
 	MButtons &= ~Button;
 	Control *last_ctrl_mousefocused = GetMouseFocusedControl();
 	if (last_ctrl_mousefocused == NULL) return;

--- a/gemrb/core/GUI/EventMgr.h
+++ b/gemrb/core/GUI/EventMgr.h
@@ -67,6 +67,8 @@ class Window;
 #define GEM_MB_SCRLUP           8
 #define GEM_MB_SCRLDOWN         16
 
+#define GEM_MB_ONGOING_ACTION   33
+
 #define GEM_MB_NORMAL           255
 #define GEM_MB_DOUBLECLICK      256
 

--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -1946,74 +1946,73 @@ void GameControl::OnMouseUp(unsigned short x, unsigned short y, unsigned short B
 				actor = NULL;
 			}
 		}
-		switch (Button) {
-			case GEM_MB_ACTION:
-				if (!actor) {
-					Actor *pc = core->GetFirstSelectedPC(false);
-					if (!pc) {
-						//this could be a non-PC
-						pc = game->selected[0];
-					}
-					//add a check if you don't want some random monster handle doors and such
-					if (overDoor) {
-						HandleDoor(overDoor, pc);
-						break;
-					}
-					if (overContainer) {
-						HandleContainer(overContainer, pc);
-						break;
-					}
-					if (overInfoPoint) {
-						if (overInfoPoint->Type==ST_TRAVEL) {
-							ieDword exitID = overInfoPoint->GetGlobalID();
-							if (core->HasFeature(GF_TEAM_MOVEMENT)) {
-								// pst forces everyone to travel (eg. ar0201 outside_portal)
-								int i = game->GetPartySize(false);
-								while(i--) {
-									game->GetPC(i, false)->UseExit(exitID);
-								}
-							} else {
-								int i = game->selected.size();
-								while(i--) {
-									game->selected[i]->UseExit(exitID);
-								}
+
+		if(Button & GEM_MB_ACTION) {
+			if (!actor) {
+				Actor *pc = core->GetFirstSelectedPC(false);
+				if (!pc) {
+					//this could be a non-PC
+					pc = game->selected[0];
+				}
+				//add a check if you don't want some random monster handle doors and such
+				if (overDoor) {
+					HandleDoor(overDoor, pc);
+					goto formation_handling;
+				}
+				if (overContainer) {
+					HandleContainer(overContainer, pc);
+					goto formation_handling;
+				}
+				if (overInfoPoint) {
+					if (overInfoPoint->Type==ST_TRAVEL) {
+						ieDword exitID = overInfoPoint->GetGlobalID();
+						if (core->HasFeature(GF_TEAM_MOVEMENT)) {
+							// pst forces everyone to travel (eg. ar0201 outside_portal)
+							int i = game->GetPartySize(false);
+							while(i--) {
+								game->GetPC(i, false)->UseExit(exitID);
+							}
+						} else {
+							int i = game->selected.size();
+							while(i--) {
+								game->selected[i]->UseExit(exitID);
 							}
 						}
-						if (HandleActiveRegion(overInfoPoint, pc, p)) {
-							core->SetEventFlag(EF_RESETTARGET);
-							break;
-						}
 					}
-					//just a single actor, no formation
-					if (game->selected.size()==1
-						&& target_mode == TARGET_MODE_CAST
-						&& spellCount
-						&& (target_types&GA_POINT)) {
-						//the player is using an item or spell on the ground
-						TryToCast(pc, p);
-						break;
+					if (HandleActiveRegion(overInfoPoint, pc, p)) {
+						core->SetEventFlag(EF_RESETTARGET);
+						goto formation_handling;
 					}
 				}
-				doMove = (!actor && target_mode == TARGET_MODE_NONE);
-				break;
-			case GEM_MB_MENU:
-				// we used to check mod in this case,
-				// but it doesnt make sense to initiate an action based on a mod on mouse down
-				// then cancel that action because the mod disapeared before mouse up
-				if (!core->HasFeature(GF_HAS_FLOAT_MENU)) {
-					SetTargetMode(TARGET_MODE_NONE);
+				//just a single actor, no formation
+				if (game->selected.size()==1
+					&& target_mode == TARGET_MODE_CAST
+					&& spellCount
+					&& (target_types&GA_POINT)) {
+					//the player is using an item or spell on the ground
+					TryToCast(pc, p);
+					goto formation_handling;
 				}
-				if (!actor) {
-					// reset the action bar
-					core->GetGUIScriptEngine()->RunFunction("GUICommonWindows", "EmptyControls");
-					core->SetEventFlag(EF_ACTION);
-				}
-				break;
-			default:
-				return; // we dont handle any other buttons beyond this point
+			}
+			doMove = (!actor && target_mode == TARGET_MODE_NONE);
+		} else if(Button & GEM_MB_MENU) {
+			// we used to check mod in this case,
+			// but it doesnt make sense to initiate an action based on a mod on mouse down
+			// then cancel that action because the mod disapeared before mouse up
+			if (!core->HasFeature(GF_HAS_FLOAT_MENU)) {
+				SetTargetMode(TARGET_MODE_NONE);
+			}
+			if (!actor) {
+				// reset the action bar
+				core->GetGUIScriptEngine()->RunFunction("GUICommonWindows", "EmptyControls");
+				core->SetEventFlag(EF_ACTION);
+			}
+		} else {
+			return; // we dont handle any other buttons beyond this point
 		}
 	}
 
+formation_handling:
 	if (doMove && game->selected.size() > 0) {
 		// construct a sorted party
 		// TODO: this is still ugly, help?
@@ -2229,7 +2228,7 @@ bool GameControl::OnSpecialKeyPress(unsigned char Key)
 	Game *game = core->GetGame();
 	if (!game) return false;
 	int partysize = game->GetPartySize(false);
-	
+
 	int pm;
 	ieDword keyScrollSpd = 64;
 	core->GetDictionary()->Lookup("Keyboard Scroll Speed", keyScrollSpd);

--- a/gemrb/core/GUI/MapControl.cpp
+++ b/gemrb/core/GUI/MapControl.cpp
@@ -58,7 +58,7 @@ Color colors[]={
 
 #define MAP_TO_SCREENX(x) (XWin + XCenter - ScrollX + (x))
 #define MAP_TO_SCREENY(y) (YWin + YCenter - ScrollY + (y))
-// Omit [XY]Pos, since these macros are used in OnMouseDown(x, y), and x, y is 
+// Omit [XY]Pos, since these macros are used in OnMouseDown(x, y), and x, y is
 //   already relative to control [XY]Pos there
 #define SCREEN_TO_MAPX(x) ((x) - XCenter + ScrollX)
 #define SCREEN_TO_MAPY(y) ((y) - YCenter + ScrollY)
@@ -424,7 +424,7 @@ void MapControl::OnMouseUp(unsigned short x, unsigned short y, unsigned short Bu
 			return;
 		case MAP_VIEW_NOTES:
 			//left click allows setting only when in MAP_SET_NOTE mode
-			if (Button == GEM_MB_ACTION) {
+			if (Button & GEM_MB_ACTION) {
 				ViewHandle(x,y);
 			}
 			ClickHandle(Button);

--- a/gemrb/core/GUI/ScrollBar.cpp
+++ b/gemrb/core/GUI/ScrollBar.cpp
@@ -166,7 +166,7 @@ void ScrollBar::DrawInternal(Region& drawFrame)
 	int upMy = GetFrameHeight(IE_GUI_SCROLLBAR_UP_UNPRESSED);
 	int doMy = GetFrameHeight(IE_GUI_SCROLLBAR_DOWN_UNPRESSED);
 	unsigned int domy = (Height - doMy);
-	
+
 	//draw the up button
 	if (( State & UP_PRESS ) != 0) {
 		video->BlitSprite( Frames[IE_GUI_SCROLLBAR_UP_PRESSED], drawFrame.x, drawFrame.y, true, &drawFrame );

--- a/gemrb/core/GUI/ScrollBar.cpp
+++ b/gemrb/core/GUI/ScrollBar.cpp
@@ -242,13 +242,15 @@ void ScrollBar::OnMouseDown(unsigned short /*x*/, unsigned short y,
 
 /** Mouse Button Up */
 void ScrollBar::OnMouseUp(unsigned short /*x*/, unsigned short /*y*/,
-			unsigned short /*Button*/, unsigned short /*Mod*/)
+			unsigned short Button, unsigned short /*Mod*/)
 {
-	MarkDirty();
-	State = 0;
-	Frames[IE_GUI_SCROLLBAR_SLIDER]->YPos = 0; //this is to clear any offset incurred by grabbing the slider
-	// refresh the cursor/hover selection
-	core->GetEventMgr()->FakeMouseMove();
+	if((Button & GEM_MB_ONGOING_ACTION) == GEM_MB_ACTION) {
+		MarkDirty();
+		State = 0;
+		Frames[IE_GUI_SCROLLBAR_SLIDER]->YPos = 0; //this is to clear any offset incurred by grabbing the slider
+		// refresh the cursor/hover selection
+		core->GetEventMgr()->FakeMouseMove();
+	}
 }
 
 /** Mousewheel scroll */

--- a/gemrb/core/GUI/WorldMapControl.cpp
+++ b/gemrb/core/GUI/WorldMapControl.cpp
@@ -57,7 +57,7 @@ WorldMapControl::WorldMapControl(const Region& frame, const char *font, int dire
 	}
 
 	//if there is no trivial area, look harder
-	if (!worldmap->GetArea(currentArea, (unsigned int &) entry) && 
+	if (!worldmap->GetArea(currentArea, (unsigned int &) entry) &&
 		core->HasFeature(GF_FLEXIBLE_WMAP) ) {
 		WMPAreaEntry *m = worldmap->FindNearestEntry(currentArea, (unsigned int &) entry);
 		if (m) {
@@ -67,7 +67,7 @@ WorldMapControl::WorldMapControl(const Region& frame, const char *font, int dire
 
 	//this also updates visible locations
 	worldmap->CalculateDistances(currentArea, Value);
-	
+
 	// alpha bit is unfortunately ignored
 	if (font[0]) {
 		ftext = core->GetFont(font);
@@ -161,7 +161,7 @@ void WorldMapControl::DrawInternal(Region& rgn)
 			continue;
 
 		Palette* text_pal = pal_normal;
-		
+
 		if (Area == m) {
 			text_pal = pal_selected;
 		} else {
@@ -309,7 +309,7 @@ void WorldMapControl::OnMouseDown(unsigned short x, unsigned short y,
 void WorldMapControl::OnMouseUp(unsigned short /*x*/, unsigned short /*y*/,
 	unsigned short Button, unsigned short /*Mod*/)
 {
-	if (Button != GEM_MB_ACTION) {
+	if (!(Button & GEM_MB_ACTION)) {
 		return;
 	}
 	MouseIsDown = false;
@@ -323,7 +323,7 @@ void WorldMapControl::OnMouseWheelScroll(short x, short y)
 {
 	ScrollX += x;
 	ScrollY += y;
-	
+
 	WorldMap* worldmap = core->GetWorldMap();
 	Sprite2D *MapMOS = worldmap->GetMapMOS();
 	if (ScrollX > MapMOS->Width - Width)

--- a/gemrb/plugins/SDLVideo/SDLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDLVideo.cpp
@@ -155,13 +155,13 @@ int SDLVideoDriver::PollEvents()
 		GetMousePos(x, y);
 		lastMouseDownTime=lastTime + EvntManager->GetRKDelay();
 		if (!core->ConsolePopped) {
-			EvntManager->MouseUp( x, y, GEM_MB_ACTION, GetModState() );
+			EvntManager->MouseUp( x, y, GEM_MB_ONGOING_ACTION, GetModState() );
 			Control* ctl = EvntManager->GetMouseFocusedControl();
 			if (ctl && ctl->ControlType == IE_GUI_BUTTON)
 				// these are repeat events so the control should stay pressed
 				((Button*)ctl)->SetState(IE_GUI_BUTTON_PRESSED);
 		}
-	} 
+	}
 	return ret;
 }
 


### PR DESCRIPTION
If you launch IWD2 and go CG in `Skills` or `Abilities` scripts, you see enabling of repeatable keys to make +/- buttons work a little better. Problem: *any* scroll bar hardly drag-scrolls anymore unless the RK-setting is properly reset since this state is managed globally. Which isn't.

This is a patch to what should be refactored: The logic invoking `MouseUp` calls when recognizing held mouse buttons now uses `GEM_MB_ONGOING_ACTION` instead, sharing the bit `GEM_MB_ACTION`. This way, we can leave `rk_flags` handling untouched while having a way to overcome interrupting events. This allows e.g. `ScrollBar` to not reset itself by receiving `GEM_MB_ONGOING_ACTION`.

Did test changes on BG and IWD2.