### PR TITLE
CharAnimations: fixes missing palette resref on stance change

### DIFF
--- a/gemrb/core/CharAnimations.cpp
+++ b/gemrb/core/CharAnimations.cpp
@@ -148,7 +148,7 @@ void CharAnimations::MaybeUpdateMainPalette(Animation **anims) {
 	if (previousStanceID != StanceID) {
 		// Test if the palette in question is actually different to the one loaded.
 		if (*palette[PAL_MAIN] != *(anims[0]->GetFrame(0)->GetPalette())) {
-			gamedata->FreePalette(palette[PAL_MAIN], 0);
+			gamedata->FreePalette(palette[PAL_MAIN], PaletteResRef[PAL_MAIN]);
 			palette[PAL_MAIN] = anims[0]->GetFrame(0)->GetPalette()->Copy();
 			SetupColors(PAL_MAIN);
 		}


### PR DESCRIPTION
In BG, I had some random encounter with Gnolls or Flinds that make the game fatally exit over `Palette is supposed to be named, but got no name!`. Fixes behaviour introduced by #181.

Should have been that way at first place I guess, but I did not correctly check the cases of the destructor of `CharAnimations`.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code 
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
