### PR TITLE
ACMReader: fixes underflow on pointer magic

### DIFF
--- a/gemrb/plugins/ACMReader/unpacker.cpp
+++ b/gemrb/plugins/ACMReader/unpacker.cpp
@@ -167,10 +167,11 @@ int CValueUnpacker::zero_fill(int pass, int /*ind*/)
 	} while (( --i ) != 0);
 	return 1;
 }
+
 int CValueUnpacker::linear_fill(int pass, int ind)
 {
 	int mask = ( 1 << ind ) - 1;
-	short* lb_ptr = buff_middle + ( ( -1ul ) << ( ind - 1 ) );
+	short* lb_ptr = buff_middle + ( ((size_t)-1) << ( ind - 1 ) );
 
 	for (int i = 0; i < subblocks; i++)
 		block_ptr[i * sb_size + pass] = lb_ptr[get_bits( ind ) & mask];


### PR DESCRIPTION
Minor nerdy things:

I attempt to put my build setup somewhere else. There I have a GCC v7.2.0 on x86_64 and after setup, IWD2 crashes right at the moment of loading menu music.

The error can be tracked down to this very line: the author once wanted to fill a ptr-wide buffer full of 0xF bytes, shift them aside and add the result to `buff_middle`. This certainly works on 32bit and surprinsingly my VBox Linux, but here `-1ul` evaluates to `0x00000000FFFFFFFF` for this op. The shifted bit pattern will then throw the pointer far away.