### PR TITLE
Subviews: fixing guideath position and display

### DIFF
--- a/gemrb/GUIScripts/GUIWORLD.py
+++ b/gemrb/GUIScripts/GUIWORLD.py
@@ -282,7 +282,7 @@ def DeathWindowEnd ():
 		GemRB.PlayMovie ("deathand",1)
 	GemRB.GamePause (1,3)
 
-	Window = GemRB.LoadWindow (17, GUICommon.GetWindowPack())
+	Window = GemRB.LoadWindow (17, GUICommon.GetWindowPack(), WINDOW_BOTTOM|WINDOW_HCENTER)
 
 	#reason for death
 	Label = Window.GetControl (0x0fffffff)

--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -1636,6 +1636,8 @@ void Game::UpdateScripts()
 		//don't check it any more
 		protagonist = PM_NO;
 		core->GetGUIScriptEngine()->RunFunction("GUIWORLD", "DeathWindow");
+		// That's for BG as the action bars to the left and right remain visible.
+		core->ToggleViewsEnabled(false, "NOT_DLG");
 		return;
 	}
 


### PR DESCRIPTION
Now they are at the bottom, and BG has the action bars visually disabled, too. 

Closes #285 