### PR TITLE
Map: statically adjusting some animation flags for PST

### DIFF
--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -3899,7 +3899,7 @@ AreaAnimation::AreaAnimation()
 	palette=NULL;
 	covers=NULL;
 	appearance = sequence = frame = transparency = height = 0;
-	Flags = startFrameRange = skipcycle = startchance = 0;
+	Flags = originalFlags = startFrameRange = skipcycle = startchance = 0;
 	unknown48 = 0;
 	Name[0] = 0;
 	BAM[0] = 0;

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -3912,6 +3912,7 @@ AreaAnimation::AreaAnimation(AreaAnimation *src)
 	sequence = src->sequence;
 	animation = NULL;
 	Flags = src->Flags;
+	originalFlags = src->originalFlags;
 	Pos.x = src->Pos.x;
 	Pos.y = src->Pos.y;
 	appearance = src->appearance;

--- a/gemrb/core/Map.h
+++ b/gemrb/core/Map.h
@@ -265,6 +265,8 @@ public:
 	Point Pos;
 	ieDword appearance;
 	ieDword Flags;
+	// flags that must not be overriden for writing back the original value
+	ieDword originalFlags;
 	//these are on one dword
 	ieWord sequence;
 	ieWord frame;

--- a/gemrb/plugins/AREImporter/AREImporter.h
+++ b/gemrb/plugins/AREImporter/AREImporter.h
@@ -70,6 +70,7 @@ public:
 	/* stores an area in the Cache (swaps it out) */
 	int PutArea(DataStream *stream, Map *map);
 private:
+	void AdjustPSTFlags(AreaAnimation*);
 	void ReadEffects(DataStream *ds, EffectQueue *fx, ieDword EffectsCount);
 	CREItem* GetItem();
 	int PutHeader(DataStream *stream, Map *map);


### PR DESCRIPTION
That's what we've synthesized in #163, it fixes every major map animation annoyance for PST. There is probably details left, like this one that I cannot explain yet, but you probably don't even notice unless playing side by side:

![ar0202_lights](https://user-images.githubusercontent.com/238558/63302933-b06d6b80-c2de-11e9-8444-cdf511c9c34f.jpg)

Closes #163 