### PR TITLE
SDL/Pixels: fixes a GCC compiler error

### DIFF
--- a/gemrb/plugins/SDLVideo/Pixels.h
+++ b/gemrb/plugins/SDLVideo/Pixels.h
@@ -433,11 +433,11 @@ public:
 			case 2:
 				return static_cast<PixelIterator<Uint16>*>(imp)->Channel(mask, shift);
 			case 3:
-				assert(false);
+				error("SDLVideo", "Cannot request SDLPixelIterator channel on 24bpp.");
 			case 4:
 				return static_cast<PixelIterator<Uint32>*>(imp)->Channel(mask, shift);
 			default:
-				assert(false);
+				error("SDLVideo", "Invalid bpp setting while requesting SDLPixelIterator channel.");
 		}
 	}
 


### PR DESCRIPTION
GCC doesn't like a missing return, regardless of the `assert`:

```cpp
[ 94%] Building CXX object gemrb/plugins/TISImporter/CMakeFiles/TISImporter.dir/TISImporter.cpp.obj
In file included from ./gemrb_subviews/gemrb/plugins/SDLVideo/SDLSurfaceDrawing.h:28,
                 from ./gemrb_subviews/gemrb/plugins/SDLVideo/SDLVideo.h:29,
                 from ./gemrb_subviews/gemrb/plugins/SDLVideo/SDLVideo.cpp:21:
./gemrb_subviews/gemrb/plugins/SDLVideo/Pixels.h: In member function 'virtual Uint8 GemRB::SDLPixelIterator::Channel(Uint32, Uint8) const':
./gemrb_subviews/gemrb/plugins/SDLVideo/Pixels.h:442:2: error: control reaches end of non-void function [-Werror=return-type]
  442 |  }
      |  ^
```
