### PR TITLE
SDLVideo: prevents a crash on screen fading under SDL2

### DIFF
--- a/gemrb/plugins/SDLVideo/SDLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDLVideo.cpp
@@ -1359,8 +1359,16 @@ void SDLVideoDriver::SetFadeColor(int r, int g, int b)
 	if (b>255) b=255;
 	else if(b<0) b=0;
 	fadeColor.b=b;
-	long val = SDL_MapRGBA( extra->format, fadeColor.r, fadeColor.g, fadeColor.b, fadeColor.a );
-	SDL_FillRect( extra, NULL, val );
+
+	/**
+	 * `extra` is tightly coupled to SDL1.2 code. Thus, some fade effects in PST
+	 * currently don't work for SDL2 - but assuming its presence otherwise causes
+	 * a crash.
+	 */
+	if (extra) {
+		long val = SDL_MapRGBA( extra->format, fadeColor.r, fadeColor.g, fadeColor.b, fadeColor.a );
+		SDL_FillRect( extra, NULL, val );
+	}
 }
 
 void SDLVideoDriver::SetFadePercent(int percent)


### PR DESCRIPTION
This is patchwork against the crash in #554. There is some more code in SDL2 that once seemed to address fade colors, but @bradallred had put (parts of) it into comments. So I guess it makes more sense to see this working in subviews than trying to recover that in master.

Just prevent people from seeing the crash in PST right now.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
