### PR TITLE
PluginLoader: fixes compiler errors for GCC and Win

### DIFF
--- a/gemrb/core/PluginLoader.cpp
+++ b/gemrb/core/PluginLoader.cpp
@@ -194,8 +194,8 @@ void LoadPlugins(char* pluginpath)
 		//printStatus( "OK", LIGHT_GREEN );
 		//using C bindings, so we don't need to jump through extra hoops
 		//with the symbol name
-		Version_t LibVersion = ( Version_t ) GET_PLUGIN_SYMBOL( hMod, "GemRBPlugin_Version" );
-		Description_t Description = ( Description_t ) GET_PLUGIN_SYMBOL( hMod, "GemRBPlugin_Description" );
+		Version_t LibVersion = ( Version_t ) (void*) GET_PLUGIN_SYMBOL( hMod, "GemRBPlugin_Version" );
+		Description_t Description = ( Description_t ) (void*) GET_PLUGIN_SYMBOL( hMod, "GemRBPlugin_Description" );
 		ID_t ID = ( ID_t ) (void*) GET_PLUGIN_SYMBOL( hMod, "GemRBPlugin_ID" );
 		Register_t Register = ( Register_t ) (void*) GET_PLUGIN_SYMBOL( hMod, "GemRBPlugin_Register" );
 


### PR DESCRIPTION
Hey,

I just tried to build the most recet `HEAD` on my Windows with GCC v9.1 and encountered the following errors:
```
./gemrb/core/PluginLoader.cpp: In function 'void GemRB::LoadPlugins(char*)':
./gemrb/core/PluginLoader.cpp:89:73: error: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'GemRB::Version_t' {aka 'const char* (*)()'} [-Werror=cast-function-type]
   89 | #define GET_PLUGIN_SYMBOL( handle, name )  GetProcAddress( handle, name )
      |                                                                         ^
./gemrb/core/PluginLoader.cpp:197:40: note: in expansion of macro 'GET_PLUGIN_SYMBOL'
  197 |   Version_t LibVersion = ( Version_t ) GET_PLUGIN_SYMBOL( hMod, "GemRBPlugin_Version" );
      |                                        ^~~~~~~~~~~~~~~~~
./gemrb/core/PluginLoader.cpp:89:73: error: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'GemRB::Description_t' {aka 'const char* (*)()'} [-Werror=cast-function-type]
   89 | #define GET_PLUGIN_SYMBOL( handle, name )  GetProcAddress( handle, name )
      |                                                                         ^
./gemrb/core/PluginLoader.cpp:198:49: note: in expansion of macro 'GET_PLUGIN_SYMBOL'
  198 |   Description_t Description = ( Description_t ) GET_PLUGIN_SYMBOL( hMod, "GemRBPlugin_Description" );
      |                                                 ^~~~~~~~~~~~~~~~~
```

Looks like 979db2def8b2efc7c29916dd04120ef5065f0d5b already attempted to fix two similar issues around that code but wasn't sufficient.

On more recent C++ standards, one seems to be able to use `reinterpret_cast` without objection here, but so far we have to go on with this cast chain.