### PR TITLE
Msvc tweaks: updated gitignore & most common compiler warning silenced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ xcuserdata
 /cmake_uninstall.cmake
 /CMakeCache.txt
 /build
+
+#MSVC generates these
+/.vs
+/CMakeSettings.json
+/out

--- a/gemrb/includes/exports.h
+++ b/gemrb/includes/exports.h
@@ -65,6 +65,8 @@
 
 /// Disable silly MSVC warnings
 #if _MSC_VER >= 1000
+//  4267 disables the warnings related to conversion between size_t and other types 
+#	pragma warning( disable: 4267 )
 //	4251 disables the annoying warning about missing dll interface in templates
 #	pragma warning( disable: 4251 521 )
 #	pragma warning( disable: 4275 )


### PR DESCRIPTION
This is the pull request I should have started with. I am still trying to do basic housekeeping, but I can't seem to manage to do anything without github desktop tripping over visual studio or vice versa. At least github desktop doesn't create a load of its own junk though. This should cover ignoring all the local stuff that MSVC creates.

I'll split that mingw tweak to another branch for my own sanity. I thought of another scenario which I hadn't thought of before as well, so I need to double check it is ok. Never imagined one line in one file would end up being so annoying...
