### PR TITLE
Windows: use Unicode/UTF-16 API

### DIFF
--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -1441,7 +1441,7 @@ int Interface::Init(InterfaceConfig* config)
 
 	if ( StupidityDetector( CachePath )) {
 		Log(ERROR, "Core", "Cache path %s doesn't exist, not a folder or contains alien files!", CachePath );
-		return false;
+		return GEM_ERROR;
 	}
 	if (!KeepCache) DelTree((const char *) CachePath, false);
 

--- a/gemrb/core/System/FileStream.cpp
+++ b/gemrb/core/System/FileStream.cpp
@@ -31,6 +31,11 @@ int FileStream::FileStreamPtrCount = 0;
 #endif
 
 #ifdef WIN32
+
+#define TCHAR_NAME(name) \
+	TCHAR t_name[MAX_PATH] = {0}; \
+	mbstowcs(t_name, name, MAX_PATH - 1);
+
 struct FileStream::File {
 private:
 	HANDLE file;
@@ -49,7 +54,8 @@ public:
 		return 0;
 	}
 	bool OpenRO(const char *name) {
-		file = CreateFile(name,
+		TCHAR_NAME(name)
+		file = CreateFile(t_name,
 			GENERIC_READ,
 			FILE_SHARE_READ | FILE_SHARE_WRITE,
 			NULL,
@@ -58,7 +64,8 @@ public:
 		return (file != INVALID_HANDLE_VALUE);
 	}
 	bool OpenRW(const char *name) {
-		file = CreateFile(name,
+		TCHAR_NAME(name)
+		file = CreateFile(t_name,
 			GENERIC_READ | GENERIC_WRITE,
 			FILE_SHARE_READ | FILE_SHARE_WRITE,
 			NULL,
@@ -67,7 +74,8 @@ public:
 		return (file != INVALID_HANDLE_VALUE);
 	}
 	bool OpenNew(const char *name) {
-		file = CreateFile(name,
+		TCHAR_NAME(name)
+		file = CreateFile(t_name,
 			GENERIC_WRITE,
 			FILE_SHARE_READ,
 			NULL,

--- a/gemrb/includes/win32def.h
+++ b/gemrb/includes/win32def.h
@@ -39,6 +39,9 @@
 # define NOMINMAX
 # endif
 
+#define UNICODE
+#define _UNICODE
+
 # include <windows.h>
 # define swprintf  _snwprintf
 # define vswprintf _vsnwprintf


### PR DESCRIPTION
## Description

This makes sure to always talk in UTF-16 to Windows where we need to do. This does not fix things related to #650 but makes sure to rely on at least one thing w.r.t. Windows post 9x.

So many string functions to read the docs for, I hope I did not missing anything too critical ...

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
