### PR TITLE
subviews: Really disabling action bar buttons

### DIFF
--- a/gemrb/core/GUI/Button.cpp
+++ b/gemrb/core/GUI/Button.cpp
@@ -317,12 +317,12 @@ void Button::SetState(unsigned char state)
 		return;
 	}
 
+	// FIXME: we should properly consolidate IE_GUI_BUTTON_DISABLED with the view Disabled flag
+	SetDisabled(state == IE_GUI_BUTTON_DISABLED);
+
 	if (State == state) {
 		return; // avoid redraw
 	}
-
-	// FIXME: we should properly consolidate IE_GUI_BUTTON_DISABLED with the view Disabled flag
-	SetDisabled(state == IE_GUI_BUTTON_DISABLED);
 
 	if (State != state) {
 		MarkDirty();


### PR DESCRIPTION
This is more like patchwork: I guess somewhere something is changing control flags of the button while it is already its own disabled state but this does not matter for `Control::IsDisabled` when starting the action, so let's reinforce that even if the state's already there.

closes #283

