### PR TITLE
Fix link to forum

### DIFF
--- a/README
+++ b/README
@@ -43,7 +43,7 @@ Our project at sourceforge.net:
 http://sourceforge.net/projects/gemrb
 
 New GemRB forum (users):
-http://forums.gibberlings3.net/index.php?showforum=91
+http://gibberlings3.net/forums/index.php?showforum=91
 
 IRC channel:
 The best way to talk with us is by joining the #GemRB channel


### PR DESCRIPTION
Old link was redirecting to forums home page instead of specific forum for GemRB.