### PR TITLE
Cleanup of invalid spells in IWD clab files

### DIFF
--- a/gemrb/unhardcoded/iwd/clabdrui.2da
+++ b/gemrb/unhardcoded/iwd/clabdrui.2da
@@ -1,5 +1,5 @@
 2DA V1.0
 ****
-            1           2           3           4           5           6           7           8  9           10  11          12  13          14  15
-ABILITY1    ****        ****        ****        ****        GA_SPIN110  ****        GA_SPIN111  *  GA_SPIN107  *   GA_SPIN141  *   GA_SPIN142  *   GA_SPIN143
-ABILITY2    ****        ****        ****        ****        ****        ****        *           *  AP_POISIMM  *   *           *   *           *   AP_FATIIMM
+            1           2           3           4           5           6           7           8  9           10  11  12  13  14  15
+ABILITY1    ****        ****        ****        ****        GA_SPIN110  ****        GA_SPIN111  *  GA_SPIN107  *   *   *   *   *   *
+ABILITY2    ****        ****        ****        ****        ****        ****        *           *  AP_POISIMM  *   *   *   *   *   AP_FATIIMM

--- a/gemrb/unhardcoded/iwd/clabpala.2da
+++ b/gemrb/unhardcoded/iwd/clabpala.2da
@@ -9,4 +9,3 @@ ABILITY5    GA_SPIN120  *  *           *  *           *  *           *  *       
 ABILITY6    GA_SPIN120  *  *           *  *           *  *           *  *           *   *           *   *           *   *
 ABILITY7    GA_SPIN121  *  *           *  *           *  *           *  *           *   *           *   *           *   *
 ABILITY8    GA_SPIN125  *  *           *  *           *  *           *  *           *   *           *   *           *   *
-ABILITY9    GA_SPIN152  *  *           *  *           *  *           *  *           *   *           *   *           *   *


### PR DESCRIPTION
See #356.

## Description
Non-HoW IWD only knows innate spells until SPIN125 so these values have nothing to do here. I have manually tested if upleveling between level 10 and 14 gives alternate innate spells - but there is nothing. 
