### PR TITLE
Encoding: decouples TLK and FS path encoding

### DIFF
--- a/gemrb/GUIScripts/iwd2/CSound.py
+++ b/gemrb/GUIScripts/iwd2/CSound.py
@@ -69,7 +69,7 @@ def BackPress():
 	return
 
 def NextPress():
-	GemRB.SetToken("VoiceSet", TextAreaControl.QueryText())
+	GemRB.SetToken("VoiceSet", TextAreaControl.QueryText(1))
 	if SoundWindow:
 		SoundWindow.Unload()
 	GemRB.SetNextScript("CharGen8") #name
@@ -82,10 +82,10 @@ def SelectSound():
 def PlayPress():
 	global SoundIndex
 
-	CharSound = TextAreaControl.QueryText()
+	CharSound = TextAreaControl.QueryText(1)
 	MyChar = GemRB.GetVar ("Slot")
 
-	GemRB.SetPlayerSound (MyChar, CharSound)
+	GemRB.SetPlayerSound (MyChar, CharSound, 1)
 	# play sound as sound slot
 	GemRB.VerbalConstant (MyChar, int(VerbalConstants[SoundIndex]))
 

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -254,6 +254,10 @@ Interface::Interface()
 	TLKEncoding.widechar = false;
 	TLKEncoding.multibyte = false;
 	TLKEncoding.zerospace = false;
+	FSPathEncoding.encoding = "UTF-8";
+	FSPathEncoding.widechar = false;
+	FSPathEncoding.multibyte = true;
+	FSPathEncoding.zerospace = false;
 	MagicBit = HasFeature(GF_MAGICBIT);
 
 	gamedata = new GameData();

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -397,6 +397,7 @@ private:
 	std::string Encoding;
 public:
 	EncodingStruct TLKEncoding;
+	EncodingStruct FSPathEncoding;
 	Holder<StringMgr> strings;
 	GlobalTimer * timer;
 	Palette *InfoTextPalette;

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -140,14 +140,6 @@ struct TimeStruct {
 	unsigned int attack_round_size;
 };
 
-struct EncodingStruct
-{
-	std::string encoding;
-	bool widechar;
-	bool multibyte;
-	bool zerospace;
-};
-
 struct SpellDescType {
 	ieResRef resref;
 	ieStrRef value;

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -8344,12 +8344,19 @@ void Actor::SetPortrait(const char* ResRef, int Which)
 	}
 }
 
