### PR TITLE
GUIScript: allows callbacks for window-scoped key presses

### DIFF
--- a/gemrb/GUIScripts/GUIClasses.py
+++ b/gemrb/GUIScripts/GUIClasses.py
@@ -67,6 +67,7 @@ class GWindow:
     'ReassignControls': _GemRB.Window_ReassignControls,
     'SetupEquipmentIcons': _GemRB.Window_SetupEquipmentIcons,
     'SetupControls': _GemRB.Window_SetupControls,
+    'SetKeyPressEvent': _GemRB.Window_SetKeyPressEvent,
     'SetVisible': _GemRB.Window_SetVisible,
     'ShowModal': _GemRB.Window_ShowModal,
     'Invalidate': _GemRB.Window_Invalidate,

--- a/gemrb/core/GUI/EventMgr.cpp
+++ b/gemrb/core/GUI/EventMgr.cpp
@@ -38,7 +38,7 @@ EventMgr::EventMgr(void)
 	// Function bar window (for function keys)
 	function_bar = NULL;
 	// Last window focused for keyboard events
-	last_win_focused = NULL;	
+	last_win_focused = NULL;
 	// Last window focused for mouse events (eg, with a click). Used to determine MouseUp events
 	last_win_mousefocused = NULL;
 	// Last window we were over. Used to determine MouseEnter and MouseLeave events
@@ -363,7 +363,8 @@ void EventMgr::KeyPress(unsigned char Key, unsigned short Mod)
 	Control *ctrl = last_win_focused->GetFocus();
 	if (!ctrl || !ctrl->OnKeyPress( Key, Mod )) {
 		// FIXME: need a better way to determine when to call ResolveKey/SetHotKey
-		if (core->GetGameControl()
+		if (!last_win_focused->OnKeyPress(Key, Mod)
+			&& core->GetGameControl()
 			&& !MButtons // checking for drag actions
 			&& !core->IsPresentingModalWindow()
 			&& !core->InCutSceneMode()

--- a/gemrb/core/GUI/Window.cpp
+++ b/gemrb/core/GUI/Window.cpp
@@ -50,6 +50,7 @@ Window::Window(unsigned short WindowID, unsigned short XPos,
 	DefaultControl[1] = -1;
 	ScrollControl = -1;
 	FunctionBar = false;
+	keyPressHandler = NULL;
 }
 
 Window::~Window()
@@ -335,6 +336,10 @@ Control* Window::GetScrollControl() const
 	return GetControl( (ieWord) ScrollControl );
 }
 
+void Window::SetKeyPressEvent(WindowKeyPressHandler handler) {
+	keyPressHandler = handler;
+}
+
 void Window::release(void)
 {
 	Visible = WINDOW_INVALID;
@@ -446,6 +451,19 @@ void Window::OnMouseOver(unsigned short x, unsigned short y)
 		cy = 0;
 	}
 	lastOver->OnMouseOver(cx, cy);
+}
+
+bool Window::OnKeyPress(unsigned char key, unsigned short mod) {
+	if(keyPressHandler) {
+		WindowKeyPress wkp;
+		wkp.windowID = this->WindowID;
+		wkp.key = key;
+		wkp.mod = mod;
+
+		return keyPressHandler(&wkp);
+	} else {
+		return false;
+	}
 }
 
 }

--- a/gemrb/core/GUI/Window.h
+++ b/gemrb/core/GUI/Window.h
@@ -53,6 +53,23 @@ class Sprite2D;
 #define WINDOW_SCALE         0x08
 #define WINDOW_BOUNDED       0x10
 
+struct WindowKeyPress {
+	unsigned short windowID;
+	unsigned short key;
+	unsigned short mod;
+};
+
+class WindowKeyPressHandler : public Holder< Callback<WindowKeyPress*> > {
+public:
+	WindowKeyPressHandler(Callback<WindowKeyPress*>* ptr = NULL)
+	: Holder< Callback<WindowKeyPress*> >(ptr) {}
+
+	bool operator()(WindowKeyPress *wkp) {
+		return (*ptr)(wkp);
+	}
+};
+
+
 /**
  * @class Window
  * Class serving as a container for Control/widget objects 
@@ -95,6 +112,8 @@ public:
 	Control* GetDefaultControl(unsigned int ctrltype) const;
 	/** Returns the Control which should get mouse scroll events */
 	Control* GetScrollControl() const;
