### PR TITLE
replaced VOODOO_SHOUT_RANGE constant with Feet2Pixels function call

### DIFF
--- a/gemrb/core/GameScript/Actions.cpp
+++ b/gemrb/core/GameScript/Actions.cpp
@@ -4936,7 +4936,6 @@ void GameScript::Shout( Scriptable* Sender, Action* parameters)
 		return;
 	}
 	Map *map=Sender->GetCurrentArea();
-	//max. shouting distance, please adjust it if you know better
 	map->Shout(actor, parameters->int0Parameter, false);
 }
 
@@ -4951,7 +4950,7 @@ void GameScript::GlobalShout( Scriptable* Sender, Action* parameters)
 		return;
 	}
 	Map *map=Sender->GetCurrentArea();
-	// 0 means unlimited shout distance
+	// true means global, unlimited, shout distance
 	map->Shout(actor, parameters->int0Parameter, true);
 }
 

--- a/gemrb/core/GameScript/Actions.cpp
+++ b/gemrb/core/GameScript/Actions.cpp
@@ -4937,7 +4937,7 @@ void GameScript::Shout( Scriptable* Sender, Action* parameters)
 	}
 	Map *map=Sender->GetCurrentArea();
 	//max. shouting distance, please adjust it if you know better
-	map->Shout(actor, parameters->int0Parameter, VOODOO_SHOUT_RANGE);
+	map->Shout(actor, parameters->int0Parameter, false);
 }
 
 void GameScript::GlobalShout( Scriptable* Sender, Action* parameters)
@@ -4952,7 +4952,7 @@ void GameScript::GlobalShout( Scriptable* Sender, Action* parameters)
 	}
 	Map *map=Sender->GetCurrentArea();
 	// 0 means unlimited shout distance
-	map->Shout(actor, parameters->int0Parameter, 0);
+	map->Shout(actor, parameters->int0Parameter, true);
 }
 
 void GameScript::Help( Scriptable* Sender, Action* /*parameters*/)
@@ -4962,7 +4962,7 @@ void GameScript::Help( Scriptable* Sender, Action* /*parameters*/)
 	}
 	//TODO: add state limiting like in Shout?
 	Map *map=Sender->GetCurrentArea();
-	map->Shout((Actor *) Sender, 0, VOODOO_SHOUT_RANGE);
+	map->Shout((Actor *) Sender, 0, false);
 }
 
 void GameScript::GiveOrder(Scriptable* Sender, Action* parameters)

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -1398,7 +1398,6 @@ void Map::Shout(Actor* actor, int shoutID, bool global)
 		if (!global) {
 			/* Audible range was confirmed to be 3x visual range in EEs, accounting for isometric scaling 
 			and more than 1x visual range in others in EE, the '48' (3*16) default can be set by the 'Audible Range'
-			game option in baldur.lua
 
 			This is a bit tricky, it has been show to not be very consistent. The game used a double value of visual 
 			range in several places, so we will use '3 * visual_range / 2' */
@@ -4182,4 +4181,3 @@ void Map::SetupReverbInfo() {
 }
 
 }
-

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -1397,7 +1397,8 @@ void Map::Shout(Actor* actor, int shoutID, bool global)
 
 		if (!global) {
 			/* Audible range was confirmed to be 3x visual range in EEs, accounting for isometric scaling 
-			and more than 1x visual range in others in EE, the '48' (3*16) default can be set by the 'Audible Range'
+			and more than 1x visual range in others;
+			in EE, the '48' (3*16) default can be set by the 'Audible Range' option in baldur.lua
 
 			This is a bit tricky, it has been show to not be very consistent. The game used a double value of visual 
 			range in several places, so we will use '3 * visual_range / 2' */

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -1406,7 +1406,7 @@ void Map::Shout(Actor* actor, int shoutID, bool global)
 			const Point& B = listener->Pos;
 			double angle = atan2(B.y - A.y, B.x - A.x);
 			int distance = (3 * actor->GetStat(IE_VISUALRANGE)) / 2;
-			if (Distance(A, B)>Feet2Pixels(distance, angle)) {
+			if (Distance(A, B) > Feet2Pixels(distance, angle)) {
 				continue;
 			}
 		}

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -1396,10 +1396,17 @@ void Map::Shout(Actor* actor, int shoutID, bool global)
 		}
 
 		if (!global) {
-		        const Point& A = actor->Pos;
+			/* Audible range was confirmed to be 3x visual range in EEs, accounting for isometric scaling 
+			and more than 1x visual range in others in EE, the '48' (3*16) default can be set by the 'Audible Range'
+			game option in baldur.lua
+
+			This is a bit tricky, it has been show to not be very consistent. The game used a double value of visual 
+			range in several places, so we will use '3 * visual_range / 2' */
+			const Point& A = actor->Pos;
 			const Point& B = listener->Pos;
 			double angle = atan2(B.y - A.y, B.x - A.x);
-			if (Distance(A, B)>Feet2Pixels(30, angle)) {
+			int distance = (3 * actor->GetStat(IE_VISUALRANGE)) / 2;
+			if (Distance(A, B)>Feet2Pixels(distance, angle)) {
 				continue;
 			}
 		}

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -1384,7 +1384,7 @@ void Map::UpdateEffects()
 	}
 }
 
