### PR TITLE
IWD2: savegame compatibility fix

### DIFF
--- a/gemrb/plugins/AREImporter/AREImporter.cpp
+++ b/gemrb/plugins/AREImporter/AREImporter.cpp
@@ -552,8 +552,16 @@ Map* AREImporter::GetMap(const char *ResRef, bool day_or_night)
 		str->ReadResRef( Script );
 		str->ReadWord( &PosX);
 		str->ReadWord( &PosY);
-		//maybe we have to store this
-		str->Seek( 36, GEM_CURRENT_POS );
+		/* ARE 9.1: 4B per position after that, but let's just try the lower two ones. */
+		if (16 == map->version) {
+			str->ReadWord(&PosX);
+			str->Seek(2, GEM_CURRENT_POS);
+			str->ReadWord(&PosY);
+			str->Seek(30, GEM_CURRENT_POS);
+		} else {
+			//maybe we have to store this
+			str->Seek( 36, GEM_CURRENT_POS );
+		}
 
 		if (core->HasFeature(GF_INFOPOINT_DIALOGS)) {
 			str->ReadResRef( WavResRef );
@@ -1916,10 +1924,18 @@ int AREImporter::PutRegions( DataStream *stream, Map *map, ieDword &VertIndex)
 			stream->Write( filling, 8);
 		}
 		tmpWord = (ieWord) ip->UsePoint.x;
+		ieDword tmpDword2 = ip->UsePoint.x;
 		stream->WriteWord( &tmpWord);
 		tmpWord = (ieWord) ip->UsePoint.y;
+		tmpDword = ip->UsePoint.y;
 		stream->WriteWord( &tmpWord);
-		stream->Write( filling, 36); //unknown
+		if (16 == map->version) {
+			stream->WriteDword(&tmpDword2);
+			stream->WriteDword(&tmpDword);
+			stream->Write(filling, 28); //unknown
+		} else {
+			stream->Write(filling, 36); //unknown
+		}
 		//these are probably only in PST
 		stream->WriteResRef( ip->EnterWav);
 		tmpWord = (ieWord) ip->TalkPos.x;


### PR DESCRIPTION
When saving an IWD2 game in GemRB, loading the game into the original game reveals an interesting issue: you cannot enter buildings anymore. Doors open correctly and the cursor shows a trigger, but nothing actually happens.

I diffed the ARE files on triggers and found a significant difference: The "alternative use point" in IESDP claims that there are two words used for x/y coords. Actually, in 9.1 AREs, these 4 bytes are unused, and instead it makes use of two dwords right behind that in the *unknown* region.

Then, I made IWD2 both read and write into these regions in addition. It's a little workaround on the lower two bytes since x/y coords are `short`s internally and I better don't simply touch that now.

Anyway, now we can better cross-play as far as I have advanced, which makes error-spotting a little easier. ;)