### PR TITLE
Feet2Pixels Correction

### DIFF
--- a/gemrb/core/Core.cpp
+++ b/gemrb/core/Core.cpp
@@ -212,8 +212,8 @@ unsigned int SquaredPersonalDistance(Scriptable *a, Scriptable *b)
 // 16 16 16 16 15 15 15 14 14 14 13 13 13 12 12 12 12 12 12
 double Feet2Pixels(int feet, double angle)
 {
-	double sin2 = pow(sin(angle) / 16, 2);
-	double cos2 = pow(cos(angle) / 12, 2);
+	double sin2 = pow(sin(angle) / 12, 2);
+	double cos2 = pow(cos(angle) / 16, 2);
 	double r = sqrt(1 / (cos2 + sin2));
 	return r * feet;
 }


### PR DESCRIPTION
## Description
Adjusted calculation so the angle used starts with 0 degrees being on the positive x-axis instead of positive y-axis.

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [X] I have tested the proposed changes
- [X] I extended the documentation, if necessary
