### PR TITLE
Infravision

### DIFF
--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -40,6 +40,7 @@
 #include "GUI/GameControl.h"
 #include "System/DataStream.h"
 #include "System/StringBuffer.h"
+#include "Video.h"
 
 #include <algorithm>
 #include <iterator>
@@ -532,7 +533,7 @@ int Game::JoinParty(Actor* actor, int join)
 				CopyResRef(actor->LargePortrait, ptab->QueryField(actor->LargePortrait, "REPLACEMENT"));
 			}
 		}
-		
+
 		if (size) {
 			ieDword id = actor->GetGlobalID();
 			for (size_t i=0;i<size; i++) {

--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -2055,6 +2055,21 @@ const Color *Game::GetGlobalTint() const
 	return NULL;
 }
 
+// applies the global tint, if any
+void Game::ApplyGlobalTint(Color &tint, ieDword &flags) const
+{
+	const Color *globalTint = GetGlobalTint();
+	if (globalTint) {
+		if (flags & BLIT_TINTED) {
+			Color::MultiplyTint(tint, globalTint);
+		} else {
+			flags |= BLIT_TINTED;
+			tint = *globalTint;
+			tint.a = 255;
+		}
+	}
+}
+
 bool Game::IsDay()
 {
 	ieDword daynight = core->Time.GetHour(GameTime);

--- a/gemrb/core/Game.h
+++ b/gemrb/core/Game.h
@@ -477,6 +477,8 @@ public:
 	bool TimeStoppedFor(const Actor* target=NULL);
 	/** updates the infravision info */
 	void Infravision();
+	/** applies the global tint if it is needed */
+	void ApplyGlobalTint(Color &tint, ieDword &flags) const;
 	/** gets the colour which should be applied over the game area,
 	may return NULL */
 	const Color *GetGlobalTint() const;

--- a/gemrb/core/Game.h
+++ b/gemrb/core/Game.h
@@ -476,7 +476,7 @@ public:
 	/** check if the passed actor is a victim of timestop */
 	bool TimeStoppedFor(const Actor* target=NULL);
 	/** updates the infravision info */
-	void Infravision();
+	void Infravision(const Actor *target=NULL);
 	/** applies the global tint if it is needed */
 	void ApplyGlobalTint(Color &tint, ieDword &flags) const;
 	/** gets the colour which should be applied over the game area,

--- a/gemrb/core/Game.h
+++ b/gemrb/core/Game.h
@@ -476,7 +476,7 @@ public:
 	/** check if the passed actor is a victim of timestop */
 	bool TimeStoppedFor(const Actor* target=NULL);
 	/** updates the infravision info */
-	void Infravision(const Actor *target=NULL);
+	void Infravision();
 	/** applies the global tint if it is needed */
 	void ApplyGlobalTint(Color &tint, ieDword &flags) const;
 	/** gets the colour which should be applied over the game area,

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -3145,7 +3145,7 @@ void Map::RemoveMapNote(const Point &point)
 {
 	std::vector<MapNote>::iterator it = mapnotes.begin();
 	for (; it != mapnotes.end(); ++it) {
-		if ((*it).Pos == point) {
+		if (it->Pos == point) {
 			mapnotes.erase(it);
 			break;
 		}
@@ -3989,6 +3989,7 @@ int AreaAnimation::GetHeight() const
 void AreaAnimation::Draw(const Region &screen, Map *area)
 {
 	Video* video = core->GetVideoDriver();
+	Game *game = core->GetGame();
 
 	//always draw the animation tinted because tint is also used for
 	//transparency
@@ -3998,6 +3999,8 @@ void AreaAnimation::Draw(const Region &screen, Map *area)
 		tint = area->LightMap->GetPixel( Pos.x / 16, Pos.y / 12);
 		tint.a = inverseTransparency;
 	}
+	ieDword flags = BLIT_TINTED;
+	if (game) game->ApplyGlobalTint(tint, flags);
 	bool covered = true;
 
 	// TODO: This needs more testing. The HOW ar9101 roast seems to need it.
@@ -4012,7 +4015,6 @@ void AreaAnimation::Draw(const Region &screen, Map *area)
 		covers=(SpriteCover **) calloc( animcount, sizeof(SpriteCover *) );
 	}
 
-
 	int ac = animcount;
 	while (ac--) {
 		Animation *anim = animation[ac];
@@ -4025,7 +4027,7 @@ void AreaAnimation::Draw(const Region &screen, Map *area)
 			}
 		}
 		video->BlitGameSprite( frame, Pos.x + screen.x, Pos.y + screen.y,
-			BLIT_TINTED, tint, covers?covers[ac]:0, palette, &screen );
+			flags, tint, covers?covers[ac]:0, palette, &screen );
 	}
 }
 

--- a/gemrb/core/Particles.cpp
+++ b/gemrb/core/Particles.cpp
@@ -197,6 +197,8 @@ void Particles::Draw(const Region &screen)
 
 	Video *video=core->GetVideoDriver();
 	Region region = video->GetViewport();
+	Game *game = core->GetGame();
+
 	if (owner) {
 		region.x-=pos.x;
 		region.y-=pos.y;
@@ -243,8 +245,11 @@ void Particles::Draw(const Region &screen)
 				if (anims) {
 					Animation* anim = anims[0];
 					Sprite2D* nextFrame = anim->GetFrame(anim->GetCurrentFrame());
+
+					ieDword flags = 0;
+					if (game) game->ApplyGlobalTint(clr, flags);
 					video->BlitGameSprite( nextFrame, points[i].pos.x - region.x, points[i].pos.y - region.y,
-						0, clr, NULL, fragments->GetPartPalette(0), &screen);
+						flags, clr, NULL, fragments->GetPartPalette(0), &screen);
 				}
 			}
 			break;

--- a/gemrb/core/Projectile.cpp
+++ b/gemrb/core/Projectile.cpp
@@ -1616,8 +1616,11 @@ void Projectile::SetupWall()
 void Projectile::DrawLine(const Region &screen, int face, ieDword flag)
 {
 	Video *video = core->GetVideoDriver();
+	Game *game = core->GetGame();
 	PathNode *iter = path;
 	Sprite2D *frame = travel[face]->NextFrame();
+	Color tint2 = tint;
+	if (game) game->ApplyGlobalTint(tint2, flag);
 	while(iter) {
 		Point pos(iter->x, iter->y);
 
@@ -1627,7 +1630,7 @@ void Projectile::DrawLine(const Region &screen, int face, ieDword flag)
 		pos.x+=screen.x;
 		pos.y+=screen.y;
 
-		video->BlitGameSprite( frame, pos.x, pos.y, flag, tint, NULL, palette, &screen);
+		video->BlitGameSprite( frame, pos.x, pos.y, flag, tint2, NULL, palette, &screen);
 		iter = iter->Next;
 	}
 }
@@ -1635,6 +1638,7 @@ void Projectile::DrawLine(const Region &screen, int face, ieDword flag)
 void Projectile::DrawTravel(const Region &screen)
 {
 	Video *video = core->GetVideoDriver();
+	Game *game = core->GetGame();
 	ieDword flag;
 
 	if(ExtFlags&PEF_HALFTRANS) {
@@ -1690,8 +1694,13 @@ void Projectile::DrawTravel(const Region &screen)
 		pos = newpos;
 	}
 
+	// set up the tint for the rest of the blits, but don't overwrite the saved one
+	Color tint2 = tint;
+	ieDword flags = flag;
+	if (game) game->ApplyGlobalTint(tint2, flags);
+
 	if (light) {
-		video->BlitGameSprite( light, pos.x, pos.y, 0, tint, NULL, NULL, &screen);
+		video->BlitGameSprite(light, pos.x, pos.y, flags^flag, tint2, NULL, NULL, &screen);
 	}
 
 	if (ExtFlags&PEF_POP) {
@@ -1712,8 +1721,8 @@ void Projectile::DrawTravel(const Region &screen)
 					frame = shadow[0]->NextFrame();
 				}
 			}
-			
-			video->BlitGameSprite( frame, pos.x, pos.y, flag, tint, NULL, palette, &screen);
+
+			video->BlitGameSprite(frame, pos.x, pos.y, flags, tint2, NULL, palette, &screen);
 			return;
 	}
 	
@@ -1724,7 +1733,7 @@ void Projectile::DrawTravel(const Region &screen)
 	
 	if (shadow[face]) {
 		Sprite2D *frame = shadow[face]->NextFrame();
-		video->BlitGameSprite( frame, pos.x, pos.y, flag, tint, NULL, palette, &screen);
+		video->BlitGameSprite(frame, pos.x, pos.y, flags, tint2, NULL, palette, &screen);
 	}
 
 	pos.y-=GetZPos();
@@ -1734,14 +1743,14 @@ void Projectile::DrawTravel(const Region &screen)
 		for(int i=0;i<Aim;i++) {
 			if (travel[i]) {
 				Sprite2D *frame = travel[i]->NextFrame();
-				video->BlitGameSprite( frame, pos.x, pos.y, flag, tint, NULL, palette, &screen);
+				video->BlitGameSprite( frame, pos.x, pos.y, flags, tint2, NULL, palette, &screen);
 				pos.y-=frame->YPos;
 			}
 		}
 	} else {
 		if (travel[face]) {
 			Sprite2D *frame = travel[face]->NextFrame();
-			video->BlitGameSprite( frame, pos.x, pos.y, flag, tint, NULL, palette, &screen);
+			video->BlitGameSprite( frame, pos.x, pos.y, flags, tint2, NULL, palette, &screen);
 		}
 	}
 

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -7648,7 +7648,10 @@ void Actor::DrawActorSprite(const Region &screen, int cx, int cy, const Region& 
 		flags |= BLIT_GREY;
 	}
 	Color tint2 = tint;
-	game->ApplyGlobalTint(tint2, flags);
+
+	if (!noGlobalTint) {
+		game->ApplyGlobalTint(tint2, flags);
+	}
 
 	// display current frames in the right order
 	const int* zOrder = ca->GetZOrder(Face);
@@ -8060,12 +8063,10 @@ void Actor::Draw(const Region &screen)
 
 		bool noGlobalTint = false;
 		// infravision, independent of light map and global light
-		int areaType = GetCurrentArea()->AreaType;
-
 		if ( HasBodyHeat() &&
-			(area->GetLightLevel(Pos)<128) &&
 			core->GetGame()->PartyHasInfravision() &&
-			((!core->GetGame()->IsDay() && (areaType & AT_OUTDOOR)) || (areaType & AT_DUNGEON))) {
+			!core->GetGame()->IsDay() &&
+			(area->AreaType & AT_OUTDOOR) && !(area->AreaFlags & AF_DREAM)) {
 			noGlobalTint = true;
 			tint.r = 255;
 

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -7640,16 +7640,15 @@ void Actor::DrawActorSprite(const Region &screen, int cx, int cy, const Region& 
 	int PartCount = ca->GetTotalPartCount();
 	Video* video = core->GetVideoDriver();
 	Region vp = video->GetViewport();
-	unsigned int flags = TranslucentShadows ? BLIT_TRANSSHADOW : 0;
+	ieDword flags = TranslucentShadows ? BLIT_TRANSSHADOW : 0;
 	if (!ca->lockPalette) flags |= BLIT_TINTED;
 	Game* game = core->GetGame();
 	// when time stops, almost everything turns dull grey, the caster and immune actors being the most notable exceptions
 	if (game->TimeStoppedFor(this)) {
 		flags |= BLIT_GREY;
 	}
-	if (noGlobalTint) {
-		flags |= BLIT_GLOW;
-	}
+	Color tint2 = tint;
+	game->ApplyGlobalTint(tint2, flags);
 
 	// display current frames in the right order
 	const int* zOrder = ca->GetZOrder(Face);
@@ -7673,7 +7672,7 @@ void Actor::DrawActorSprite(const Region &screen, int cx, int cy, const Region& 
 			assert(newsc->Covers(cx, cy, nextFrame->XPos, nextFrame->YPos, nextFrame->Width, nextFrame->Height));
 
 			video->BlitGameSprite( nextFrame, cx + screen.x, cy + screen.y,
-				flags, tint, newsc, ca->GetPartPalette(partnum), &screen);
+				flags, tint2, newsc, ca->GetPartPalette(partnum), &screen);
 		}
 	}
 }

--- a/gemrb/core/Scriptable/Actor.h
+++ b/gemrb/core/Scriptable/Actor.h
@@ -371,7 +371,8 @@ private:
 	/** paint the actor itself. Called internally by Draw() */
 	void DrawActorSprite(const Region &screen, int cx, int cy, const Region& bbox,
 				SpriteCover*& sc, Animation** anims,
-				unsigned char Face, const Color& tint);
+				unsigned char Face, const Color& tint,
+				bool noGlobalTint = false);
 
 	/** fixes the palette */
 	void SetupColors();

--- a/gemrb/core/Scriptable/Container.cpp
+++ b/gemrb/core/Scriptable/Container.cpp
@@ -75,14 +75,18 @@ Container::~Container()
 void Container::DrawPile(bool highlight, Region screen, Color tint)
 {
 	Video* video = core->GetVideoDriver();
+	Game *game = core->GetGame();
+
+	//draw it with highlight
+	ieDword flags = BLIT_TINTED | (highlight ? 0 : BLIT_NOSHADOW);
+	if (game) game->ApplyGlobalTint(tint, flags);
+
 	CreateGroundIconCover();
 	for (int i = 0;i<MAX_GROUND_ICON_DRAWN;i++) {
 		if (groundicons[i]) {
-			//draw it with highlight
 			video->BlitGameSprite(groundicons[i],
 				screen.x + Pos.x, screen.y + Pos.y,
-				BLIT_TINTED | (highlight ? 0:BLIT_NOSHADOW),
-				tint, groundiconcover);
+				flags, tint, groundiconcover);
 		}
 	}
 }

