### PR TITLE
GUIScripts::IWD2: navigation among PCs inside GUIs

### DIFF
--- a/gemrb/GUIScripts/GUICommonWindows.py
+++ b/gemrb/GUIScripts/GUICommonWindows.py
@@ -2074,7 +2074,6 @@ def RealRestPress ():
 def SwitchPCByKey (wIdx, key, mod):
 	if key >= 49 and key <= 54:
 		GemRB.GameSelectPCSingle(key - 48)
-		SelectionChanged ()
 		RunSelectionChangeHandler ()
 		return 1
 	return 0

--- a/gemrb/GUIScripts/GUICommonWindows.py
+++ b/gemrb/GUIScripts/GUICommonWindows.py
@@ -2070,3 +2070,12 @@ def RestPress ():
 def RealRestPress ():
 	GemRB.RestParty(0, 0, 1)
 	return
+
+def SwitchPCByKey (wIdx, key, mod):
+	if key >= 49 and key <= 54:
+		GemRB.GameSelectPCSingle(key - 48)
+		SelectionChanged ()
+		RunSelectionChangeHandler ()
+		return 1
+	return 0
+

--- a/gemrb/GUIScripts/GUIREC.py
+++ b/gemrb/GUIScripts/GUIREC.py
@@ -134,6 +134,8 @@ def OpenRecordsWindow ():
 	GUICommonWindows.SetSelectionChangeHandler (UpdateRecordsWindow)
 	UpdateRecordsWindow ()
 
+	Window.SetKeyPressEvent (GUICommonWindows.SwitchPCByKey)
+
 	OptionsWindow.SetVisible (WINDOW_VISIBLE)
 	Window.SetVisible (WINDOW_VISIBLE)
 	PortraitWindow.SetVisible (WINDOW_VISIBLE)

--- a/gemrb/GUIScripts/bg1/GUIINV.py
+++ b/gemrb/GUIScripts/bg1/GUIINV.py
@@ -181,6 +181,8 @@ def OpenInventoryWindow ():
 	Window.SetVisible (WINDOW_FRONT)
 	PortraitWindow.SetVisible (WINDOW_VISIBLE)
 
+	Window.SetKeyPressEvent (GUICommonWindows.SwitchPCByKey)
+
 	# force unpause the game
 	GemRB.GamePause(0, 0)
 	return

--- a/gemrb/GUIScripts/iwd2/GUIINV.py
+++ b/gemrb/GUIScripts/iwd2/GUIINV.py
@@ -90,6 +90,8 @@ def OpenInventoryWindow ():
 	GUICommonWindows.SetupMenuWindowControls (OptionsWindow, 0, OpenInventoryWindow)
 	Window.SetFrame ()
 
+	Window.SetKeyPressEvent (GUICommonWindows.SwitchPCByKey)
+
 	#ground items scrollbar
 	ScrollBar = Window.GetControl (66)
 	ScrollBar.SetEvent (IE_GUI_SCROLLBAR_ON_CHANGE, RefreshInventoryWindow)

--- a/gemrb/GUIScripts/iwd2/GUIREC.py
+++ b/gemrb/GUIScripts/iwd2/GUIREC.py
@@ -99,6 +99,8 @@ def OpenRecordsWindow ():
 	GUICommonWindows.SetupMenuWindowControls (OptionsWindow, 0, OpenRecordsWindow)
 	Window.SetFrame ()
 
+	Window.SetKeyPressEvent (GUICommonWindows.SwitchPCByKey)
+
 	if not BonusSpellTable:
 		BonusSpellTable = GemRB.LoadTable ("mxsplbon")
 	if not HateRaceTable:

--- a/gemrb/GUIScripts/iwd2/GUISPL.py
+++ b/gemrb/GUIScripts/iwd2/GUISPL.py
@@ -108,6 +108,8 @@ def OpenSpellBookWindow ():
 		Button.SetState (IE_GUI_BUTTON_LOCKED)
 		Button.SetVarAssoc ("SpellIndex", i)
 
+	Window.SetKeyPressEvent (GUICommonWindows.SwitchPCByKey)
+
 	GUICommonWindows.SetSelectionChangeHandler (SelectedNewPlayer)
 	SelectedNewPlayer ()
 	return

--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -590,6 +590,8 @@ bool Game::SelectPCSingle(int index)
 		return false;
 
 	SelectedSingle = index;
+	core->SetEventFlag(EF_SELECTION);
+
 	return true;
 }
 


### PR DESCRIPTION
Ok, as you suggested in #53, I did some minor modifications to the code. In IWD2, everything works well.

I tried BG1 and managed to get the same work for `GUIINV` and `GUIREC`. In contrast, `GUIMG` and `GUIPR` fail as there is something inside the Python scripts shaking `last_win_focused` to set the options window focused, not the desired center window. If you enter such a GUI on a PC that can actually cast spells, it works until reaching a PC with a grayed window.

I tried some things but this is a little beyond what I'm trying to focus on right now. So I skipped that for now.