### PR TITLE
IWD: Don't open racial enemy selection window in chargen for druids

### DIFF
--- a/gemrb/GUIScripts/iwd/CharGen.py
+++ b/gemrb/GUIScripts/iwd/CharGen.py
@@ -1524,17 +1524,21 @@ def SkillsPress():
 	LUSkillsSelection.SkillsNullify (MyChar)
 
 	if SkillsState == 0:
-		GemRB.SetVar ("HatedRace", 0)
-		if IsThief!="*":
-			SkillsSelect()
-		elif DruidSpell!="*":
+		if DruidSpell != "*":
 			Skill = GemRB.LoadTable("SKILLRNG").GetValue(str(Level), "STEALTH")
 			GemRB.SetPlayerStat (MyChar, IE_STEALTH, Skill)
-			RacialEnemySelect()
-		elif IsBard!="*":
+		elif IsBard != "*":
 			Skill = GemRB.LoadTable(IsBard).GetValue(str(Level), "PICK_POCKETS")
 			GemRB.SetPlayerStat (MyChar, IE_PICKPOCKET, Skill)
-			SkillsState = 1
+
+		GemRB.SetVar ("HatedRace", 0)
+		GemRB.SetVar ("RacialEnemy", 0)
+		GemRB.SetVar ("RacialEnemyIndex", 0)
+		HateRace = CommonTables.ClassSkills.GetValue(ClassName, "HATERACE")
+		if HateRace != "*":
+			RacialEnemySelect()
+		elif IsThief != "*":
+			SkillsSelect()
 		else:
 			SkillsState = 1
 


### PR DESCRIPTION
## Description
As @lynxlynxlynx pointed out, druids shouldn't be able to select racial enemy.


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
