### PR TITLE
BIFImporter: Memory mapped file reading

### DIFF
--- a/android/GEMRB_Android.mk
+++ b/android/GEMRB_Android.mk
@@ -158,6 +158,7 @@ LOCAL_SRC_FILES :=  main/gemrb/plugins/SAVImporter/SAVImporter.cpp \
 		    main/gemrb/core/System/String.cpp \
 		    main/gemrb/core/System/Logging.cpp \
 		    main/gemrb/core/System/FileStream.cpp \
+		    main/gemrb/core/System/MappedFileMemoryStream.cpp \
 		    main/gemrb/core/System/MemoryStream.cpp \
 		    main/gemrb/core/System/DataStream.cpp \
 		    main/gemrb/core/System/SlicedStream.cpp \

--- a/gemrb/core/CMakeLists.txt
+++ b/gemrb/core/CMakeLists.txt
@@ -130,6 +130,7 @@ FILE(GLOB gemrb_core_LIB_SRCS
 	Scriptable/PCStatStruct.cpp
 	System/DataStream.cpp
 	System/FileStream.cpp
+	System/MappedFileMemoryStream.cpp
 	System/MemoryStream.cpp
 	System/Logger.cpp
 	System/Logger/File.cpp

--- a/gemrb/core/FileCache.cpp
+++ b/gemrb/core/FileCache.cpp
@@ -22,6 +22,7 @@
 #include "Interface.h"
 #include "PluginMgr.h"
 #include "System/FileStream.h"
+#include "System/MappedFileMemoryStream.h"
 #include "System/VFS.h"
 
 namespace GemRB {
@@ -51,7 +52,7 @@ DataStream* CacheCompressedStream(DataStream *stream, const char* filename, int 
 	} else {
 		stream->Seek(length, GEM_CURRENT_POS);
 	}
-	return FileStream::OpenFile(path);
+	return new MappedFileMemoryStream{path};
 }
 
 }

--- a/gemrb/core/Makefile.am
+++ b/gemrb/core/Makefile.am
@@ -114,6 +114,7 @@ libgemrb_core_la_SOURCES = \
 	System/FileStream.cpp \
 	System/Logger.cpp \
 	System/Logging.cpp \
+	System/MappedFileMemoryStream.cpp \
 	System/MemoryStream.cpp \
 	System/SlicedStream.cpp \
 	System/String.cpp \

