### PR TITLE
OpenGL: better text rendering

### DIFF
--- a/gemrb/plugins/SDLVideo/GLPaletteManager.cpp
+++ b/gemrb/plugins/SDLVideo/GLPaletteManager.cpp
@@ -40,10 +40,7 @@ GLuint GLPaletteManager::CreatePaletteTexture(Palette* palette, unsigned int col
 		{
 			for (unsigned int i=0; i<256; i++)
 			{
-				if (colors[i].a == 0)
-				{
-					colors[i].a = 0xFF;
-				}
+				colors[i].a = 0xFF;
 			}
 		}
 		colors[colorKey].a = 0;


### PR DESCRIPTION
On OpenGL, some texts look close to illegible:
![font1](https://user-images.githubusercontent.com/238558/30779103-29909cf6-a0e7-11e7-805b-92b84f18944f.png)

The code did only unset full-transparent pixels when it should unset anything but `0xFF` for keyed palettes. But then we can also save instructions and failing branch predictions for this check completely.

Magic effects still look the same (and some a little dark).