### PR TITLE
CharAnimations: palette update

### DIFF
--- a/gemrb/core/CharAnimations.cpp
+++ b/gemrb/core/CharAnimations.cpp
@@ -140,6 +140,20 @@ unsigned char CharAnimations::MaybeOverrideStance(unsigned char stance) const
 	if(AvatarsRowNum==~0u) return stance;
 	return AvatarTable[AvatarsRowNum].StanceOverride[stance];
 }
+/*
+ * For some actors (Arundel, FFG, fire giants) a new stance requires a
+ * different palette to use. Presumably, this is relevant for PAL_MAIN only.
+ */
+void CharAnimations::MaybeUpdateMainPalette(Animation **anims) {
+	if (previousStanceID != StanceID) {
+		// Test if the palette in question is actually different to the one loaded.
+		if (*palette[PAL_MAIN] != *(anims[0]->GetFrame(0)->GetPalette())) {
+			gamedata->FreePalette(palette[PAL_MAIN], 0);
+			palette[PAL_MAIN] = anims[0]->GetFrame(0)->GetPalette()->Copy();
+			SetupColors(PAL_MAIN);
+		}
+	}
+}
 
 static ieResRef EmptySound={0};
 
@@ -658,7 +672,7 @@ CharAnimations::CharAnimations(unsigned int AnimID, ieDword ArmourLevel)
 		palette[i] = NULL;
 	}
 	shadowPalette = NULL;
-	nextStanceID = 0;
+	previousStanceID = nextStanceID = 0;
 	StanceID = 0;
 	autoSwitchOnEnd = false;
 	lockPalette = false;
@@ -1011,6 +1025,9 @@ Animation** CharAnimations::GetAnimation(unsigned char Stance, unsigned char Ori
 	Animation** anims = Anims[StanceID][Orient];
 
 	if (anims) {
+		MaybeUpdateMainPalette(anims);
+		previousStanceID = StanceID;
+
 		return anims;
 	}
 
@@ -1120,6 +1137,8 @@ Animation** CharAnimations::GetAnimation(unsigned char Stance, unsigned char Ori
 				palette[ptype] = a->GetFrame(0)->GetPalette()->Copy();
 				// ...and setup the colours properly
 				SetupColors(ptype);
+			} else if (ptype == PAL_MAIN) {
+				MaybeUpdateMainPalette(anims);
 			}
 		} else if (part == actorPartCount) {
 			if (!palette[PAL_WEAPON]) {
@@ -1269,6 +1288,7 @@ Animation** CharAnimations::GetAnimation(unsigned char Stance, unsigned char Ori
 			error("CharAnimations", "Unknown animation type\n");
 	}
 	delete equipdat;
+	previousStanceID = StanceID;
 
 	return Anims[StanceID][Orient];
 }

--- a/gemrb/core/CharAnimations.h
+++ b/gemrb/core/CharAnimations.h
@@ -176,7 +176,7 @@ public:
 	unsigned char ArmorType, WeaponType, RangedType;
 	ieResRef ResRef;
 	ieResRef PaletteResRef[5];
-	unsigned char nextStanceID, StanceID;
+	unsigned char previousStanceID, nextStanceID, StanceID;
 	bool autoSwitchOnEnd;
 	bool lockPalette;
 public:
@@ -272,6 +272,7 @@ private:
 	void GetEquipmentResRef(const char* equipRef, bool offhand,
 		char* ResRef, unsigned char& Cycle, EquipResRefData* equip);
 	unsigned char MaybeOverrideStance(unsigned char stance) const;
+	void MaybeUpdateMainPalette(Animation**);
 };
 
 }

--- a/gemrb/core/Palette.cpp
+++ b/gemrb/core/Palette.cpp
@@ -278,4 +278,12 @@ void Palette::SetupGlobalRGBModification(const Palette* src,
 		applyMod(src->col[i],col[i],mod);
 }
 
+bool Palette::operator==(const Palette& other) const {
+	return memcmp(col, other.col, sizeof(col)) == 0;
+}
+
+bool Palette::operator!=(const Palette& other) const {
+	return !(*this == other);
+}
+
 }

--- a/gemrb/core/Palette.h
+++ b/gemrb/core/Palette.h
@@ -99,6 +99,8 @@ public:
 
 	Palette* Copy();
 
+	bool operator==(const Palette&) const;
+	bool operator!=(const Palette&) const;
 private:
 	unsigned int refcount;
 


### PR DESCRIPTION
This fixes:
- PST: Grace, Ebb and some guards having overall bad animation colors.
- BG2: Umber hulks and fire giants having bad attack animation colors.
- IWD: Arundel and some colorfully misplaced pixels.

Closes #168

By the way, the PR template is not taking effect yet!