### PR TITLE
SDL2: enables pasting of text into console

### DIFF
--- a/gemrb/core/GUI/Console.cpp
+++ b/gemrb/core/GUI/Console.cpp
@@ -86,11 +86,20 @@ void Console::SetBackGround(Sprite2D* back)
 	//if 'back' is NULL then no BackGround will be drawn
 	Back = back;
 }
+
+/* Inserts the given text right behind the cursor position. */
+void Console::InsertText(const String& string)
+{
+	Buffer.insert(CurPos, string);
+	CurPos += string.size();
+}
+
 /** Sets the Text of the current control */
 void Console::SetText(const String& string)
 {
 	Buffer = string;
 }
+
 /** Key Press Event */
 bool Console::OnKeyPress(unsigned char Key, unsigned short /*Mod*/)
 {

--- a/gemrb/core/GUI/Console.h
+++ b/gemrb/core/GUI/Console.h
@@ -51,6 +51,8 @@ public:
 	void SetCursor(Sprite2D* cur);
 	/** Set BackGround */
 	void SetBackGround(Sprite2D* back);
+	/** Inserts text at the current cursor position */
+	void InsertText(const String&);
 	/** Sets the Text of the current control */
 	void SetText(const String& string);
 	/** Draws the Console on the Output Display */

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -3268,6 +3268,17 @@ void Interface::DelAllWindows()
 	ModalWindow = NULL;
 }
 
+/**
+ * Delegates a pasting request of text to a fitting consumer, e.g. console,
+ * potentially text inputs, ...
+ */
+void Interface::RequestPasting(const String & string)
+{
+	if (ConsolePopped) {
+		console->InsertText(string);
+	}
+}
+
 /** Popup the Console */
 void Interface::PopupConsole()
 {

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -528,6 +528,8 @@ public:
 	void RedrawAll();
 	/** Refreshes any control associated with the variable name with value*/
 	void RedrawControls(const char *varname, unsigned int value);
+	/** Attempts to paste text into the interface. */
+	void RequestPasting(const String&);
 	/** Popup the Console */
 	void PopupConsole();
 	/** Get the SaveGameIterator */

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -731,8 +731,29 @@ int SDL20VideoDriver::ProcessEvent(const SDL_Event & event)
 				break;
 			}
 			else {
-				// we do not want these events to cascade down to SDL_KEYDOWN, so we return here instead of at default .
-				return SDLVideoDriver::ProcessEvent(event);
+				/**
+				 * As being SDL2-only, try to query the clipboard state to
+				 * paste when middle clicking the mouse.
+				 */
+				if (
+					   event.button.button == SDL_BUTTON_MIDDLE
+					&& event.type == SDL_MOUSEBUTTONDOWN
+					&& SDL_HasClipboardText()
+				) {
+					char *pasteValue = SDL_GetClipboardText();
+
+					if (pasteValue != NULL) {
+						String *pasteValueString = StringFromCString(pasteValue);
+						core->RequestPasting(*pasteValueString);
+						delete pasteValueString;
+						SDL_free(pasteValue);
+					}
+
+					break;
+				} else {
+					// we do not want these events to cascade down to SDL_KEYDOWN, so we return here instead of at default .
+					return SDLVideoDriver::ProcessEvent(event);
+				}
 			}
 		case SDL_KEYDOWN:
 			{


### PR DESCRIPTION
Thought I'd pick something from the issue list again.

I did some minmal decoupling in order to let `Interface` be the one that moves the clipboard text to whatever it considers appropriate -- the console only so far.

Tested successfully on Windows and Linux.

Closes #154 