### PR TITLE
Windows build tweaks

### DIFF
--- a/gemrb/includes/exports.h
+++ b/gemrb/includes/exports.h
@@ -65,6 +65,8 @@
 
 /// Disable silly MSVC warnings
 #if _MSC_VER >= 1000
+//  4267 disables the warnings related to conversion between size_t and other types 
+#	pragma warning( disable: 4267 )
 //	4251 disables the annoying warning about missing dll interface in templates
 #	pragma warning( disable: 4251 521 )
 #	pragma warning( disable: 4275 )

--- a/gemrb/plugins/GUIScript/GUIScript.h
+++ b/gemrb/plugins/GUIScript/GUIScript.h
@@ -23,6 +23,11 @@
 
 // NOTE: Python.h has to be included first.
 
+// This definition needs to be here to keep mingw happy with standard python.org packages
+#if _MINGW32_
+#define hypot _hypot
+#endif
+
 #if defined(WIN32) && defined(_DEBUG)
 #undef _DEBUG
 #include <Python.h>


### PR DESCRIPTION
I was having a bit of a headache trying to relearn to use git from a different approach via MSVC and github desktop. In the end I gave up and decided to just use the command line.

Only two conservative changes here, turns out only this and the one I PR'd previously were actually needed to stop either compilers aborting.

I am still figuring out what to do about the tweaks to cmake, something really strange is happening on my end with the vcpkg integration and I haven't worked out what it is yet. 

The only other thing I need to update after that is .gitignore, because MSVC puts a bunch of its own clutter in the source directory, Including a CmakeSettings.json that defaults to useless settings that I can't work out how to pre-emptively override....