### PR TITLE
CharAnimations: unsets palette resref name on stance change

### DIFF
--- a/gemrb/core/CharAnimations.cpp
+++ b/gemrb/core/CharAnimations.cpp
@@ -149,6 +149,8 @@ void CharAnimations::MaybeUpdateMainPalette(Animation **anims) {
 		// Test if the palette in question is actually different to the one loaded.
 		if (*palette[PAL_MAIN] != *(anims[0]->GetFrame(0)->GetPalette())) {
 			gamedata->FreePalette(palette[PAL_MAIN], PaletteResRef[PAL_MAIN]);
+			PaletteResRef[PAL_MAIN][0] = 0;
+
 			palette[PAL_MAIN] = anims[0]->GetFrame(0)->GetPalette()->Copy();
 			SetupColors(PAL_MAIN);
 		}


### PR DESCRIPTION
See #190. `SetupColors` has a side-effect of replacing the animation palette again using `FreePalette` after the recently updated (stance changed) palette. In case of the related issue, an unrelated `PaletteResRef` name may be still be given at that time, leading to the crash.

Closes #190 

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
