### PR TITLE
GCC 10.1 fix in Windows iconv mapping

### DIFF
--- a/gemrb/core/CodepageToIconv.h
+++ b/gemrb/core/CodepageToIconv.h
@@ -21,6 +21,7 @@
 
 #include <array>
 #include <utility>
+#include <cstdint>
 
 namespace GemRB {
 


### PR DESCRIPTION
With GCC v10.1, this one can no longer be omitted here, obviously.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission) :shrug: 
