### PR TITLE
GUIScripts: the clock in IWD2

### DIFF
--- a/gemrb/GUIScripts/GUICommonWindows.py
+++ b/gemrb/GUIScripts/GUICommonWindows.py
@@ -256,6 +256,8 @@ def SetupMenuWindowControls (Window, Gears=None, CloseWindowCallback=None):
 		UpdateClock ()
 	else:
 		rb = OptionControl['Rest']
+		if iwd2:
+			UpdateClock ()
 
 	# Rest
 	if Window.HasControl (rb):
@@ -2042,12 +2044,14 @@ def UpdateClock ():
 
 	else:
 		Clock = None
-		if OptionsWindow and OptionsWindow.HasControl (9):
-			Clock = OptionsWindow.GetControl (9)
+		if OptionsWindow:
+			if GameCheck.IsIWD2():
+				Clock = OptionsWindow.GetControl (10)
+			elif OptionsWindow.HasControl(9):
+				Clock = OptionsWindow.GetControl (9)
 		elif ActionsWindow and ActionsWindow.HasControl (62):
 			Clock = ActionsWindow.GetControl (62)
-
-		if Clock and Clock.HasAnimation("CGEAR"):
+		if Clock and (Clock.HasAnimation("CGEAR") or GameCheck.IsIWD2()):
 			Hours = (GemRB.GetGameTime () % 7200) / 300
 			GUICommon.SetGamedaysAndHourToken ()
 			Clock.SetBAM ("CDIAL", 0, (Hours + 12) % 24)

--- a/gemrb/GUIScripts/GUIMA.py
+++ b/gemrb/GUIScripts/GUIMA.py
@@ -153,6 +153,7 @@ def ShowMap ():
 
 ###################################################
 def OpenMapWindow ():
+	import GameCheck
 	global MapWindow, OptionsWindow, PortraitWindow
 	global OldPortraitWindow, OldOptionsWindow
 
@@ -189,7 +190,7 @@ def OpenMapWindow ():
 	OldOptionsWindow = GUICommonWindows.OptionsWindow
 	OptionsWindow = GemRB.LoadWindow (0)
 	GUICommonWindows.MarkMenuButton (OptionsWindow)
-	GUICommonWindows.SetupMenuWindowControls (OptionsWindow, 0, OpenMapWindow)
+	GUICommonWindows.SetupMenuWindowControls (OptionsWindow, GameCheck.IsIWD2(), OpenMapWindow)
 	OptionsWindow.SetFrame ()
 
 	# World Map

--- a/gemrb/GUIScripts/iwd2/GUIINV.py
+++ b/gemrb/GUIScripts/iwd2/GUIINV.py
@@ -88,7 +88,7 @@ def OpenInventoryWindow ():
 	PortraitWindow = GUICommonWindows.OpenPortraitWindow ()
 	OldOptionsWindow = GUICommonWindows.OptionsWindow
 	OptionsWindow = GemRB.LoadWindow (0)
-	GUICommonWindows.SetupMenuWindowControls (OptionsWindow, 0, OpenInventoryWindow)
+	GUICommonWindows.SetupMenuWindowControls (OptionsWindow, 1, OpenInventoryWindow)
 	Window.SetFrame ()
 
 	Window.SetKeyPressEvent (GUICommonWindows.SwitchPCByKey)


### PR DESCRIPTION
Contrary to other games, the globe-clock is visible nearly everywhere and its control ID was wrong so there is no natural way to retrieve the time by tooltip (and at all?). 

It actually moves in map overview and inventory - and as in the original, if you click it in the inventory, the puppet stops moving. :+1: 