### PR TITLE
subviews: makes SDL v1.2 code compile on GCC again

### DIFF
--- a/gemrb/plugins/SDLVideo/SDLSurfaceDrawing.h
+++ b/gemrb/plugins/SDLVideo/SDLSurfaceDrawing.h
@@ -182,7 +182,7 @@ void DrawHLineSurface(SDL_Surface* dst, Point p, short x2, const Region& clip, c
 		Uint32 c = SDL_MapRGBA(dst->format, color.r, color.g, color.b, color.a);
 
 		int numPx = std::min(x2 - p.x, dst->w - p.x);
-		SDL_memset4(px, c, numPx);
+		std::fill(px, px + numPx, c);
 	}
 }
 


### PR DESCRIPTION
Interestingly, `std::fill` is about as fast as that `SDL_memset4` on Linux, but only half as good on an old Windows 7 with Lynnfield CPU.

Anyway, that's more like the canonical way to have it compiling without errors (#577).