### PR TITLE
No circles for flying creatures & not valid for dialog

### DIFF
--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -684,9 +684,9 @@ void Actor::SetAnimationID(unsigned int AnimID)
 		CopyResRef(anims->PaletteResRef[PAL_MAIN], paletteResRef);
 	}
 	//bird animations are not hindered by searchmap
-	//only animtype==7 (bird) uses this feature
+	//only animations with a space of 0 in avatars.2da files use this feature
 	//this is a hardcoded hack, but works for all engine type
-	if (anims->GetAnimType()!=IE_ANI_BIRD) {
+	if (anims->GetCircleSize() != 0) {
 		BaseStats[IE_DONOTJUMP]=0;
 	} else {
 		BaseStats[IE_DONOTJUMP]=DNJ_BIRD;
@@ -6146,6 +6146,8 @@ bool Actor::ValidTarget(int ga_flags, Scriptable *checker) const
 		if (Modified[IE_STATE_ID] & (STATE_CANTLISTEN^STATE_SLEEP)) return false;
 		//can't talk to hostile
 		if (Modified[IE_EA]>=EA_EVILCUTOFF) return false;
+		// neither to bats and birds
+		if (anims->GetCircleSize() == 0) return false;
 		break;
 	}
 	if (ga_flags&GA_NO_DEAD) {

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -685,7 +685,6 @@ void Actor::SetAnimationID(unsigned int AnimID)
 	}
 	//bird animations are not hindered by searchmap
 	//only animations with a space of 0 in avatars.2da files use this feature
-	//this is a hardcoded hack, but works for all engine type
 	if (anims->GetCircleSize() != 0) {
 		BaseStats[IE_DONOTJUMP]=0;
 	} else {

--- a/gemrb/unhardcoded/bg1/avatars.2da
+++ b/gemrb/unhardcoded/bg1/avatars.2da
@@ -240,12 +240,12 @@
 0xB600     NNOM       NNOM       NNOM       NNOM       18         2          0          *
 0xB610     NNOW       NNOW       NNOW       NNOW       18         2          0          *
 0xB700     NSLV       NSLV       NSLV       NSLV       18         2          0          *
-0xC000     ABAT       ABAT       ABAT       ABAT       3          1          1          *
+0xC000     ABAT       ABAT       ABAT       ABAT       3          0          1          *
 0xC100     ACAT       ACAT       ACAT       ACAT       3          1          1          *
 0xC200     ACHK       ACHK       ACHK       ACHK       3          1          1          *
 0xC300     ARAT       ARAT       ARAT       ARAT       3          1          1          *
 0xC400     ASQU       ASQU       ASQU       ASQU       3          1          1          *
-0xC500     ABAT       ABAT       ABAT       ABAT       3          1          1          *
+0xC500     ABAT       ABAT       ABAT       ABAT       3          0          1          *
 0xC600     NBEG       NBEG       NBEG       NBEG       18         2          0          *
 0xC610     NPRO       NPRO       NPRO       NPRO       18         2          0          *
 0xC700     NBOY       NBOY       NBOY       NBOY       18         2          0          *

--- a/gemrb/unhardcoded/bg2/avatars.2da
+++ b/gemrb/unhardcoded/bg2/avatars.2da
@@ -257,12 +257,12 @@
 0xB600     NNOM       NNOM       NNOM       NNOM       18         2          0          *
 0xB610     NNOW       NNOW       NNOW       NNOW       18         2          0          *
 0xB700     NSLV       NSLV       NSLV       NSLV       18         2          0          *
-0xC000     ABAT       ABAT       ABAT       ABAT       3          1          1          *
+0xC000     ABAT       ABAT       ABAT       ABAT       3          0          1          *
 0xC100     ACAT       ACAT       ACAT       ACAT       3          1          1          *
 0xC200     ACHK       ACHK       ACHK       ACHK       3          1          1          *
 0xC300     ARAT       ARAT       ARAT       ARAT       3          1          1          *
 0xC400     ASQU       ASQU       ASQU       ASQU       3          1          1          *
-0xC500     ABAT       ABAT       ABAT       ABAT       3          1          1          *
+0xC500     ABAT       ABAT       ABAT       ABAT       3          0          1          *
 0xC600     NBEG       NBEG       NBEG       NBEG       18         2          0          *
 0xC610     NPRO       NPRO       NPRO       NPRO       18         2          0          *
 0xC700     NBOY       NBOY       NBOY       NBOY       18         2          0          *

--- a/gemrb/unhardcoded/how/avatars.2da
+++ b/gemrb/unhardcoded/how/avatars.2da
@@ -233,12 +233,12 @@
 0xB600    NNOML     NNOML      NNOML      NNOML      2          2          0          *
 0xB610    NNOWL     NNOWL      NNOWL      NNOWL      2          2          0          *
 0xB700    NSLVL     NSLVL      NSIWL      NSIWL      18         2          0          *
-0xC000    ABAT      ABAT       ABAT       ABAT       2          1          1          *
+0xC000    ABAT      ABAT       ABAT       ABAT       2          0          1          *
 0xC100    ACAT      ACAT       ACAT       ACAT       2          1          1          *
 0xC200    ACHK      ACHK       ACHK       ACHK       2          1          1          *
 0xC300    ARAT      ARAT       ARAT       ARAT       2          1          1          *
 0xC400    ASQU      ASQU       ASQU       ASQU       2          1          1          *
-0xC500    ABAT      ABAT       ABAT       ABAT       2          1          1          *
+0xC500    ABAT      ABAT       ABAT       ABAT       2          0          1          *
 0xC600    NBEGH     NBEGH      NBEGH      NBEGH      2          2          0          *
 0xC610    NPROH     NPROH      NPROH      NPROH      2          2          0          *
 0xC700    NBOYH     NBOYH      NBOYH      NBOYH      3          2          0          *

--- a/gemrb/unhardcoded/iwd/avatars.2da
+++ b/gemrb/unhardcoded/iwd/avatars.2da
@@ -224,12 +224,12 @@
 0xB600    NNOML     NNOML      NNOML      NNOML      2          2          0          *
 0xB610    NNOWL     NNOWL      NNOWL      NNOWL      2          2          0          *
 0xB700    NSLVL     NSLVL      NSIWL      NSIWL      18         2          0          *
-0xC000    ABAT      ABAT       ABAT       ABAT       2          1          1          *
+0xC000    ABAT      ABAT       ABAT       ABAT       2          0          1          *
 0xC100    ACAT      ACAT       ACAT       ACAT       2          1          1          *
 0xC200    ACHK      ACHK       ACHK       ACHK       2          1          1          *
 0xC300    ARAT      ARAT       ARAT       ARAT       2          1          1          *
 0xC400    ASQU      ASQU       ASQU       ASQU       2          1          1          *
-0xC500    ABAT      ABAT       ABAT       ABAT       2          1          1          *
+0xC500    ABAT      ABAT       ABAT       ABAT       2          0          1          *
 0xC600    NBEGH     NBEGH      NBEGH      NBEGH      2          2          0          *
 0xC610    NPROH     NPROH      NPROH      NPROH      2          2          0          *
 0xC700    NBOYH     NBOYH      NBOYH      NBOYH      3          2          0          *

--- a/gemrb/unhardcoded/iwd2/avatars.2da
+++ b/gemrb/unhardcoded/iwd2/avatars.2da
@@ -243,12 +243,12 @@
 0xB600     NNOML      NNOML      NNOML      NNOML      3          2          0          *
 0xB610     NNOWL      NNOWL      NNOWL      NNOWL      3          2          0          *
 0xB700     NSLVL      NSLVL      NSLVL      NSLVL      3          2          0          *
-0xC000     ABAT       ABAT       ABAT       ABAT       3          1          1          *
+0xC000     ABAT       ABAT       ABAT       ABAT       3          0          1          *
 0xC100     ACAT       ACAT       ACAT       ACAT       3          1          1          *
 0xC200     ACHK       ACHK       ACHK       ACHK       3          1          1          *
 0xC300     ARAT       ARAT       ARAT       ARAT       3          1          1          *
 0xC400     ASQU       ASQU       ASQU       ASQU       3          1          1          *
-0xC500     ABAT       ABAT       ABAT       ABAT       3          1          1          *
+0xC500     ABAT       ABAT       ABAT       ABAT       3          0          1          *
 0xC600     NBEGH      NBEGH      NBEGH      NBEGH      3          2          0          *
 0xC610     NPROH      NPROH      NPROH      NPROH      3          2          0          *
 0xC700     NBOY       NBOY       NBOY       NBOY       18         2          0          *


### PR DESCRIPTION
- Flying creatures like Marcel's bats from #258 and birds not having circles drawn even at maximum marker feedback. 
- above creatures are not valid for dialog anymore (#263), though they still have the talk cursor and tooltips
- tested locally