### PR TITLE
fixed issue #324

### DIFF
--- a/gemrb/plugins/CREImporter/CREImporter.cpp
+++ b/gemrb/plugins/CREImporter/CREImporter.cpp
@@ -2952,7 +2952,7 @@ int CREImporter::PutKnownSpells( DataStream *stream, Actor *actor)
 		unsigned int level = actor->spellbook.GetSpellLevelCount(i);
 		for (unsigned int j=0;j<level;j++) {
 			unsigned int count = actor->spellbook.GetKnownSpellsCount(i, j);
-			for (unsigned int k=0;k<count;k++) {
+			for (int k=count-1;0<=k;k--) {
 				CREKnownSpell *ck = actor->spellbook.GetKnownSpell(i, j, k);
 				assert(ck);
 				stream->WriteResRef(ck->SpellResRef);


### PR DESCRIPTION
## Description
Saving reverses the order of known spells in the PC's spell-book, saving the spells in reverse order preserves the original order on next load. I Inverted the loop to start indexing from (count-1) to fix the issue.


## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [X] I have tested the proposed changes
- [X] I extended the documentation, if necessary