+	/** Sets callback on catching a key press event. */
+	void SetKeyPressEvent(WindowKeyPressHandler handler);
 	/** Sets 'ctrl' as currently under mouse */
 	void SetOver(Control* ctrl);
 	/** Returns last control under mouse */
@@ -119,6 +138,8 @@ public:
 	void OnMouseLeave(unsigned short x, unsigned short y);
 	/** Mouse is over the current control */
 	void OnMouseOver(unsigned short x, unsigned short y);
+	/** Key has been pressed */
+	bool OnKeyPress(unsigned char key, unsigned short mod);
 public: //Public attributes
 	/** WinPack */
 	char WindowPack[10];
@@ -140,6 +161,8 @@ public: //Public attributes
 	int DefaultControl[2]; //default enter and cancel
 	int ScrollControl;
 	bool FunctionBar;
+
+	WindowKeyPressHandler keyPressHandler;
 private: // Private attributes
 	/** BackGround Image. No BackGround if this variable is NULL. */
 	Sprite2D* BackGround;

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -2564,6 +2564,48 @@ static PyObject* GemRB_Control_SetEvent(PyObject * /*self*/, PyObject* args)
 	Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR( GemRB_Window_SetKeyPressEvent__doc,
+"===== Window_SetKeyPressEvent =====\n\
+\n\
+**Prototype:** _GemRB.Window_SetKeyPressEvent (callback)\n\
+\n\
+**Description:** Sets a callback function to handle key press event on window scopes. \n\
+\n\
+**Parameters:**\n\
+  * callback - Python function that accepts (windowIndex, key, mod) arguments and returns\n\
+	* 					 1 indicating succesful key press consumption or 0 otherwise. \n\
+\n\
+**Return value:** N/A\n\
+\n\
+**Example:**\n\
+    Window.SetKeyPressEvent (KeyPressCallback)\n\
+    return\n\
+\n\
+**See also:** [[guiscript:QuitGame]]\n\
+"
+);
+
+static PyObject* GemRB_Window_SetKeyPressEvent(PyObject* /*self*/, PyObject *args) {
+	int windowIndex;
+	PyObject *fn;
+
+	if(!PyArg_ParseTuple(args, "iO", &windowIndex, &fn)) {
+		return AttributeError(GemRB_Window_SetKeyPressEvent__doc);
+	}
+
+	WindowKeyPressHandler handler = NULL;
+	if(fn != Py_None && PyCallable_Check(fn)) {
+		handler = new PythonObjectCallback<WindowKeyPress>(fn);
+	}
+
+	Window *window = core->GetWindow(windowIndex);
+	if(window) {
+		window->SetKeyPressEvent(handler);
+	}
+
+	Py_RETURN_NONE;
+}
+
 PyDoc_STRVAR( GemRB_SetNextScript__doc,
 "===== SetNextScript =====\n\
 \n\
@@ -15554,6 +15596,7 @@ static PyMethodDef GemRBInternalMethods[] = {
 	METHOD(Window_Invalidate, METH_VARARGS),
 	METHOD(Window_ReassignControls, METH_VARARGS),
 	METHOD(Window_SetFrame, METH_VARARGS),
+	METHOD(Window_SetKeyPressEvent, METH_VARARGS),
 	METHOD(Window_SetPicture, METH_VARARGS),
 	METHOD(Window_SetPos, METH_VARARGS),
 	METHOD(Window_SetSize, METH_VARARGS),

--- a/gemrb/plugins/GUIScript/PythonHelpers.cpp
+++ b/gemrb/plugins/GUIScript/PythonHelpers.cpp
@@ -19,25 +19,9 @@
  */
 
 #include "PythonHelpers.h"
+#include "GUI/Window.h"
 
 using namespace GemRB;
-
-static bool CallPython(PyObject *Function, PyObject *args = NULL)
-{
-	if (!Function) {
-		return false;
-	}
-	PyObject *ret = PyObject_CallObject(Function, args);
-	Py_XDECREF( args );
-	if (ret == NULL) {
-		if (PyErr_Occurred()) {
-			PyErr_Print();
-		}
-		return false;
-	}
-	Py_DECREF(ret);
-	return true;
-}
 
 PythonCallback::PythonCallback(PyObject *Function)
 	: Function(Function)
@@ -64,30 +48,10 @@ bool PythonCallback::operator() ()
 	return CallPython(Function);
 }
 