--- a/gemrb/core/ScriptedAnimation.cpp
+++ b/gemrb/core/ScriptedAnimation.cpp
@@ -649,6 +649,7 @@ bool ScriptedAnimation::Draw(const Region &screen, const Point &Pos, const Color
 	}
 
 	Video *video = core->GetVideoDriver();
+	Game *game = core->GetGame();
 
 	Sprite2D* frame;
 
@@ -690,6 +691,8 @@ bool ScriptedAnimation::Draw(const Region &screen, const Point &Pos, const Color
 	if ((Transparency & IE_VVC_TINT)==IE_VVC_TINT) {
 		tint = p_tint;
 	}
+	ieDword flags = flag;
+	if (game) game->ApplyGlobalTint(tint, flags);
 
 	int cx = Pos.x + XPos;
 	int cy = Pos.y - ZPos + YPos;
@@ -707,9 +710,9 @@ bool ScriptedAnimation::Draw(const Region &screen, const Point &Pos, const Color
 		assert(cover->Covers(cx, cy, frame->XPos, frame->YPos, frame->Width, frame->Height));
 	}
 
-	video->BlitGameSprite( frame, cx + screen.x, cy + screen.y, flag, tint, cover, palette, &screen);
+	video->BlitGameSprite( frame, cx + screen.x, cy + screen.y, flags, tint, cover, palette, &screen);
 	if (light) {
-		video->BlitGameSprite( light, cx + screen.x, cy + screen.y, 0, tint, NULL, NULL, &screen);
+		video->BlitGameSprite( light, cx + screen.x, cy + screen.y, flags^flag, tint, NULL, NULL, &screen);
 	}
 	return false;
 }