--- a/gemrb/core/System/MappedFileMemoryStream.cpp
+++ b/gemrb/core/System/MappedFileMemoryStream.cpp
@@ -1,0 +1,117 @@
+/* GemRB - Infinity Engine Emulator
+ * Copyright (C) 2020 The GemRB Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#include <cassert>
+
+#ifndef WIN32
+#include <sys/mman.h>
+#endif
+
+#include "MappedFileMemoryStream.h"
+#include "System/VFS.h"
+
+namespace GemRB {
+
+MappedFileMemoryStream::MappedFileMemoryStream(const std::string& fileName)
+	: MemoryStream(fileName.c_str(), nullptr, 0),
+		fileHandle(nullptr),
+		fileOpened(false),
+		fileMapped(false)
+{
+#ifdef WIN32
+	TCHAR t_name[MAX_PATH] = {0};
+	mbstowcs(t_name, fileName.c_str(), MAX_PATH - 1);
+
+	this->fileHandle =
+		CreateFile(
+			t_name,
+			GENERIC_READ,
+			FILE_SHARE_READ,
+			nullptr,
+			OPEN_EXISTING,
+			FILE_ATTRIBUTE_NORMAL,
+			nullptr
+		);
+	this->fileOpened = fileHandle != INVALID_HANDLE_VALUE;
+
+	if (fileOpened) {
+		LARGE_INTEGER fileSize;
+		GetFileSizeEx(fileHandle, &fileSize);
+		assert(fileSize.QuadPart <= ULONG_MAX);
+		size = static_cast<unsigned long>(fileSize.QuadPart);
+	}
+#else
+	this->fileHandle = fopen(fileName.c_str(), "rb");
+	this->fileOpened = fileHandle != nullptr;
+
+	if (fileOpened) {
+		struct stat statData{};
+		fstat(fileno(static_cast<FILE*>(fileHandle)), &statData);
+		this->size = statData.st_size;
+	}
+#endif
+
+	if (fileOpened) {
+		this->data = static_cast<char*>(readonly_mmap(fileHandle));
+		this->fileMapped = data != nullptr;
+	}
+}
+
+bool MappedFileMemoryStream::isOk() const {
+	return fileOpened && fileMapped;
+}
+
+DataStream* MappedFileMemoryStream::Clone() {
+	return new MappedFileMemoryStream(originalfile);
+}
+
+int MappedFileMemoryStream::Read(void* dest, unsigned int length) {
+	if (!fileMapped) {
+		return GEM_ERROR;
+	}
+
+	return MemoryStream::Read(dest, length);
+}
+
+int MappedFileMemoryStream::Seek(int pos, int startPos) {
+	if (!fileMapped) {
+		return GEM_ERROR;
+	}
+
+	return MemoryStream::Seek(pos, startPos);
+}
+
+int MappedFileMemoryStream::Write(const void*, unsigned int) {
+	return GEM_ERROR;
+}
+
+MappedFileMemoryStream::~MappedFileMemoryStream() {
+	if (fileMapped) {
+		munmap(data, size);
+	}
+
+	this->data = nullptr;
+
+	if (fileOpened) {
+#ifdef WIN32
+		CloseHandle(fileHandle);
+#else
+		fclose(static_cast<FILE*>(fileHandle));
+#endif
+	}
+}
+
+}

--- a/gemrb/core/System/MappedFileMemoryStream.h
+++ b/gemrb/core/System/MappedFileMemoryStream.h
@@ -1,0 +1,46 @@
+/* GemRB - Infinity Engine Emulator
+ * Copyright (C) 2020 The GemRB Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef MAPPED_FILE_MEMORY_STREAM_H
+#define MAPPED_FILE_MEMORY_STREAM_H
+
+#include "System/FileStream.h"
+#include "System/MemoryStream.h"
+
+namespace GemRB {
+
+class GEM_EXPORT MappedFileMemoryStream : public MemoryStream {
+	public:
+		MappedFileMemoryStream(const std::string& fileName);
+		~MappedFileMemoryStream();
+
+		bool isOk() const;
+
+		int Read(void* dest, unsigned int len) override;
+		int Seek(int pos, int startPos) override;
+		int Write(const void* src, unsigned int len) override;
+		DataStream* Clone() override;
+
+	private:
+		void *fileHandle;
+		bool fileOpened;
+		bool fileMapped;
+};
+
+}
+
+#endif

--- a/gemrb/core/System/MemoryStream.cpp
+++ b/gemrb/core/System/MemoryStream.cpp
@@ -27,7 +27,7 @@
 
 namespace GemRB {
 
-MemoryStream::MemoryStream(char *name, void* data, unsigned long size)
+MemoryStream::MemoryStream(const char *name, void* data, unsigned long size)
 	: data((char*)data)
 {
 	this->size = size;

--- a/gemrb/core/System/MemoryStream.h
+++ b/gemrb/core/System/MemoryStream.h
@@ -29,16 +29,16 @@ namespace GemRB {
 
 class GEM_EXPORT MemoryStream : public DataStream
 {
-private:
+protected:
 	char *data;
 public:
-	MemoryStream(char *name, void* data, unsigned long size);
+	MemoryStream(const char *name, void* data, unsigned long size);
 	~MemoryStream();
-	DataStream* Clone();
+	DataStream* Clone() override;
 
-	int Read(void* dest, unsigned int length);
-	int Write(const void* src, unsigned int length);
-	int Seek(int pos, int startpos);
+	int Read(void* dest, unsigned int length) override;
+	int Write(const void* src, unsigned int length) override;
+	int Seek(int pos, int startpos) override;
 };
 
 }

--- a/gemrb/core/System/VFS.cpp
+++ b/gemrb/core/System/VFS.cpp
@@ -47,6 +47,7 @@
 
 #ifndef WIN32
 #include <dirent.h>
+#include <sys/mman.h>
 #endif
 
 #ifdef __APPLE__
@@ -519,6 +520,44 @@ GEM_EXPORT char* CopyGemDataPath(char* outPath, ieWord maxLen)
 	return outPath;
 }
 
+#ifdef WIN32
+
+void* readonly_mmap(void *fd) {
+	HANDLE mappingHandle =
+		CreateFileMapping(
+			static_cast<HANDLE>(fd),
+			nullptr,
+			PAGE_READONLY,
+			0,
+			0,
+			nullptr
+		);
+
+	if (mappingHandle == nullptr) {
+		return nullptr;
+	}
+
+	void *start = MapViewOfFile(mappingHandle, FILE_MAP_READ, 0, 0, 0);
+	CloseHandle(mappingHandle);
+
+	return start;
+}
+
+void munmap(void *start, size_t) {
+	UnmapViewOfFile(start);
+}
+
+#else
+
+void* readonly_mmap(void *vfd) {
+	int fd = fileno(static_cast<FILE*>(vfd));
+	struct stat statData;
+	fstat(fd, &statData);
+
+	return mmap(nullptr, statData.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+}
+
+#endif
 
 DirectoryIterator::DirectoryIterator(const char *path)
 	: predicate(NULL), Directory(NULL), Entry(NULL)

--- a/gemrb/core/System/VFS.h
+++ b/gemrb/core/System/VFS.h
@@ -126,6 +126,11 @@ GEM_EXPORT char* CopyHomePath(char* outPath, ieWord maxLen);
 // default directory housing GUIScripts/Override/Unhardcoded
 GEM_EXPORT char* CopyGemDataPath(char* outPath, ieWord maxLen);
 
+void* readonly_mmap(void *fd);
+#ifdef WIN32
+void munmap(void *start, size_t);
+#endif
+
 class GEM_EXPORT DirectoryIterator {
 public:
 	typedef Predicate<const char*> FileFilterPredicate;


### PR DESCRIPTION
## Description
As discussed in #738, now the approach with mmap and its Windows counter part.

Reduces loading time up to 80%, can't even read some of the loading screen texts any more. Please try out!

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission) :shrug: 