-void Map::Shout(Actor* actor, int shoutID, unsigned int radius)
+void Map::Shout(Actor* actor, int shoutID, bool global)
 {
 	size_t i=actors.size();
 	while (i--) {
@@ -1395,8 +1395,11 @@ void Map::Shout(Actor* actor, int shoutID, unsigned int radius)
 			continue;
 		}
 
-		if (radius) {
-			if (Distance(actor->Pos, listener->Pos)>radius) {
+		if (!global) {
+		        const Point& A = actor->Pos;
+			const Point& B = listener->Pos;
+			double angle = atan2(B.y - A.y, B.x - A.x);
+			if (Distance(A, B)>Feet2Pixels(30, angle)) {
 				continue;
 			}
 		}

--- a/gemrb/core/Map.h
+++ b/gemrb/core/Map.h
@@ -418,7 +418,7 @@ public:
 	SpriteCover* BuildSpriteCover(int x, int y, int xpos, int ypos,
 		unsigned int width, unsigned int height, int flag, bool areaanim = false);
 	void ActivateWallgroups(unsigned int baseindex, unsigned int count, int flg);
-	void Shout(Actor* actor, int shoutID, unsigned int radius);
+	void Shout(Actor* actor, int shoutID, bool global);
 	void ActorSpottedByPlayer(Actor *actor);
 	void InitActors();
 	void InitActor(Actor *actor);

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -4340,7 +4340,8 @@ void Actor::PlayExistenceSounds()
 	audio->GetListenerPos(xpos, ypos);
 	Point listener(xpos, ypos);
 	double angle = atan2(listener.y - Pos.y, listener.x - Pos.x);
-	  if (nextComment && !Immobile() && Distance(Pos, listener) <= Feet2Pixels(30, angle)) {
+	int distance = (3 * this->GetStat(IE_VISUALRANGE)) / 2; // refer to Map::Shout regarding audible range
+	if (nextComment && !Immobile() && Distance(Pos, listener) <= Feet2Pixels(distance, angle)) {
 		//setup as an ambient
 		ieStrRef strref = GetVerbalConstant(VB_EXISTENCE, 5);
 		if (strref != (ieStrRef) -1) {

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -4339,7 +4339,8 @@ void Actor::PlayExistenceSounds()
 	int xpos, ypos;
 	audio->GetListenerPos(xpos, ypos);
 	Point listener(xpos, ypos);
-	if (nextComment && !Immobile() && Distance(Pos, listener) <= VOODOO_SHOUT_RANGE) {
+	double angle = atan2(listener.y - Pos.y, listener.x - Pos.x);
+	  if (nextComment && !Immobile() && Distance(Pos, listener) <= Feet2Pixels(30, angle)) {
 		//setup as an ambient
 		ieStrRef strref = GetVerbalConstant(VB_EXISTENCE, 5);
 		if (strref != (ieStrRef) -1) {

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -4340,7 +4340,7 @@ void Actor::PlayExistenceSounds()
 	audio->GetListenerPos(xpos, ypos);
 	Point listener(xpos, ypos);
 	double angle = atan2(listener.y - Pos.y, listener.x - Pos.x);
-	int distance = (3 * this->GetStat(IE_VISUALRANGE)) / 2; // refer to Map::Shout regarding audible range
+	int distance = (3 * GetStat(IE_VISUALRANGE)) / 2; // refer to Map::Shout regarding audible range
 	if (nextComment && !Immobile() && Distance(Pos, listener) <= Feet2Pixels(distance, angle)) {
 		//setup as an ambient
 		ieStrRef strref = GetVerbalConstant(VB_EXISTENCE, 5);

--- a/gemrb/includes/voodooconst.h
+++ b/gemrb/includes/voodooconst.h
@@ -60,13 +60,6 @@ static const int VOODOO_FINDTRAP_RANGE = 10;
 // The distance of operating a trigger, container, dialog buffer etc.
 static unsigned int MAX_OPERATING_DISTANCE IGNORE_UNUSED = 40; //a search square is 16x12 (diagonal of 20), so that's about two
 
-// used for the shout action, supposedly "slightly larger than the default visual radius of NPCs"
-// while it looks too big, it is needed this big in at least pst (help())
-// bgee testing shows a radius of 72 feet
-// In the EE Help() has the range of "visualrange" * 3 * (16 * (1 or 3/4 in the vertical)) == 3x visual range, converted via Feet2pixels
-// the '48' (3*16) default can be set by the 'Audible Range' game option in baldur.lua
-static const unsigned int VOODOO_SHOUT_RANGE = 400;
-
 // existence delay is a stat used to delay various char quips, but it's sometimes set to 0,
 // while it should clearly always be delayed at least a bit. The engine uses randomization.
 // Estimates from bg1 research:


### PR DESCRIPTION
## Description
Replaced VOODOO_SHOUT_RANGE with a call to Feet2Pixels. Also adjusted Map::Shout to accept a flag signifying if the call was from GameScript::GlobalShout or not to still allow for the unlimited shout distance of GameScript::GlobalShout.


## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [X] I have tested the proposed changes
- [X] I extended the documentation, if necessary
