### PR TITLE
remove 'register' keyword

### DIFF
--- a/gemrb/core/Polygon.cpp
+++ b/gemrb/core/Polygon.cpp
@@ -88,7 +88,7 @@ bool Gem_Polygon::PointIn(const Point &p) const
 
 bool Gem_Polygon::PointIn(int tx, int ty) const
 {
-	register int   j, yflag0, yflag1, xflag0 , index;
+	int   j, yflag0, yflag1, xflag0 , index;
 	bool inside_flag = false;
 	Point* vtx0, * vtx1;
 

--- a/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
+++ b/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
@@ -2397,7 +2397,7 @@ static int al_switch_good[12]={0,0x13,0x12,0x11,0,0x23,0x22,0x21,0,0x33,0x32,0x3
 int fx_alignment_invert (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 {
 	if(0) print("fx_alignment_invert(%2d)", fx->Opcode);
-	register ieDword newalign = target->GetStat( IE_ALIGNMENT );
+	ieDword newalign = target->GetStat( IE_ALIGNMENT );
 	if (!newalign) {
 		// unset, so just do nothing;
 		return FX_APPLIED;


### PR DESCRIPTION
This keyword has no real meaningful impact anymore and causes issues
when compiling under newer versions of the C++ standard.