### PR TITLE
OpenGL: adds missing header update

### DIFF
--- a/gemrb/plugins/SDLVideo/SDL20GLVideo.h
+++ b/gemrb/plugins/SDLVideo/SDL20GLVideo.h
@@ -67,6 +67,7 @@ namespace GemRB
 		void DrawPolyline(Gem_Polygon* poly, const Color& color, bool fill = false);
 		void DrawEllipse(short cx, short cy, unsigned short xr, unsigned short yr, const Color& color, bool clipped = true);
 		void DrawCircle(short cx, short cy, unsigned short r, const Color& color, bool clipped = true);
+		void SetPixel(short x, short y, const Color& color, bool clipped = true);
 		/*void DrawEllipseSegment(short cx, short cy, unsigned short xr, unsigned short yr, const Color& color, double anglefrom, double angleto, bool drawlines = true, bool clipped = true);*/
 		void DestroyMovieScreen();
 		Sprite2D* GetScreenshot(Region r);


### PR DESCRIPTION
In #63 I missed adding `SDL20GLVideo.h` so the `OPENGL_BACKEND=OpenGL` setup won't compile. CI is probably not building that. :grin: 