### PR TITLE
Talking circles

### DIFF
--- a/gemrb/core/GameScript/GSUtils.cpp
+++ b/gemrb/core/GameScript/GSUtils.cpp
@@ -522,6 +522,11 @@ void DisplayStringCore(Scriptable* const Sender, int Strref, int flags)
 		unsigned int len = 0;
 		core->GetAudioDrv()->Play(Sound, channel, 0, 0, speech, &len);
 		ieDword counter = ( AI_UPDATE_TIME * len ) / 1000;
+
+		if (Sender->Type == ST_ACTOR && len > 0) {
+			reinterpret_cast<Actor*>(Sender)->SetAnimatedTalking(len);
+		}
+
 		if ((counter != 0) && (flags &DS_WAIT) )
 			Sender->SetWait( counter );
 	}

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -4305,7 +4305,12 @@ void Actor::PlayExistenceSounds()
 						core->GetDictionary()->Lookup("Volume Ambients", vol);
 						int stream = audio->SetupNewStream(Pos.x, Pos.y, 0, vol, true, true);
 						if (stream != -1) {
-							audio->QueueAmbient(stream, sb.Sound);
+							int audioLength = audio->QueueAmbient(stream, sb.Sound);
+
+							if (audioLength > 0) {
+								SetAnimatedTalking(audioLength);
+							}
+
 							audio->ReleaseStream(stream, false);
 						}
 					}

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -57,6 +57,8 @@
 #include "System/StringBuffer.h"
 #include "StringMgr.h"
 
+#include <cmath>
+
 namespace GemRB {
 
 //configurable?
@@ -539,6 +541,7 @@ Actor::Actor()
 	WMLevelMod = 0;
 	TicksLastRested = LastFatigueCheck = 0;
 	speed = 0;
+	remainingTalkSoundTime = lastTalkTimeCheckAt = 0;
 	WeaponType = AttackStance = 0;
 	DifficultyMargin = disarmTrap = 0;
 	spellStates = (ieDword *) calloc(SpellStatesSize, sizeof(ieDword));
@@ -733,6 +736,8 @@ void Actor::SetCircleSize()
 		return;
 
 	GameControl *gc = core->GetGameControl();
+	float oscillationFactor = 1.0f;
+
 	if (UnselectableTimer) {
 		color = &magenta;
 		color_index = 4;
@@ -742,9 +747,17 @@ void Actor::SetCircleSize()
 	} else if (Modified[IE_CHECKFORBERSERK]) {
 		color = &yellow;
 		color_index = 5;
-	} else if (gc && (gc->GetDialogueFlags()&DF_IN_DIALOG) && gc->dialoghandler->IsTarget(this)) {
+	} else if (gc && (((gc->GetDialogueFlags()&DF_IN_DIALOG) && gc->dialoghandler->IsTarget(this)) || remainingTalkSoundTime > 0)) {
 		color = &white;
 		color_index = 3; //?? made up
+
+		if (remainingTalkSoundTime > 0) {
+			/**
+			 * Approximation: pulsating at about 2Hz over a notable radius growth.
+			 * Maybe check this relation for dragons and rats, too.
+			 */
+			oscillationFactor = 1.1f + std::sin(remainingTalkSoundTime * (4 * M_PI) / 1000) * 0.1f;
+		}
 	} else {
 		switch (Modified[IE_EA]) {
 			case EA_PC:
@@ -778,7 +791,7 @@ void Actor::SetCircleSize()
 	if (csize >= MAX_CIRCLE_SIZE)
 		csize = MAX_CIRCLE_SIZE - 1;
 
-	SetCircle( anims->GetCircleSize(), *color, core->GroundCircles[csize][color_index], core->GroundCircles[csize][(color_index == 0) ? 3 : color_index] );
+	SetCircle( anims->GetCircleSize(), oscillationFactor, *color, core->GroundCircles[csize][color_index], core->GroundCircles[csize][(color_index == 0) ? 3 : color_index] );
 }
 
 static void ApplyClab_internal(Actor *actor, const char *clab, int level, bool remove, int diff)
@@ -8385,6 +8398,20 @@ void Actor::Draw(const Region &screen)
 			drawcircle = markerfeedback >= 5;
 		}
 	}
