### PR TITLE
Animation: prevents first frame of new loop to remain for too long

### DIFF
--- a/gemrb/core/Animation.cpp
+++ b/gemrb/core/Animation.cpp
@@ -173,7 +173,6 @@ Sprite2D* Animation::NextFrame(void)
 			pos = 0;
 			endReached = true;
 		}
-		starttime = 0;
 	}
 	return ret;
 }


### PR DESCRIPTION
fixes #732

So when an animation loop overflows, `starttime` was reset to 0. From what I see, `starttime` is used to determine the timestamp of the last update of the frame counter. But when it is set to 0, this code https://github.com/gemrb/gemrb/blob/4831717a78b1e97cf1823138824b7494619143ed/gemrb/core/Animation.cpp#L133-L139
in the next frame request will make it look like "just now". So we have a whole cycle of pos 0 in addition as this line won't do anything then:

https://github.com/gemrb/gemrb/blob/4831717a78b1e97cf1823138824b7494619143ed/gemrb/core/Animation.cpp#L158

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission) :shrug: 
