### PR TITLE
[subviews] SDL: fixes compiler errors in SDL 1.2 code

### DIFF
--- a/gemrb/plugins/SDLVideo/Pixels.h
+++ b/gemrb/plugins/SDLVideo/Pixels.h
@@ -361,7 +361,7 @@ public:
 	}
 
 	SDLPixelIterator(Direction x, Direction y, const SDL_Rect& clip, SDL_Surface* surf)
-	: IPixelIterator(NULL, surf->pitch, x, y), format(surf->format), clip(clip)
+	: IPixelIterator(NULL, surf->pitch, x, y), imp(NULL), format(surf->format), clip(clip)
 	{
 		Uint8* pixels = static_cast<Uint8*>(surf->pixels);
 		pixels = FindStart(pixels, surf->pitch, format->BytesPerPixel, clip, xdir, ydir);

--- a/gemrb/plugins/SDLVideo/SDL12Video.h
+++ b/gemrb/plugins/SDLVideo/SDL12Video.h
@@ -186,7 +186,7 @@ public:
 		va_list args;
 		va_start(args, pitch);
 
-		enum PLANES {Y, U, V};
+		enum {Y, U, V};
 		const ieByte* planes[3];
 		unsigned int strides[3];
 


### PR DESCRIPTION
For GCC 9.2 and the current flag set, this code was illegal.

See #224.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
