### PR TITLE
[subviews] DirectoryIterator: prevents some unwanted behaviour on filter flags

### DIFF
--- a/gemrb/core/PluginLoader.cpp
+++ b/gemrb/core/PluginLoader.cpp
@@ -177,11 +177,15 @@ void LoadPlugins(const char* pluginpath)
 	const char* pluginExt = "so";
 #endif
 
-	dirIt.SetFilterPredicate(new ExtFilter(pluginExt));
+	dirIt.SetFlags(DirectoryIterator::Files);
+	dirIt.SetFilterPredicate(new ExtFilter(pluginExt)); // rewinds
 
 	typedef std::set<std::string> PathSet;
 	PathSet delayedPlugins;
-	dirIt.SetFlags(DirectoryIterator::Files);
+
+	if (!dirIt) {
+		return;
+	}
 
 	char path[_MAX_PATH];
 	do {

--- a/gemrb/plugins/DirectoryImporter/DirectoryImporter.cpp
+++ b/gemrb/plugins/DirectoryImporter/DirectoryImporter.cpp
@@ -121,7 +121,7 @@ void CachedDirectoryImporter::Refresh()
 	cache.clear();
 
 	DirectoryIterator it(path);
-	it.SetFlags(DirectoryIterator::Files);
+	it.SetFlags(DirectoryIterator::Files, true);
 	if (!it)
 		return;
 

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -4740,7 +4740,7 @@ static PyObject* GemRB_TextArea_ListResources(PyObject* self, PyObject* args)
 
 	int itflags = DirectoryIterator::Files;
 	itflags |= (dirs) ? DirectoryIterator::Directories : 0;
-	dirit.SetFlags(itflags);
+	dirit.SetFlags(itflags, true);
 
 	std::vector<std::string> strings;
 	if (dirit) {


### PR DESCRIPTION
Found three things that may result in crashes or unforeseen behaviour. One is the issue, the others look reasonable to address.

fixes #692

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code 
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
