### PR TITLE
subviews: fixing the remaining font-related compiler errors

### DIFF
--- a/gemrb/core/GUI/TextSystem/TextContainer.cpp
+++ b/gemrb/core/GUI/TextSystem/TextContainer.cpp
@@ -709,7 +709,7 @@ void TextContainer::DrawContents(const Layout& layout, const Point& dp)
 
 	if (Editable() && printPos < cursorPos && printPos + textLen >= cursorPos) {
 		const Font* printFont = ts->LayoutFont();
-		Font::StringSizeMetrics metrics = {Size(0,0), 0, true};
+		Font::StringSizeMetrics metrics = {Size(0,0), 0, 0, true};
 
 		// diff is the length of the TextSpan we want however, it may fall inside of a word
 		size_t diff = cursorPos - printPos;
@@ -772,7 +772,7 @@ void TextContainer::MoveCursorToPoint(const Point& p)
 		TextSpan* ts = (TextSpan*)layout->content;
 		const String& text = ts->Text();
 		const Font* printFont = ts->LayoutFont();
-		Font::StringSizeMetrics metrics = {Size(0,0), 0, true};
+		Font::StringSizeMetrics metrics = {Size(0,0), 0, 0, true};
 		size_t numChars = 0;
 
 		const Regions& regions = layout->regions;

--- a/gemrb/core/GUI/Tooltip.cpp
+++ b/gemrb/core/GUI/Tooltip.cpp
@@ -127,7 +127,7 @@ void Tooltip::SetText(const String& t)
 {
 	text = t;
 
-	Font::StringSizeMetrics metrics = {Size(), 0, true};
+	Font::StringSizeMetrics metrics = {Size(), 0, 0, true};
 	// FIXME: arbitrary fallback size
 	metrics.size = (background) ? background->MaxTextSize() : Size(128,128);
 	textSize = font->StringSize( text, &metrics );


### PR DESCRIPTION
Fixing GCC errors. I guess not limiting the number of lines is the general case?

```
./gemrb/core/GUI/Tooltip.cpp: In member function 'void GemRB::Tooltip::SetText(const String&)':
./gemrb/core/GUI/Tooltip.cpp:130:52: error: missing initializer for member 'GemRB::Font::StringSizeMetrics::forceBreak' [-Werror=missing-field-initializers]
  130 |  Font::StringSizeMetrics metrics = {Size(), 0, true};
      |                                                    ^
./gemrb/core/GUI/TextSystem/TextContainer.cpp: In member function 'virtual void GemRB::TextContainer::DrawContents(const GemRB::ContentContainer::Layout&, const GemRB::Point&)':
./gemrb/core/GUI/TextSystem/TextContainer.cpp:712:56: error: missing initializer for member 'GemRB::Font::StringSizeMetrics::forceBreak' [-Werror=missing-field-initializers]
  712 |   Font::StringSizeMetrics metrics = {Size(0,0), 0, true};
      |                                                        ^
./gemrb/core/GUI/TextSystem/TextContainer.cpp: In member function 'void GemRB::TextContainer::MoveCursorToPoint(const GemRB::Point&)':
./gemrb/core/GUI/TextSystem/TextContainer.cpp:775:56: error: missing initializer for member 'GemRB::Font::StringSizeMetrics::forceBreak' [-Werror=missing-field-initializers]
  775 |   Font::StringSizeMetrics metrics = {Size(0,0), 0, true};`
```
