### PR TITLE
BG1 avatars.2da: Additional entry for ghouls

### DIFF
--- a/gemrb/unhardcoded/bg1/avatars.2da
+++ b/gemrb/unhardcoded/bg1/avatars.2da
@@ -149,6 +149,7 @@
 0x7500     MDOP       MDOP       MDOP       MDOP       14         2          1          *
 0x7501     MDOP       MDOP       MDOP       MDOP       14         2          GR         *
 0x7600     METT       METT       METT       METT       14         2          1          *
+0x7700     MGHL       MGHL       MGHL       MGHL       14         2          1          *
 0x7701     MGHL       MGHL       MGHL       MGHL       14         2          1          *
 0x7702     MGHL       MGHL       MGHL       MGHL       14         2          RE         *
 0x7703     MGHL       MGHL       MGHL       MGHL       14         2          GA         *


### PR DESCRIPTION
It misses a line for 0x7700 (Ghouls), so the game falls back to the ettercap animation. This adds that line, tested locally.