### PR TITLE
fix expended items not deleting

### DIFF
--- a/gemrb/core/Inventory.cpp
+++ b/gemrb/core/Inventory.cpp
@@ -1420,6 +1420,8 @@ void Inventory::SetSlotItemRes(const ieResRef ItemResRef, int SlotID, int Charge
 			SetSlotItem( TmpItem, SlotID );
 		} else {
 			delete TmpItem;
+			//if the item isn't creatable, we still destroy the old item
+			KillSlot( SlotID );
 		}
 	} else {
 		//if the item isn't creatable, we still destroy the old item

--- a/gemrb/core/Inventory.cpp
+++ b/gemrb/core/Inventory.cpp
@@ -1469,7 +1469,7 @@ void Inventory::BreakItemSlot(ieDword slot)
 	if (!itm) return;
 	//if it is the magic weapon slot, don't break it, just remove it, because it couldn't be removed
 	//or for pst, just remove it as there is no breaking (the replacement item is a sound)
-	if(slot ==(unsigned int) SLOT_MAGIC || core->HasFeature(GF_HAS_PICK_SOUND)) {
+	if (slot == (unsigned int) SLOT_MAGIC || core->HasFeature(GF_HAS_PICK_SOUND)) {
 		newItem[0]=0;
 	} else {
 		memcpy(newItem, itm->ReplacementItem,sizeof(newItem) );

--- a/gemrb/core/Inventory.cpp
+++ b/gemrb/core/Inventory.cpp
@@ -1420,8 +1420,6 @@ void Inventory::SetSlotItemRes(const ieResRef ItemResRef, int SlotID, int Charge
 			SetSlotItem( TmpItem, SlotID );
 		} else {
 			delete TmpItem;
-			//if the item isn't creatable, we still destroy the old item
-			KillSlot( SlotID );
 		}
 	} else {
 		//if the item isn't creatable, we still destroy the old item
@@ -1470,7 +1468,8 @@ void Inventory::BreakItemSlot(ieDword slot)
 	const Item *itm = GetItemPointer(slot, Slot);
 	if (!itm) return;
 	//if it is the magic weapon slot, don't break it, just remove it, because it couldn't be removed
-	if(slot ==(unsigned int) SLOT_MAGIC) {
+	//or for pst, just remove it as there is no breaking (the replacement item is a sound)
+	if(slot ==(unsigned int) SLOT_MAGIC || core->HasFeature(GF_HAS_PICK_SOUND)) {
 		newItem[0]=0;
 	} else {
 		memcpy(newItem, itm->ReplacementItem,sizeof(newItem) );


### PR DESCRIPTION
## Description
My first attempt to contribute. I've found out that depleted items are not deleted because the replacement item "Z_GEN2B.itm" is not present. as @lynxlynxlynx pointed out, it's actually a sound as PST does not use replacement items.

Issue #651 

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [X] I have tested the proposed changes
- [X] I extended the documentation, if necessary
