### PR TITLE
Fix opening attribute window for TNO only

### DIFF
--- a/gemrb/GUIScripts/pst/NewLife.py
+++ b/gemrb/GUIScripts/pst/NewLife.py
@@ -72,7 +72,8 @@ def OpenLUStatsWindow(Type = 1):
 		GUIREC.RecordsWindow.SetVisible (WINDOW_INVISIBLE)
 		# only TNO gets the main stat boosts
 		pc = GemRB.GameGetSelectedPCSingle ()
-		if pc != 1:
+		Specific = GemRB.GetPlayerStat (pc, IE_SPECIFIC)
+		if Specific != 2:
 			GUIREC.OpenLevelUpWindow ()
 			return
 	else:


### PR DESCRIPTION
## Description
Fixes check determining whether PC on level up is TNO or not. The attribute assignment window should be shown for TNO only.

Fixes #657 

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [X] I have tested the proposed changes
- [X] I extended the documentation, if necessary
