### PR TITLE
Remove an old Win32 workaround that conflicts with cmath in MSVC2019

### DIFF
--- a/gemrb/includes/win32def.h
+++ b/gemrb/includes/win32def.h
@@ -59,12 +59,6 @@
 
 #include "System/VFS.h"
 
-#ifdef _MSC_VER
-# ifndef round
-#  define round(x) ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
-# endif
-#endif
-
 #ifndef M_PI
 #define M_PI    3.14159265358979323846 // pi
 #endif


### PR DESCRIPTION
I am guessing it is ok to remove this completely as GemRB requires a much more recent C++ standard anyway.

