### PR TITLE
Include <clocale> to make MSVC happy with PR #650

### DIFF
--- a/gemrb/GemRB.cpp
+++ b/gemrb/GemRB.cpp
@@ -21,6 +21,7 @@
 // GemRB.cpp : Defines the entry point for the application.
 
 #include "win32def.h" // logging
+#include <clocale> //language encoding
 
 #include "Interface.h"
 


### PR DESCRIPTION
I was not able to build gemrb.cpp on VS2019 without including 'locale.h'

As per Brad's suggestion, using 'clocale' works fine

Without this, the set_locale function chokes the build as 'undefined'

I don't see any reason why it wouldn't work, but if someone throws me a Polish or German dialog(f).tlk set for any game I can verify it works for me.