### PR TITLE
String: extends buffer in `MBCStringFromString'

### DIFF
--- a/gemrb/core/System/String.cpp
+++ b/gemrb/core/System/String.cpp
@@ -109,10 +109,12 @@ String* StringFromCString(const char* string)
 
 char* MBCStringFromString(const String& string)
 {
-	char* cStr = (char*)malloc(string.length()+1);
+	size_t allocatedBytes = string.length() * sizeof(String::value_type);
+	char *cStr = (char*)malloc(allocatedBytes);
+
 	// FIXME: depends on locale setting
 	// FIXME: currently assumes a character-character mapping (Unicode -> ASCII)
-	size_t newlen = wcstombs(cStr, string.c_str(), string.length());
+	size_t newlen = wcstombs(cStr, string.c_str(), allocatedBytes);
 	if (newlen == static_cast<size_t>(-1)) {
 		// invalid multibyte sequence
 		free(cStr);


### PR DESCRIPTION
If `String` aliases to `std::wstring`, `::length` returns the number
of wide-chars, not bytes. For the worst case, we should allow each
`wchar_t` to be mapped into space not smaller, shrinking the space after
the result of `wcstombs`.

Otherwise, multibyte charachters make the resulting string cut-off
early.

As I'm tracking down the problem that German IWD2-PC-sound files containing umlaut-chars are not displayed correctly and played in CG (`ResourceManager` can't find them), I noticed that that the path `Kämpfer_männlich_1` (=`fighter_male_1`) in `TextBox::QueryText` contains 20 *chars*, effectively writes `KÃ¤MPFER_MÃ¤NNLI` (20 *bytes* mb-string) to Python. Although lost in encoding, this patch fixes the behaviour to return at least the fully-sized but still useless string `KÃ¤MPFER_MÃ¤NNLICH_1`.

Code is not doing an overflow check on `allocatedBytes` calculation. Just to mention.

P.S. Got the encoding issue, working on it.