-void Actor::SetSoundFolder(const char *soundset)
+void Actor::SetSoundFolder(const char *soundset, bool mbStringPath)
 {
 	if (core->HasFeature(GF_SOUNDFOLDERS)) {
 		char filepath[_MAX_PATH];
+		bool useMbPath = mbStringPath && core->FSPathEncoding.multibyte;
 
-		strnlwrcpy(PCStats->SoundFolder, soundset, 32);
+		if(useMbPath) {
+			memset(PCStats->SoundFolder, 0, SOUNDFOLDERSIZE);
+			memcpy(PCStats->SoundFolder, soundset, SOUNDFOLDERSIZE - 1);
+		} else {
+			strnlwrcpy(PCStats->SoundFolder, soundset, 32);
+		}
+
 		PathJoin(filepath, core->GamePath, "sounds", PCStats->SoundFolder, NULL);
 		char file[_MAX_PATH];
 
@@ -8363,7 +8370,12 @@ void Actor::SetSoundFolder(const char *soundset)
 		} else {
 			return;
 		}
-		strnlwrcpy(PCStats->SoundSet, file, 8);
+
+		if(useMbPath) {
+			memcpy(PCStats->SoundSet, file, 8);
+		} else {
+			strnlwrcpy(PCStats->SoundSet, file, 8);
+		}
 	} else {
 		strnlwrcpy(PCStats->SoundSet, soundset, 8);
 		PCStats->SoundFolder[0]=0;

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -8392,7 +8392,13 @@ void Actor::GetSoundFolder(char *soundset, int full, ieResRef overrideSet) const
 	}
 
 	if (core->HasFeature(GF_SOUNDFOLDERS)) {
-		strnlwrcpy(soundset, PCStats->SoundFolder, 32);
+		if(core->FSPathEncoding.multibyte) {
+			memset(soundset, 0, SOUNDFOLDERSIZE);
+			memcpy(soundset, PCStats->SoundFolder, SOUNDFOLDERSIZE - 1);
+		} else {
+			strnlwrcpy(soundset, PCStats->SoundFolder, 32);
+		}
+
 		if (full) {
 			strcat(soundset,"/");
 			strncat(soundset, set, 8);

--- a/gemrb/core/Scriptable/Actor.h
+++ b/gemrb/core/Scriptable/Actor.h
@@ -463,7 +463,7 @@ public:
 	/** Sets the Icon ResRef */
 	//Which - 0 both, 1 Large, 2 Small
 	void SetPortrait(const char* ResRef, int Which=0);
-	void SetSoundFolder(const char *soundset);
+	void SetSoundFolder(const char *soundset, bool mbString = false);
 	/* Use overrideSet to replace PCStats->SoundSet */
 	void GetSoundFolder(char *soundset, int flag, ieResRef overrideSet = 0) const;
 	/** Gets the Character Long Name/Short Name */

--- a/gemrb/core/System/String.cpp
+++ b/gemrb/core/System/String.cpp
@@ -107,6 +107,10 @@ String* StringFromCString(const char* string)
 	return StringFromEncodedData((ieByte*)string, core->TLKEncoding);
 }
 
+String* StringFromCString(const char* string, const EncodingStruct& encoding) {
+	return StringFromEncodedData((ieByte*)string, encoding);
+}
+
 char* MBCStringFromString(const String& string)
 {
 	size_t allocatedBytes = string.length() * sizeof(String::value_type);
@@ -124,6 +128,20 @@ char* MBCStringFromString(const String& string)
 	cStr = (char*)realloc(cStr, newlen+1);
 	cStr[newlen] = '\0';
 	return cStr;
+}
+
+char* MBCStringFromString(const String& string, const EncodingStruct& encoding) {
+	char *currentLocale = std::setlocale(LC_CTYPE, "");
+	size_t currentLocaleLength = strlen(currentLocale);
+	char *previousLocale = (char*)calloc(currentLocaleLength + 1, 1);
+	memcpy(previousLocale, currentLocale, currentLocaleLength);
+
+	std::setlocale(LC_CTYPE, encoding.encoding.c_str());
+	char *result = MBCStringFromString(string);
+	std::setlocale(LC_CTYPE, previousLocale);
+	free(previousLocale);
+
+	return result;
 }
 
 unsigned char pl_uppercase[256];

--- a/gemrb/core/System/String.cpp
+++ b/gemrb/core/System/String.cpp
@@ -109,10 +109,12 @@ String* StringFromCString(const char* string)
 
 char* MBCStringFromString(const String& string)
 {
-	char* cStr = (char*)malloc(string.length()+1);
+	size_t allocatedBytes = string.length() * sizeof(String::value_type);
+	char *cStr = (char*)malloc(allocatedBytes);
+
 	// FIXME: depends on locale setting
 	// FIXME: currently assumes a character-character mapping (Unicode -> ASCII)
-	size_t newlen = wcstombs(cStr, string.c_str(), string.length());
+	size_t newlen = wcstombs(cStr, string.c_str(), allocatedBytes);
 	if (newlen == static_cast<size_t>(-1)) {
 		// invalid multibyte sequence
 		free(cStr);

--- a/gemrb/core/System/String.h
+++ b/gemrb/core/System/String.h
@@ -24,6 +24,7 @@
 
 #include <cstring>
 #include <string>
+#include <locale>
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>
@@ -44,7 +45,9 @@ struct EncodingStruct;
 typedef std::wstring String;
 // String creators
 GEM_EXPORT String* StringFromCString(const char* string);
+GEM_EXPORT String* StringFromCString(const char* string, const EncodingStruct&);
 GEM_EXPORT char* MBCStringFromString(const String& string);
+GEM_EXPORT char* MBCStringFromString(const String& string, const EncodingStruct&);
 
 // String manipulators
 GEM_EXPORT void StringToLower(String& string);

--- a/gemrb/core/System/String.h
+++ b/gemrb/core/System/String.h
@@ -24,7 +24,7 @@
 
 #include <cstring>
 #include <string>
-#include <locale>
+#include <clocale>
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>

--- a/gemrb/core/System/String.h
+++ b/gemrb/core/System/String.h
@@ -38,6 +38,8 @@
 
 namespace GemRB {
 
+struct EncodingStruct;
+
 //typedef std::basic_string<ieWord> String;
 typedef std::wstring String;
 // String creators
@@ -58,6 +60,14 @@ GEM_EXPORT void strnlwrcpy(char* d, const char *s, int l, bool pad = true);
 GEM_EXPORT void strnuprcpy(char* d, const char *s, int l);
 GEM_EXPORT void strnspccpy(char* d, const char *s, int l, bool upper = false);
 GEM_EXPORT int strlench(const char* string, char ch);
+
+struct EncodingStruct
+{
+	std::string encoding;
+	bool widechar;
+	bool multibyte;
+	bool zerospace;
+};
 
 }
 

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -1998,7 +1998,7 @@ textarea.\n\
 \n\
 **Parameters:**\n\
   * WindowIndex, ControlIndex - the control's reference\n\
-	* flags - Set to 1 if querying a text from a ListResource source\n\
+  * flags - Set to 1 if querying a text from a ListResource source\n\
 \n\
 **Return value:** string, may be empty\n\
 \n\

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -6652,7 +6652,7 @@ static PyObject* GemRB_TextArea_ListResources(PyObject * /*self*/, PyObject* arg
 			if (name[0] == '.' || dirit.IsDirectory() != dirs)
 				continue;
 
-			String* string = StringFromCString(name);
+			String* string = StringFromCString(name, core->FSPathEncoding);
 			if (dirs == false) {
 				size_t pos = string->find_last_of(L'.');
 				if (pos == String::npos || (type == DIRECTORY_CHR_SOUNDS && pos-- == 0)) {

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -1998,6 +1998,7 @@ textarea.\n\
 \n\
 **Parameters:**\n\
   * WindowIndex, ControlIndex - the control's reference\n\
+	* flags - Set to 1 if querying a text from a ListResource source\n\
 \n\
 **Return value:** string, may be empty\n\
 \n\
@@ -2015,8 +2016,9 @@ The above example sets the VoiceSet token to the value of the selected string in
 static PyObject* GemRB_Control_QueryText(PyObject * /*self*/, PyObject* args)
 {
 	int wi, ci;
+	int flag = 0;
 
-	if (!PyArg_ParseTuple( args, "ii", &wi, &ci )) {
+	if (!PyArg_ParseTuple( args, "ii|i", &wi, &ci, &flag )) {
 		return AttributeError( GemRB_Control_QueryText__doc );
 	}
 
@@ -2024,7 +2026,14 @@ static PyObject* GemRB_Control_QueryText(PyObject * /*self*/, PyObject* args)
 	if (!ctrl) {
 		return NULL;
 	}
-	char* cStr = MBCStringFromString(ctrl->QueryText());
+	char* cStr = NULL;
+
+	if(flag) {
+		cStr = MBCStringFromString(ctrl->QueryText(), core->FSPathEncoding);
+	} else {
+		cStr = MBCStringFromString(ctrl->QueryText());
+	}
+
 	if (cStr) {
 		PyObject* pyStr = PyString_FromString(cStr);
 		free(cStr);
@@ -7547,6 +7556,7 @@ PyDoc_STRVAR( GemRB_SetPlayerSound__doc,
 **Parameters:**\n\
   * Slot        - numeric, the character's slot\n\
   * SoundFolder - string, a folder in Sounds (iwd2 style), or a filename (bg2 style)\n\
+  * flag - set to 1 if SoundFolder is a potential multibyte name\n\
 \n\
 **Return value:** N/A\n\
 \n\
@@ -7557,14 +7567,16 @@ static PyObject* GemRB_SetPlayerSound(PyObject * /*self*/, PyObject* args)
 {
 	const char *Sound=NULL;
 	int globalID;
+	int flag = 0;
 
-	if (!PyArg_ParseTuple( args, "is", &globalID, &Sound )) {
+	if (!PyArg_ParseTuple( args, "is|i", &globalID, &Sound, &flag )) {
 		return AttributeError( GemRB_SetPlayerSound__doc );
 	}
+
 	GET_GAME();
 	GET_ACTOR_GLOBAL();
 
-	actor->SetSoundFolder(Sound);
+	actor->SetSoundFolder(Sound, flag);
 	Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
My setup is as follows: I have a german IWD2 (TLK encoding ISO-8859-1), located on a Linux FS running GemRB, resource listing reveals UTF-8 file paths. The `Sounds` directory consists of 60% of files with names containing umlauts.

When I CGen a new party, the sound files list
1. displays visual garbage around umlaut-chars,
2. the resource manager is unable to find the selected sound file (please review #46 first). No sound then.

In order to overcome 1, it is crucial to replace `TLKEncoding` by `FSPathEncoding` where necessary, since the global encoding makes no sense here. For 2, from the Python interface/IWD2 `CSounds` script, I made everything on the way aware of multi-byteness of the file path to use. Otherwise, it ends up in that beautiful `strnlwrcpy` that disrupts everything. I try not to break anything.

**But**: I don't not know the situation at large, as e.g. `pl_uppercase`/`pl_lowercase` must have been used for files as well. Looking at the name, I assume that some polish version _might_ be broken then, but that's just a guess. This is where I need further information, we could make `FSPathEncoding` configurable I guess.
