### PR TITLE
Fix learning memorizing spells for cleric spellbook in chargen

### DIFF
--- a/gemrb/GUIScripts/iwd/CharGen.py
+++ b/gemrb/GUIScripts/iwd/CharGen.py
@@ -347,8 +347,8 @@ def LearnSpells(MyChar):
 		Spellbook.SetupSpellLevels (MyChar, TableName, IE_SPELL_TYPE_PRIEST, 1)
 		Learnable = Spellbook.GetLearnablePriestSpells (ClassFlag, t, 1)
 		PriestMemorized = GemRB.GetVar ("PriestMemorized")
-		j = 1
-		while (PriestMemorized and PriestMemorized != 1<<(j-1)):
+		j = 0
+		while PriestMemorized and PriestMemorized != 1<<j:
 			j = j + 1
 		for i in range (len(Learnable) ):
 			GemRB.LearnSpell (MyChar, Learnable[i], 0)


### PR DESCRIPTION
## Description
This fixes #723. Spells were shifted by one, it was impossible to learn first as well.


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