--- a/gemrb/core/Video.h
+++ b/gemrb/core/Video.h
@@ -53,7 +53,7 @@ enum SpriteBlitFlags {
 	BLIT_GREY = IE_VVC_GREYSCALE, // 0x80000; timestop palette
 	BLIT_SEPIA = IE_VVC_SEPIA, // 0x02000000; dream scene palette
 	BLIT_DARK = IE_VVC_DARKEN, // 0x00100000; not implemented in SDLVideo yet
-	BLIT_GLOW = IE_VVC_GLOWING // 0x00200000; not implemented in SDLVideo yet
+	BLIT_GLOW = IE_VVC_GLOWING // 0x00200000; infravision, possibly incorrect
 	// Note: bits 29,30,31 are used by SDLVideo internally
 };
 

--- a/gemrb/includes/RGBAColor.h
+++ b/gemrb/includes/RGBAColor.h
@@ -28,6 +28,12 @@ struct RevColor {
 
 struct Color {
 	unsigned char r,g,b,a;
+
+	static void MultiplyTint(Color& tint, const Color* tintMod) {
+		tint.r = (tint.r * tintMod->r) >> 8;
+		tint.g = (tint.g * tintMod->g) >> 8;
+		tint.b = (tint.b * tintMod->b) >> 8;
+	}
 }
 #ifdef __GNUC__
 	__attribute__((aligned(4)))

--- a/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
@@ -554,8 +554,8 @@ void GLVideoDriver::BlitGameSprite(const Sprite2D* spr, int x, int y, unsigned i
 	}
 	GLTextureSprite2D* glSprite = (GLTextureSprite2D*)spr;
 	GLuint coverTexture = 0;
-	
-	if (!anchor && core->GetGame()) 
+
+	if (!(flags & BLIT_GLOW) && !anchor && core->GetGame())
 	{
 		const Color *totint = core->GetGame()->GetGlobalTint();
 		if (totint) 

--- a/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
@@ -555,27 +555,6 @@ void GLVideoDriver::BlitGameSprite(const Sprite2D* spr, int x, int y, unsigned i
 	GLTextureSprite2D* glSprite = (GLTextureSprite2D*)spr;
 	GLuint coverTexture = 0;
 
-	if (!(flags & BLIT_GLOW) && !anchor && core->GetGame())
-	{
-		const Color *totint = core->GetGame()->GetGlobalTint();
-		if (totint) 
-		{
-			if (flags & BLIT_TINTED) 
-			{
-				tint.r = (tint.r * totint->r) >> 8;
-				tint.g = (tint.g * totint->g) >> 8;
-				tint.b = (tint.b * totint->b) >> 8;
-			} 
-			else
-			{
-				flags |= BLIT_TINTED;
-				tint = *totint;
-			}
-		}
-	}
-
-
-
 	if(glSprite->IsPaletted())
 	{
 		if (cover)

--- a/gemrb/plugins/SDLVideo/SDLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDLVideo.cpp
@@ -607,7 +607,7 @@ void SDLVideoDriver::BlitGameSprite(const Sprite2D* spr, int x, int y,
 	}
 
 	// global tint
-	if (!anchor && core->GetGame()) {
+	if (!(flags & BLIT_GLOW) && !anchor && core->GetGame()) {
 		const Color *totint = core->GetGame()->GetGlobalTint();
 		if (totint) {
 			if (flags & BLIT_TINTED) {

--- a/gemrb/plugins/SDLVideo/SDLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDLVideo.cpp
@@ -606,22 +606,7 @@ void SDLVideoDriver::BlitGameSprite(const Sprite2D* spr, int x, int y,
 		}
 	}
 
-	// global tint
-	if (!(flags & BLIT_GLOW) && !anchor && core->GetGame()) {
-		const Color *totint = core->GetGame()->GetGlobalTint();
-		if (totint) {
-			if (flags & BLIT_TINTED) {
-				tint.r = (tint.r * totint->r) >> 8;
-				tint.g = (tint.g * totint->g) >> 8;
-				tint.b = (tint.b * totint->b) >> 8;
-			} else {
-				flags |= BLIT_TINTED;
-				tint = *totint;
-				tint.a = 255;
-			}
-		}
-	}
-
+	// global tint is handled by the callers
 
 	// implicit flags:
 	const unsigned int blit_TINTALPHA =    0x40000000U;


### PR DESCRIPTION
As you see in the screenshots of #63, infravision is enabled (by the half-orc) even at daytime while it should be enabled by night or inside dungeons only. For at least IWD2, infravision is not red but white.

Moreover, the infravision is far too dark (current implementation in screen 1 vs original in screen 2/3): It's set relative to the light map and global tints. For infravision and my research, actors always glow. For non-IWD2, I've hardcoded the value to some medium red which is very close the original one (screen 2) - somehow, we have a little more global dark blue from somewhere (screen 3 vs screen 4) so I suggest to live with these values for now.

Since there is no documentation in both code and docs, I took the unused `BLIT_GLOW` bit to circumvent global tinting. To me, the whole thing shouldn't take place in the video drivers, but I think that's another issue.

In addition, no game except IWD2 seems to take infravision into account as a racial bonus (not covered here).

![infra](https://user-images.githubusercontent.com/238558/30774550-afc504d2-a084-11e7-8357-6d55e821f861.png)
![infra_bg](https://user-images.githubusercontent.com/238558/30774553-afce56ea-a084-11e7-9b40-a3ff0cf2954e.png)
![infra2](https://user-images.githubusercontent.com/238558/30774551-afc78dce-a084-11e7-92a4-29a2e60fa18e.png)
![infra3](https://user-images.githubusercontent.com/238558/30774552-afcadc86-a084-11e7-8007-fb18122d14eb.png)