+
+	if (remainingTalkSoundTime > 0) {
+		unsigned int currentTick = GetTickCount();
+		unsigned int diffTime = currentTick - lastTalkTimeCheckAt;
+		lastTalkTimeCheckAt = currentTick;
+
+		if (diffTime >= remainingTalkSoundTime) {
+			remainingTalkSoundTime = 0;
+		} else {
+			remainingTalkSoundTime -= diffTime;
+		}
+		SetCircleSize();
+	}
+
 	if (drawcircle) {
 		DrawCircle(vp);
 		drawtarget = ((Selected || Over) && !(InternalFlags&IF_NORETICLE) && Modified[IE_EA] <= EA_CONTROLLABLE && Destination != Pos);
@@ -11156,6 +11183,11 @@ unsigned int Actor::GetAdjustedTime(unsigned int time) const
 
 ieDword Actor::GetClassID (const ieDword isclass) {
 	return classesiwd2[isclass];
+}
+
+void Actor::SetAnimatedTalking (unsigned int length) {
+	remainingTalkSoundTime = std::max(remainingTalkSoundTime, length);
+	lastTalkTimeCheckAt = GetTickCount();
 }
 
 }

--- a/gemrb/core/Scriptable/Actor.h
+++ b/gemrb/core/Scriptable/Actor.h
@@ -396,6 +396,8 @@ private:
 	Projectile* attackProjectile ;
 	ieDword TicksLastRested;
 	ieDword LastFatigueCheck;
+	unsigned int remainingTalkSoundTime;
+	unsigned int lastTalkTimeCheckAt;
 	/** paint the actor itself. Called internally by Draw() */
 	void DrawActorSprite(const Region &screen, int cx, int cy, const Region& bbox,
 				SpriteCover*& sc, Animation** anims,
@@ -936,6 +938,7 @@ public:
 	std::list<int> ListLevels() const;
 	void ChangeSorcererType (ieDword classIdx);
 	unsigned int GetAdjustedTime(unsigned int time) const;
+	void SetAnimatedTalking(unsigned int);
 };
 }
 

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -1698,6 +1698,7 @@ Selectable::Selectable(ScriptableType type)
 	Selected = false;
 	Over = false;
 	size = 0;
+	sizeFactor = 1.0f;
 	cover = NULL;
 	circleBitmap[0] = NULL;
 	circleBitmap[1] = NULL;
@@ -1764,8 +1765,9 @@ void Selectable::DrawCircle(const Region &vp)
 		// for size == 1, radii are 12, 9
 		int csize = (size - 1) * 4;
 		if (csize < 4) csize = 3;
+
 		core->GetVideoDriver()->DrawEllipse( (ieWord) (Pos.x - vp.x), (ieWord) (Pos.y - vp.y),
-		(ieWord) (csize * 4), (ieWord) (csize * 3), *col );
+		(ieWord) (csize * 4 * sizeFactor), (ieWord) (csize * 3 * sizeFactor), *col );
 	}
 }
 
@@ -1809,9 +1811,10 @@ void Selectable::Select(int Value)
 	SetSpriteCover(NULL);
 }
 
-void Selectable::SetCircle(int circlesize, const Color &color, Sprite2D* normal_circle, Sprite2D* selected_circle)
+void Selectable::SetCircle(int circlesize, float factor, const Color &color, Sprite2D* normal_circle, Sprite2D* selected_circle)
 {
 	size = circlesize;
+	sizeFactor = factor;
 	selectedColor = color;
 	overColor.r = color.r >> 1;
 	overColor.g = color.g >> 1;

--- a/gemrb/core/Scriptable/Scriptable.h
+++ b/gemrb/core/Scriptable/Scriptable.h
@@ -386,6 +386,7 @@ public:
 	Color overColor;
 	Sprite2D *circleBitmap[2];
 	int size;
+	float sizeFactor;
 private:
 	// current SpriteCover for wallgroups
 	SpriteCover* cover;
@@ -396,7 +397,7 @@ public:
 	void SetOver(bool over);
 	bool IsSelected() const;
 	void Select(int Value);
-	void SetCircle(int size, const Color &color, Sprite2D* normal_circle, Sprite2D* selected_circle);
+	void SetCircle(int size, float, const Color &color, Sprite2D* normal_circle, Sprite2D* selected_circle);
 
 	/* store SpriteCover */
 	void SetSpriteCover(SpriteCover* c);


### PR DESCRIPTION
This covers many cases when the original games indicate the sound emitting actor by a pulsating white circle, essentially most of the time when there is a verbal constant requested but also existence sounds. I have bound it to the time of the sound file (presumably) playing, without looking for cases of early interruption -- if you know some, I can try to implement them.

The animation was no exact rocket science but it's the numbers that really make it look like in BG1.

Closes #159 