### PR TITLE
Map: prevents crash if map note has encoding issues

### DIFF
--- a/gemrb/core/Map.h
+++ b/gemrb/core/Map.h
@@ -196,8 +196,13 @@ public:
 		if (text) {
 			//update custom strref
 			char* mbstring = MBCStringFromString(*text);
-			strref = core->UpdateString( strref, mbstring);
-			free(mbstring);
+			if (mbstring) {
+				strref = core->UpdateString( strref, mbstring);
+				free(mbstring);
+			} else {
+				strref = core->UpdateString(strref, "?");
+				Log(WARNING, "Map", "Failed to update string from map note, possibly an enconding issue.");
+			}
 		}
 	}
 	MapNote(const ieStrRef ref, ieWord color)


### PR DESCRIPTION
I'm not fully sure what you meant by "fallback" exactly - I inserted a question mark for that case - since I did not really see where this bubbles through at the end of PST since it's actually loaded into the game but just not updated in the string table.

Closes #185 

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code 
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
