### PR TITLE
OpenGL: some fixes

### DIFF
--- a/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
@@ -441,8 +441,32 @@ void GLVideoDriver::drawPolygon(Point* points, unsigned int count, const Color& 
 	glDeleteBuffers(1, &buffer);
 }
 
+void GLVideoDriver::SetPixel(short x, short y, const Color& color, bool clipped) {
+	if (clipped) {
+		x += xCorr;
+		y += yCorr;
+		if (( x >= ( xCorr + Viewport.w ) ) || ( y >= ( yCorr + Viewport.h ) )) {
+			return;
+		}
+		if (( x < xCorr ) || ( y < yCorr )) {
+			return;
+		}
+	} else {
+		if (( x >= disp->w ) || ( y >= disp->h )) {
+			return;
+		}
+		if (( x < 0 ) || ( y < 0 )) {
+			return;
+		}
+	}
+
+	Region region(x, y, 1, 1);
+	clearRect(region, color);
+}
+
 void GLVideoDriver::drawEllipse(int cx /*center*/, int cy /*center*/, unsigned short xr, unsigned short yr, float thickness, const Color& color)
 {
+	glDisable(GL_SCISSOR_TEST);
 	const float support = 0.75;
 	useProgram(programEllipse);
     if (thickness < 1.0) thickness = 1.0;
@@ -480,6 +504,7 @@ void GLVideoDriver::drawEllipse(int cx /*center*/, int cy /*center*/, unsigned s
 	glDisableVertexAttribArray(a_position);
 
 	glDeleteBuffers(1, &buffer);
+	glEnable(GL_SCISSOR_TEST);
 }
 
 void GLVideoDriver::BlitTile(const Sprite2D* spr, const Sprite2D* mask, int x, int y, const Region* clip, unsigned int flags)

--- a/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
@@ -504,8 +504,17 @@ void GLVideoDriver::BlitTile(const Sprite2D* spr, const Sprite2D* mask, int x, i
 	{
 		totint = core->GetGame()->GetGlobalTint();
 	}
-	return GLBlitSprite((GLTextureSprite2D*)spr, Region(0, 0, spr->Width, spr->Height), dst,
+
+	if (!(blitFlags & BLIT_HALFTRANS)) {
+		glBlendFunc(GL_ONE, GL_ZERO);
+	}
+
+	GLBlitSprite((GLTextureSprite2D*)spr, Region(0, 0, spr->Width, spr->Height), dst,
 						NULL, blitFlags, totint, (GLTextureSprite2D*)mask);
+
+	if (!(blitFlags & BLIT_HALFTRANS)) {
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+	}
 }
 
 void GLVideoDriver::BlitGameSprite(const Sprite2D* spr, int x, int y, unsigned int flags, Color tint,

--- a/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
@@ -358,6 +358,14 @@ void GLVideoDriver::GLBlitSprite(GLTextureSprite2D* spr, const Region& src, cons
 	program->SetUniformValue("u_tint", COLOR_SIZE, (GLfloat)colorTint.r/255, (GLfloat)colorTint.g/255, (GLfloat)colorTint.b/255, (GLfloat)colorTint.a/255);
 	program->SetUniformValue("u_alphaModifier", 1, alphaModifier);
 
+	unsigned int shadowMode = 1;
+	if (flags & BLIT_NOSHADOW) {
+		shadowMode = 0;
+	} else if (flags & BLIT_TRANSSHADOW) {
+		shadowMode = 2;
+	}
+	program->SetUniformValue("u_shadowMode", 1, (GLint)shadowMode);
+
 	GLint a_position = program->GetAttribLocation("a_position");
 	GLint a_texCoord = program->GetAttribLocation("a_texCoord");
 

--- a/gemrb/plugins/SDLVideo/Shaders/SpritePal.glslf
+++ b/gemrb/plugins/SDLVideo/Shaders/SpritePal.glslf
@@ -5,10 +5,23 @@ uniform sampler2D s_mask;		// optional mask
 varying vec2 v_texCoord;
 uniform float u_alphaModifier;
 uniform vec4 u_tint;
+uniform int u_shadowMode;
+
 void main()
 {
 	float alphaModifier = u_alphaModifier * texture2D(s_mask, v_texCoord).a;
 	float index = texture2D(s_texture, v_texCoord).a;
-	vec4 color = texture2D(s_palette, vec2((0.5 + index*255.0)/256.0, 0.5));
-	gl_FragColor = vec4(color.r*u_tint.r, color.g*u_tint.g, color.b*u_tint.b, color.a * alphaModifier);
+	int iindex = int(index * 255.0);
+
+	if ((0 == u_shadowMode) && (1 == iindex)) {
+		gl_FragColor = vec4(255, 255, 255, 0);
+	} else {
+		vec4 color = texture2D(s_palette, vec2((0.5 + index*255.0)/256.0, 0.5));
+
+		if (2 == u_shadowMode && (1 == iindex)) {
+			color = vec4(color.r/2.0, color.g/2.0, color.b/2.0, 0.5);
+		}
+
+		gl_FragColor = vec4(color.r*u_tint.r, color.g*u_tint.g, color.b*u_tint.b, color.a * alphaModifier);
+	}
 }

--- a/gemrb/plugins/SDLVideo/Shaders/SpritePalGrayed.glslf
+++ b/gemrb/plugins/SDLVideo/Shaders/SpritePalGrayed.glslf
@@ -4,11 +4,24 @@ uniform sampler2D s_palette;	// palette 256 x 1 pixels
 uniform sampler2D s_mask;		// optional mask
 varying vec2 v_texCoord;
 uniform float u_alphaModifier;
+uniform int u_shadowMode;
+
 void main()
 {
 	float alphaModifier = u_alphaModifier * texture2D(s_mask, v_texCoord).a;
 	float index = texture2D(s_texture, v_texCoord).a;
-	vec4 color = texture2D(s_palette, vec2((0.5 + index*255.0)/256.0, 0.5));
-	float gray = (color.r + color.g + color.b)*0.333333;
-	gl_FragColor = vec4(gray, gray, gray, color.a * alphaModifier);
+	int iindex = int(index * 255.0);
+
+	if ((0 == u_shadowMode) && (1 == iindex)) {
+		gl_FragColor = vec4(255, 255, 255, 0);
+	} else {
+		vec4 color = texture2D(s_palette, vec2((0.5 + index*255.0)/256.0, 0.5));
+
+		if (2 == u_shadowMode && (1 == iindex)) {
+			color = vec4(color.r/2.0, color.g/2.0, color.b/2.0, 0.5);
+		}
+
+		float gray = (color.r + color.g + color.b)*0.333333;
+		gl_FragColor = vec4(gray, gray, gray, color.a * alphaModifier);
+	}
 }

--- a/gemrb/plugins/SDLVideo/Shaders/SpritePalSepia.glslf
+++ b/gemrb/plugins/SDLVideo/Shaders/SpritePalSepia.glslf
@@ -6,12 +6,25 @@ varying vec2 v_texCoord;
 uniform float u_alphaModifier;
 const vec3 lightColor = vec3(0.9, 0.9, 0.5);
 const vec3 darkColor = vec3(0.2, 0.05, 0.0);
+uniform int u_shadowMode;
+
 void main()
 {
 	float alphaModifier = u_alphaModifier * texture2D(s_mask, v_texCoord).a;
 	float index = texture2D(s_texture, v_texCoord).a;
-	vec4 color = texture2D(s_palette, vec2((0.5 + index*255.0)/256.0, 0.5));
-	float gray = (color.r + color.g + color.b)*0.333333;
-	vec3 sepia = darkColor*(1.0 - gray) + lightColor*gray;
-	gl_FragColor = vec4(sepia, color.a * alphaModifier);
+	int iindex = int(index * 255.0);
+
+	if ((0 == u_shadowMode) && (1 == iindex)) {
+		gl_FragColor = vec4(255, 255, 255, 0);
+	} else {
+		vec4 color = texture2D(s_palette, vec2((0.5 + index*255.0)/256.0, 0.5));
+
+		if (2 == u_shadowMode && (1 == iindex)) {
+			color = vec4(color.r/2.0, color.g/2.0, color.b/2.0, 0.5);
+		}
+
+		float gray = (color.r + color.g + color.b)*0.333333;
+		vec3 sepia = darkColor*(1.0 - gray) + lightColor*gray;
+		gl_FragColor = vec4(sepia, color.a * alphaModifier);
+	}
 }


### PR DESCRIPTION
![iwd2s](https://user-images.githubusercontent.com/238558/30726594-202c9d32-9f4c-11e7-856a-4bb04fc3fb3d.png)

There are some minor but annoying rendering issues when using OpenGL:

1. Mysterious black pixels in the snow. Blending on area tiles is enabled even if there is no reason to (as of the docs, tiles contain no alpha-values and `BLIT_HALFTRANS` isn't set here), so I set blending to opaque for the area background.
2. Char shadows are opaque and item piles are always outlined. Both these issues are half-related since there is no support on `BLIT_NOSHADOW` and `BLIT_TRANSSHADOW`. I put this handling to the fragment shaders - my experience in GLSL is limited, but they are ES compliant and for now, they work. ;)
3. Ground circles are mostly missing (see the piece of green circle close to the goblin at the center?) and ground reticles lack the outer bound. Something is messed up around scissoring, so for `DrawEllipse`, I disabled it. And `SetPixel` failed trying something SDL-related, so it has turned into some simple GL override.

The chimney smoke also looks weird, but it's nearly the same in the SW renderer so I skipped that for now.

![iwd2_after](https://user-images.githubusercontent.com/238558/30726879-df503006-9f4d-11e7-8383-e52778a4d6f6.png)

Tested on IWD2 and BG on Windows.