+namespace GemRB {
 
-PythonControlCallback::PythonControlCallback(PyObject *Function)
-: Function(Function)
-{
-	if (Function && PyCallable_Check(Function)) {
-		Py_INCREF(Function);
-	} else {
-		Function = NULL;
-	}
-}
-
-PythonControlCallback::~PythonControlCallback()
-{
-	if (Py_IsInitialized()) {
-		Py_XDECREF(Function);
-	}
-}
-
-bool PythonControlCallback::operator() ()
-{
-	return (*this)(NULL);
-}
-
-bool PythonControlCallback::operator() (Control* ctrl)
+template <>
+bool PythonObjectCallback<Control>::operator() (Control* ctrl)
 {
 	if (!Function || !Py_IsInitialized()) {
 		return false;
@@ -132,4 +96,63 @@ bool PythonControlCallback::operator() (Control* ctrl)
 	Py_DECREF(func_code);
 	Py_DECREF(co_argcount);
 	return CallPython(Function, args);
+}
+
+template <>
+bool PythonObjectCallback<WindowKeyPress>::operator() (WindowKeyPress *wkp) {
+	if (!Function || !Py_IsInitialized()) {
+		return false;
+	}
+
+	PyObject *args = PyTuple_Pack(3, PyInt_FromLong(wkp->windowID),
+																	 PyInt_FromLong(wkp->key),
+																	 PyInt_FromLong(wkp->mod));
+	long result = CallPythonWithReturn(Function, args);
+
+	return result > 0;
+}
+
+PyObject* CallPythonObject(PyObject *Function, PyObject *args) {
+	if (!Function) {
+		return NULL;
+	}
+
+	PyObject *ret = PyObject_CallObject(Function, args);
+	Py_XDECREF( args );
+	if (ret == NULL) {
+		if (PyErr_Occurred()) {
+			PyErr_Print();
+		}
+		return NULL;
+	}
+
+	return ret;
+}
+
+bool CallPython(PyObject *Function, PyObject *args)
+{
+	PyObject *ret = CallPythonObject(Function, args);
+
+	if(ret) {
+		Py_DECREF(ret);
+
+		return true;
+	} else {
+		return false;
+	}
+}
+
+long CallPythonWithReturn(PyObject *Function, PyObject *args) {
+	PyObject *ret = CallPythonObject(Function, args);
+
+	if(ret) {
+		long value = PyInt_AsLong(ret);
+		Py_DECREF(ret);
+
+		return value;
+	}
+
+	return -1;
+}
+
 }

--- a/gemrb/plugins/GUIScript/PythonHelpers.cpp
+++ b/gemrb/plugins/GUIScript/PythonHelpers.cpp
@@ -112,7 +112,7 @@ bool PythonObjectCallback<WindowKeyPress>::operator() (WindowKeyPress *wkp) {
 	return result > 0;
 }
 
-PyObject* CallPythonObject(PyObject *Function, PyObject *args) {
+static PyObject* CallPythonObject(PyObject *Function, PyObject *args) {
 	if (!Function) {
 		return NULL;
 	}


### PR DESCRIPTION
One thing I'm really missing is changing PCs (in the inventory window) by pressing keys 1-6.

I did some research but did not find a way to have a flexible way to customize key stroke events outside of controls (i.e. do the actual logic in Python). Callbacks are limited to controls and certain events so far.

This PR allows scripts to make use of reading pressed keys on the unspecified window level and to act on them. If you think this is a good idea, we can do something like this to solve the inventory issue: https://github.com/MarcelHB/gemrb/compare/window_keys...MarcelHB:inventory_pc_key?expand=1