### PR TITLE
Temporary fix for issue #332

### DIFF
--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -2105,7 +2105,7 @@ void Game::Infravision()
 static const Color DreamTint={0xf0,0xe0,0xd0,0x10};    //light brown scale
 static const Color NightTint={0x80,0x80,0xe0,0x40};    //dark, bluish
 static const Color DuskTint={0xe0,0x80,0x80,0x40};     //dark, reddish
-static const Color FogTint={0xff,0xff,0xff,0x40};      //whitish
+//TODO: add FogTint when a solution that does not hinder lightness calculation is implemented
 static const Color DarkTint={0x80,0x80,0xe0,0x10};     //slightly dark bluish
 
 const Color *Game::GetGlobalTint() const

--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -2130,9 +2130,7 @@ const Color *Game::GetGlobalTint() const
 		if (WeatherBits&WB_RAIN) {
 			return &DarkTint;
 		}
-		if (WeatherBits&WB_FOG) {
-			return &FogTint;
-		}
+		//TODO: add FogTint when it is fixed to not hinder lightness calculation
 	}
 
 	return NULL;

--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -2105,7 +2105,6 @@ void Game::Infravision()
 static const Color DreamTint={0xf0,0xe0,0xd0,0x10};    //light brown scale
 static const Color NightTint={0x80,0x80,0xe0,0x40};    //dark, bluish
 static const Color DuskTint={0xe0,0x80,0x80,0x40};     //dark, reddish
-//TODO: add FogTint when a solution that does not hinder lightness calculation is implemented
 static const Color DarkTint={0x80,0x80,0xe0,0x10};     //slightly dark bluish
 
 const Color *Game::GetGlobalTint() const

--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -2129,7 +2129,6 @@ const Color *Game::GetGlobalTint() const
 		if (WeatherBits&WB_RAIN) {
 			return &DarkTint;
 		}
-		//TODO: add FogTint when it is fixed to not hinder lightness calculation
 	}
 
 	return NULL;

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -3759,9 +3759,7 @@ int Map::GetWeather()
 	if (Snow>=core->Roll(1,100,0) ) {
 		return WB_SNOW;
 	}
-	if (Fog>=core->Roll(1,100,0) ) {
-		return WB_FOG;
-	}
+	//TODO: add FOG when FogTint is fixed to not hinder lightness calculation
 	return WB_NORMAL;
 }
 

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -3759,7 +3759,7 @@ int Map::GetWeather()
 	if (Snow>=core->Roll(1,100,0) ) {
 		return WB_SNOW;
 	}
-	//TODO: add FOG when FogTint is fixed to not hinder lightness calculation
+	// TODO: handle WB_FOG the same way when we start drawing it
 	return WB_NORMAL;
 }
 


### PR DESCRIPTION
## Description
Removed Fog from GetGlobalTint and GetWeather to prevent miscalculated lightness in GetLightLevel. FogTint variable was also removed due to compilation error "un-used variable" with FreeBSD clang version 6.0.1.


## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [X] I have tested the proposed changes
- [X] I extended the documentation, if necessary
