### PR TITLE
OpenGL: fix for map tile rendering

### DIFF
--- a/gemrb/plugins/SDLVideo/GLPaletteManager.cpp
+++ b/gemrb/plugins/SDLVideo/GLPaletteManager.cpp
@@ -43,7 +43,9 @@ GLuint GLPaletteManager::CreatePaletteTexture(Palette* palette, unsigned int col
 				colors[i].a = 0xFF;
 			}
 		}
-		colors[colorKey].a = 0;
+		if (PALETTE_INVALID_INDEX != colorKey) {
+			colors[colorKey].a = 0;
+		}
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 #ifdef USE_GL
 		glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);

--- a/gemrb/plugins/SDLVideo/GLPaletteManager.h
+++ b/gemrb/plugins/SDLVideo/GLPaletteManager.h
@@ -3,7 +3,9 @@
 
 #include <map>
 
-namespace GemRB 
+#define PALETTE_INVALID_INDEX 256
+
+namespace GemRB
 {
 	class Palette;
 

--- a/gemrb/plugins/SDLVideo/GLTextureSprite2D.cpp
+++ b/gemrb/plugins/SDLVideo/GLTextureSprite2D.cpp
@@ -16,14 +16,14 @@ static Uint8 GetShiftValue(Uint32 value)
 	return 24;
 }
 
-GLTextureSprite2D::GLTextureSprite2D (int Width, int Height, int Bpp, void* pixels,	Uint32 rmask, Uint32 gmask, 
+GLTextureSprite2D::GLTextureSprite2D (int Width, int Height, int Bpp, void* pixels,	Uint32 rmask, Uint32 gmask,
 										Uint32 bmask, Uint32 amask) : Sprite2D(Width, Height, Bpp, pixels)
 {
 	currentPalette = NULL;
 	glTexture = 0;
 	glPaletteTexture = 0;
 	glMaskTexture = 0;
-	colorKeyIndex = 0; // invalid index
+	colorKeyIndex = PALETTE_INVALID_INDEX;
 	rMask = rmask;
 	gMask = gmask;
 	bMask = bmask;

--- a/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
@@ -360,13 +360,13 @@ void GLVideoDriver::GLBlitSprite(GLTextureSprite2D* spr, const Region& src, cons
 	program->SetUniformValue("u_tint", COLOR_SIZE, (GLfloat)colorTint.r/255, (GLfloat)colorTint.g/255, (GLfloat)colorTint.b/255, (GLfloat)colorTint.a/255);
 	program->SetUniformValue("u_alphaModifier", 1, alphaModifier);
 
-	unsigned int shadowMode = 1;
+	GLint shadowMode = 1;
 	if (flags & BLIT_NOSHADOW) {
 		shadowMode = 0;
 	} else if (flags & BLIT_TRANSSHADOW) {
 		shadowMode = 2;
 	}
-	program->SetUniformValue("u_shadowMode", 1, (GLint)shadowMode);
+	program->SetUniformValue("u_shadowMode", 1, shadowMode);
 
 	GLint a_position = program->GetAttribLocation("a_position");
 	GLint a_texCoord = program->GetAttribLocation("a_texCoord");
@@ -559,16 +559,8 @@ void GLVideoDriver::BlitTile(const Sprite2D* spr, const Sprite2D* mask, int x, i
 		totint = core->GetGame()->GetGlobalTint();
 	}
 
-	if (!(blitFlags & BLIT_HALFTRANS)) {
-		glBlendFunc(GL_ONE, GL_ZERO);
-	}
-
 	GLBlitSprite((GLTextureSprite2D*)spr, src, dst,
 						NULL, blitFlags, totint, (GLTextureSprite2D*)mask);
-
-	if (!(blitFlags & BLIT_HALFTRANS)) {
-		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-	}
 }
 
 void GLVideoDriver::BlitGameSprite(const Sprite2D* spr, int x, int y, unsigned int flags, Color tint,


### PR DESCRIPTION
In #63 , I tried to fix "mysterious black pixels on snow" for OpenGL. This fix was very rough, it breaks BG water rendering.

![bg_water](https://user-images.githubusercontent.com/238558/31154147-616d5306-a8a5-11e7-93c4-13d307fd509c.png)

Not that bad, this way I discovered some more general bug as `0` has been treated as invalid palette index for OpenGL. But since this is the default color key index for transparency, by default, for every paletted texture, the pixels of color index `0` are then discarded regardless of intended transparency.