### PR TITLE
subviews: fix for properly clearing render targets in some cases

### DIFF
--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -128,7 +128,7 @@ int SDL20VideoDriver::UpdateRenderTarget(const Color* color)
 
 	if (screenClip.Dimensions() == screenSize)
 	{
-		// SDL does _not_ seem to like having a clip rect of the entire renderer size
+		// Some SDL backends complain on having a clip rect of the entire renderer size
 		// I'm not sure if it is an SDL bug; possibly its just 0 based so it is out of bounds?
 		SDL_RenderSetClipRect(renderer, NULL);
 	} else {

--- a/gemrb/plugins/SDLVideo/SDL20Video.h
+++ b/gemrb/plugins/SDLVideo/SDL20Video.h
@@ -163,6 +163,14 @@ public:
 	void Clear() {
 		SDL_SetRenderTarget(renderer, texture);
 		SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_TRANSPARENT);
+#if SDL_COMPILEDVERSION == SDL_VERSIONNUM(2, 0, 10)
+		/**
+		 * See GH issue #410. In some SDL2 backends of this version, a clear
+		 * runs over an outdated state of the clipping settings. This can
+		 * be overcome by a harmless draw command right before.
+		 */
+		SDL_RenderDrawPoint(renderer, 0, 0);
+#endif
 		SDL_RenderClear(renderer);
 
 		ClearMaskLayer();
@@ -172,6 +180,9 @@ public:
 		if (maskLayer) {
 			SDL_SetRenderTarget(renderer, maskLayer);
 			SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_TRANSPARENT);
+#if SDL_COMPILEDVERSION == SDL_VERSIONNUM(2, 0, 10)
+			SDL_RenderDrawPoint(renderer, 0, 0);
+#endif
 			SDL_RenderClear(renderer);
 		}
 	}


### PR DESCRIPTION
I removed your other change since there is no reason IMO to keep that switch - and it did not help here.

closes #410

