### PR TITLE
OpenLevelUpWindow: Fix Sorcerer LevelUp

### DIFF
--- a/gemrb/GUIScripts/LevelUp.py
+++ b/gemrb/GUIScripts/LevelUp.py
@@ -246,7 +246,7 @@ def OpenLevelUpWindow():
 			if CommonTables.KitList.GetValue (Kit, 7) == 1: # see if we're a kitted mage
 				Specialist = 1
 
-			if Spellbook.HasSorcererBook (pc, Classes[0]):
+			if Spellbook.HasSorcererBook (pc, Classes[i]):
 				MageTable = "SPLSRCKN"
 
 			MageTable = GemRB.LoadTable (MageTable)

--- a/gemrb/GUIScripts/LevelUp.py
+++ b/gemrb/GUIScripts/LevelUp.py
@@ -245,6 +245,10 @@ def OpenLevelUpWindow():
 			Specialist = 0
 			if CommonTables.KitList.GetValue (Kit, 7) == 1: # see if we're a kitted mage
 				Specialist = 1
+
+			if Spellbook.HasSorcererBook (pc, Classes[0]):
+				MageTable = "SPLSRCKN"
+
 			MageTable = GemRB.LoadTable (MageTable)
 			# loop through each spell level and save the amount possible to cast (current)
 			for j in range (MageTable.GetColumnCount ()):


### PR DESCRIPTION
The LevelUp code does several checks to make sure that only
the relevant ability windows are opened.

One of these checks is about spell selection. If the character class
has a MageTable, then a loop counts the difference in spell count
for each spell level and if there are new spells known, the spell
selection window is opened.

The problem is that for sorcerers it checks the MXSPLSRC table
which is how many spells the character can cast and not the proper
table which is SPLSRCKN and defines how many spells the character knows.

So, when a sorcerer levels up to a level that doesn't grant additional
known spells but grants more spell castings per day, the spell selection
window is opened but there are no spells to be selected and the leveling
process is stuck.

The code is modified to check SPLSRCKN table for sorcerers.

----

Due to the spell progression, this bug cannot be triggered in vanilla BG2.
The levels that sorcerers do not get any new known spells and can trigger
the bug are 2, 24, 26 - 27, 29, 33 - 35, 37 - 40. In the vanilla BG2 game,
sorcerers do not get more frequent spell castings from level 20 and up,
so that leaves us only L2 which cannot be reached because
they cannot be dual classed.

However, the bug can be triggered in BGT where you cannot level up to L2
and must wait to level up directly to L3 and in BG2 with the Un-nerfed spell
progression component of BG2 Tweaks / Tweaks Anthology which gives
more spell castings and triggers the bug for the above levels.