### PR TITLE
[subviews] Compiler fixes

### DIFF
--- a/gemrb/core/Scriptable/Door.h
+++ b/gemrb/core/Scriptable/Door.h
@@ -47,7 +47,7 @@ class TileOverlay;
 #define DOOR_LOCKEDINFOTEXT 0x8000
 #define DOOR_WARNINGINFOTEXT 0x10000
 
-class DoorTrigger {
+class GEM_EXPORT DoorTrigger {
 	WallPolygonGroup openWalls;
 	WallPolygonGroup closedWalls;
 

--- a/gemrb/core/Scriptable/Scriptable.h
+++ b/gemrb/core/Scriptable/Scriptable.h
@@ -27,6 +27,7 @@
 
 #include <list>
 #include <map>
+#include <memory>
 
 namespace GemRB {
 


### PR DESCRIPTION
Otherwise, GCC refuses to continue:
```cpp
[  2%] Building CXX object gemrb/core/CMakeFiles/gemrb_core.dir/ArchiveImporter.cpp.obj
In file included from ./gemrb_subviews/gemrb/core/Game.h:37,
                 from ./gemrb_subviews/gemrb/core/Animation.cpp:25:
./gemrb_subviews/gemrb/core/Scriptable/Scriptable.h:412:7: error: 'shared_ptr' in namespace 'std' does not name a template type
  412 |  std::shared_ptr<Gem_Polygon> outline;
      |       ^~~~~~~~~~
In file included from ./gemrb_subviews/gemrb/core/Game.h:37,
                 from ./gemrb_subviews/gemrb/core/Animation.cpp:25:
./gemrb_subviews/gemrb/core/Scriptable/Scriptable.h:30:1: note: 'std::shared_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
   29 | #include <map>
  +++ |+#include <memory>
   30 |
   ```
```
  ./gemrb_subviews/gemrb/plugins/AREImporter/AREImporter.cpp:977: undefined reference to `GemRB::DoorTrigger::DoorTrigger(std::shared_ptr<GemRB::Gem_Polygon>, std::vector<std::shared_ptr<GemRB::Wall_Polygon>, std::allocator<std::shared_ptr<GemRB::Wall_Polygon> > >&&, std::shared_ptr<GemRB::Gem_Polygon>, std::vector<std::shared_ptr<GemRB::Wall_Polygon>, std::allocator<std::shared_ptr<GemRB::Wall_Polygon> > >&&)'
collect2.exe: error: ld returned 1 exit status
```
