### PR TITLE
fix incorrect usage of SDL_GetNumTouchDevices

### DIFF
--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -867,7 +867,7 @@ float SDL20VideoDriver::ScaleCoordinateVertical(float y)
 // note from upstream: on some platforms a device may become seen only after use
 bool SDL20VideoDriver::TouchInputEnabled() const
 {
-	return SDL_GetNumTouchDevices > 0;
+	return SDL_GetNumTouchDevices() > 0;
 }
 
 #ifndef USE_OPENGL


### PR DESCRIPTION
use it as a function not as a function pointer

causes gcc 5.1 warning: error: ordered comparison of pointer with integer zero [-Werror=extra]