### PR TITLE
OpenAL: z-axis for listener

### DIFF
--- a/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
+++ b/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
@@ -613,7 +613,7 @@ int OpenALAudioDriver::CreateStream(Holder<SoundMgr> newMusic)
 
 void OpenALAudioDriver::UpdateListenerPos(int XPos, int YPos )
 {
-	alListener3f( AL_POSITION, (float) XPos, (float) YPos, 0.0f );
+	alListener3f( AL_POSITION, (float) XPos, (float) YPos, LISTENER_HEIGHT );
 	checkALError("Unable to update listener position.", WARNING);
 }
 

--- a/gemrb/plugins/OpenALAudio/OpenALAudio.h
+++ b/gemrb/plugins/OpenALAudio/OpenALAudio.h
@@ -61,6 +61,8 @@
 #define REFERENCE_DISTANCE 50
 #define ACM_BUFFERSIZE 8192
 
+#define LISTENER_HEIGHT 100.0f
+
 namespace GemRB {
 
 class OpenALSoundHandle : public SoundHandle {


### PR DESCRIPTION
Maybe it's a more subjective issue, but let's consider the chanting dudes in this screenshot below:

![audio](https://user-images.githubusercontent.com/238558/31170901-25c1aba0-a8fe-11e7-970c-d9b47ad0cb04.png)

When centering through them when their samples are playing, inside the inner rectangle you have a very loud sound with very little fade-in, and each red line immediately flips one source (on stereo) from one speaker to the other one. This feels very unbalanced.

On OpenAL, the listener's position is ground (`{ x, y, 0 }`) as all sources are. I propose to put it to the camera (height!), so it has a longer fade-in/out and less amplitude right above. Values `< 100` don't address the impression well, `> 200` makes sounds too low.

Feel free to try it and propose something else, but I consider `0` a bad choice. For distance calculations I think it's Ok to leave it as-is.

Other addressed examples include:
* single miraculously loud foot-steps
* the isolated fireplace sound in the Candlekeep Inn