### PR TITLE
SDL2: Fix RMB stuck cursor

### DIFF
--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -733,7 +733,6 @@ int SDL20VideoDriver::ProcessEvent(const SDL_Event & event)
 			else {
 				// we do not want these events to cascade down to SDL_KEYDOWN, so we return here instead of at default .
 				return SDLVideoDriver::ProcessEvent(event);
-				break;
 			}
 		case SDL_KEYDOWN:
 			{

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -725,12 +725,14 @@ int SDL20VideoDriver::ProcessEvent(const SDL_Event & event)
 		// discard them if they are produced by touch events
 		// do NOT discard mouse wheel events
 		case SDL_MOUSEMOTION:
-			if (event.motion.which == SDL_TOUCH_MOUSEID) {
-				break;
-			}
 		case SDL_MOUSEBUTTONDOWN:
 		case SDL_MOUSEBUTTONUP:
 			if (event.button.which == SDL_TOUCH_MOUSEID) {
+				break;
+			}
+			else {
+				// we do not want these events to cascade down to SDL_KEYDOWN, so we return here instead of at default .
+				return SDLVideoDriver::ProcessEvent(event);
 				break;
 			}
 		case SDL_KEYDOWN:


### PR DESCRIPTION
If not using touch input,
SDL_MOUSEMOTION/SDL_MOUSEBUTTONDOWN/SDL_MOUSEBUTTONUP would never break,
instead moving on to SDL_KEYDOWN -- which would read
event.key.keysym.scancode and erronously break on the scancode event
read when RMB+MouseMovement occurred, never moving on to return the
event to SDLVideoDriver::ProcessEvent . We now explicitly return the
event when event.button.which is not SDL_TOUCH_MOUSEID .