### PR TITLE
Actor animation: shadow palette

### DIFF
--- a/gemrb/core/CharAnimations.cpp
+++ b/gemrb/core/CharAnimations.cpp
@@ -479,6 +479,10 @@ Palette* CharAnimations::GetPartPalette(int part)
 	return palette[type];
 }
 
+Palette* CharAnimations::GetShadowPalette() const {
+	return shadowPalette;
+}
+
 static inline int compare_avatars(const void *a, const void *b)
 {
 	return (int) (((const AvatarStruct *)a)->AnimID - ((const AvatarStruct *)b)->AnimID);
@@ -653,6 +657,7 @@ CharAnimations::CharAnimations(unsigned int AnimID, ieDword ArmourLevel)
 		modifiedPalette[i] = NULL;
 		palette[i] = NULL;
 	}
+	shadowPalette = NULL;
 	nextStanceID = 0;
 	StanceID = 0;
 	autoSwitchOnEnd = false;
@@ -745,6 +750,10 @@ CharAnimations::~CharAnimations(void)
 		gamedata->FreePalette(palette[i], 0);
 	for (i = 0; i < PAL_MAX; ++i)
 		gamedata->FreePalette(modifiedPalette[i], 0);
+
+	if (shadowPalette) {
+		gamedata->FreePalette(shadowPalette, 0);
+	}
 
 	for (i = 0; i < MAX_ANIMS; ++i) {
 		for (int j = 0; j < MAX_ORIENT; ++j) {
@@ -1329,10 +1338,8 @@ Animation** CharAnimations::GetShadowAnimation(unsigned char stance, unsigned ch
 			return NULL;
 		}
 
-		PaletteType paletteType = PAL_MAIN;
-		if (!palette[paletteType]) {
-			palette[paletteType] = animation->GetFrame(0)->GetPalette()->Copy();
-			SetupColors(paletteType);
+		if (!shadowPalette) {
+			shadowPalette = animation->GetFrame(0)->GetPalette()->Copy();
 		}
 
 		switch (StanceID) {

--- a/gemrb/core/CharAnimations.h
+++ b/gemrb/core/CharAnimations.h
@@ -171,6 +171,7 @@ public:
 	bool change[PAL_MAX];
 	Palette* palette[PAL_MAX];
 	Palette* modifiedPalette[PAL_MAX];
+	Palette* shadowPalette;
 	unsigned int AvatarsRowNum;
 	unsigned char ArmorType, WeaponType, RangedType;
 	ieResRef ResRef;
@@ -201,6 +202,7 @@ public:
 
 	// returns Palette for a given part (unlocked)
 	Palette* GetPartPalette(int part); // TODO: clean this up
+	Palette* GetShadowPalette() const;
 
 public: //attribute functions
 	static int GetAvatarsCount();

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -8045,7 +8045,7 @@ void Actor::DrawVideocells(const Region &screen, vvcVector &vvcCells, const Colo
 
 void Actor::DrawActorSprite(const Region &screen, int cx, int cy, const Region& bbox,
 			SpriteCover*& newsc, Animation** anims,
-			unsigned char Face, const Color& tint)
+			unsigned char Face, const Color& tint, bool useShadowPalette)
 {
 	CharAnimations* ca = GetAnims();
 	int PartCount = ca->GetTotalPartCount();
@@ -8080,8 +8080,9 @@ void Actor::DrawActorSprite(const Region &screen, int cx, int cy, const Region& 
 			}
 			assert(newsc->Covers(cx, cy, nextFrame->XPos, nextFrame->YPos, nextFrame->Width, nextFrame->Height));
 
+			Palette* palette = useShadowPalette ? ca->GetShadowPalette() : ca->GetPartPalette(partnum);
 			video->BlitGameSprite( nextFrame, cx + screen.x, cy + screen.y,
-				flags, tint, newsc, ca->GetPartPalette(partnum), &screen);
+				flags, tint, newsc, palette, &screen);
 		}
 	}
 }
@@ -8506,7 +8507,7 @@ void Actor::Draw(const Region &screen)
 		newsc = sc = GetSpriteCover();
 		Animation **shadowAnimations = ca->GetShadowAnimation(StanceID, Face);
 		if (shadowAnimations) {
-			DrawActorSprite(screen, cx, cy, BBox, newsc, shadowAnimations, Face, tint);
+			DrawActorSprite(screen, cx, cy, BBox, newsc, shadowAnimations, Face, tint, true);
 		}
 
 		// actor itself

--- a/gemrb/core/Scriptable/Actor.h
+++ b/gemrb/core/Scriptable/Actor.h
@@ -399,7 +399,7 @@ private:
 	/** paint the actor itself. Called internally by Draw() */
 	void DrawActorSprite(const Region &screen, int cx, int cy, const Region& bbox,
 				SpriteCover*& sc, Animation** anims,
-				unsigned char Face, const Color& tint);
+				unsigned char Face, const Color& tint, bool useShadowPalette = false);
 
 	/** fixes the palette */
 	void SetupColors();


### PR DESCRIPTION
Please check if this is what we were talking about in #123, and why I was hestitating to reuse `DrawActorSprite` for this purpose: It always uses a ragdoll palette for drawing - even if we pass different animations to it, so I prefer not to touch that so much and use a different path.

Closes #123 