### PR TITLE
OpenGL: no more flickering on overlays

### DIFF
--- a/gemrb/core/Video.h
+++ b/gemrb/core/Video.h
@@ -246,6 +246,10 @@ public:
 	Region GetViewport(void) const;
 	void SetViewport(int x, int y, unsigned int w, unsigned int h);
 	void MoveViewportTo(int x, int y);
+
+	virtual void DrawBackgroundBuffer() = 0;
+	virtual void FreeBackgroundBuffer() = 0;
+	virtual void TakeBackgroundBuffer() = 0;
 };
 
 }

--- a/gemrb/plugins/SDLVideo/SDL20GLVideo.h
+++ b/gemrb/plugins/SDLVideo/SDL20GLVideo.h
@@ -36,11 +36,14 @@ namespace GemRB
 		GLSLProgram* programPalSepia; // shader program for paletted sprites  with sepia effect
 		GLSLProgram* programRect; // shader program for drawing rects and lines
 		GLSLProgram* programEllipse; // shader program for drawing ellipses and circles
-		
+
 		Uint32 spritesPerFrame; // sprites counter
 		GLSLProgram* lastUsedProgram; // stores last used program to prevent switching if possible (switching may cause performance lack)
 
 		GLPaletteManager* paletteManager; // palette manager instance
+
+		GLTextureSprite2D *backgroundBuffer;
+		Region GLViewport;
 
 		void useProgram(GLSLProgram* program); // use this instead program->Use()
 		bool createPrograms();
@@ -71,6 +74,10 @@ namespace GemRB
 		/*void DrawEllipseSegment(short cx, short cy, unsigned short xr, unsigned short yr, const Color& color, double anglefrom, double angleto, bool drawlines = true, bool clipped = true);*/
 		void DestroyMovieScreen();
 		Sprite2D* GetScreenshot(Region r);
+
+		void DrawBackgroundBuffer();
+		void FreeBackgroundBuffer();
+		void TakeBackgroundBuffer();
 	};
 }
 

--- a/gemrb/plugins/SDLVideo/SDLVideo.h
+++ b/gemrb/plugins/SDLVideo/SDLVideo.h
@@ -162,6 +162,9 @@ public:
 							ieDword titleref)=0;
 	int PollMovieEvents();
 
+	void DrawBackgroundBuffer() {};
+	void FreeBackgroundBuffer() {};
+	void TakeBackgroundBuffer() {};
 protected:
 	void DrawMovieSubtitle(ieDword strRef);
 	void BlitSurfaceClipped(SDL_Surface*, const Region& src, const Region& dst);


### PR DESCRIPTION
There is one problem where GUI drawing and OpenGL bite each other: screen areas that are not redrawn inside a frame only redraw the cursor into the back buffer. For the cursor movements, this produces tons of artifacts on the background of overlaying windows or modals. For modals, thanks to double buffering, we have a some nauseaing 15Hz flickering in addition (one grayed background and the previous one without gray tone).

![flickering](https://user-images.githubusercontent.com/238558/31042257-101cad5c-a5a4-11e7-9b04-6ce416ea007a.png)

For OpenGL, for now I propose to create a texture of everything that has been drawn to the background the last time before we create a modal or put a window on top. A suspended window then isn't really redrawn but just the top-most active window(s) on top of the screenshot of the disabled ones.

This isn't perfect yet: e. g. I cannot remove a cursor that sticks on an element the last time it had been drawn correctly and won't ever be drawn again since it's outside of the draw area now. Maybe your `subviews` will address these issues more accurately. But for now, the rendering is smooth again: at max. one bad cursor and no more flickering.