### PR TITLE
PST savegame fix

### DIFF
--- a/gemrb/core/Scriptable/Actor.h
+++ b/gemrb/core/Scriptable/Actor.h
@@ -377,6 +377,11 @@ public:
 	int checkHP;
 	// to determine that a tick has passed
 	ieDword checkHPTime;
+	/**
+	 * We don't know how to profit of them, but PST needs them saved.
+	 * Otherwise, some actors are badly drawn, like TNO but not Morte.
+	 */
+	ieByte pstColorBytes[10];
 private:
 	//this stuff doesn't get saved
 	CharAnimations* anims;

--- a/gemrb/plugins/CREImporter/CREImporter.cpp
+++ b/gemrb/plugins/CREImporter/CREImporter.cpp
@@ -1200,8 +1200,8 @@ void CREImporter::GetActorPST(Actor *act)
 		act->BaseStats[IE_COLORS+i] = tmpWord;
 	}
 	act->BaseStats[IE_COLORCOUNT] = tmpByte; //hack
-
-	str->Seek(31, GEM_CURRENT_POS);
+	str->Read(act->pstColorBytes, 10);
+	str->Seek(21, GEM_CURRENT_POS);
 	str->Read( &tmpByte, 1 );
 	act->BaseStats[IE_SPECIES]=tmpByte; // offset: 0x311
 	str->Read( &tmpByte, 1 );
@@ -2788,7 +2788,8 @@ int CREImporter::PutActorPST(DataStream *stream, Actor *actor)
 		tmpWord = actor->BaseStats[IE_COLORS+i];
 		stream->WriteWord( &tmpWord);
 	}
-	stream->Write(filling,31);
+	stream->Write(actor->pstColorBytes, 10);
+	stream->Write(filling, 21);
 	tmpByte = actor->BaseStats[IE_SPECIES];
 	stream->Write( &tmpByte, 1);
 	tmpByte = actor->BaseStats[IE_TEAM];

--- a/gemrb/plugins/GAMImporter/GAMImporter.cpp
+++ b/gemrb/plugins/GAMImporter/GAMImporter.cpp
@@ -762,7 +762,7 @@ int GAMImporter::PutKillVars(DataStream *stream, Game *game)
 	for (unsigned int i=0;i<KillVarsCount;i++) {
 		//global variables are locals for game, that's why the local/global confusion
 		pos=game->kaputz->GetNextAssoc( pos, name, value);
-		strnspccpy(tmpname,name,32);
+		strnspccpy(tmpname, name, 32, core->HasFeature(GF_NO_NEW_VARIABLES));
 		stream->Write( tmpname, 32);
 		stream->Write( filling, 8);
 		stream->WriteDword( &value);
@@ -784,7 +784,20 @@ int GAMImporter::PutVariables(DataStream *stream, Game *game)
 	for (unsigned int i=0;i<GlobalCount;i++) {
 		//global variables are locals for game, that's why the local/global confusion
 		pos=game->locals->GetNextAssoc( pos, name, value);
-		strnspccpy(tmpname, name, 32);
+
+		/* PST hates to have some variables lowercased. */
+		if (core->HasFeature(GF_NO_NEW_VARIABLES)) {
+			/* This is one anomaly that must have a space injected (PST crashes otherwise). */
+			if (strcmp("dictionary_githzerai_hjacknir", name) == 0) {
+				memset(tmpname, 0, sizeof(ieVariable));
+				strncpy(tmpname, "DICTIONARY_GITHZERAI_ HJACKNIR", sizeof(ieVariable));
+			} else {
+				strnspccpy(tmpname, name, 32, true);
+			}
+		} else {
+			strnspccpy(tmpname, name, 32);
+		}
+
 		stream->Write( tmpname, 32);
 		stream->Write( filling, 8);
 		stream->WriteDword( &value);


### PR DESCRIPTION
## Description
Makes save games from GemRB work in PST to the extent we know it did not so far.

See #659 

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
