### PR TITLE
Substitution for VCPKG's dll placement script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,14 @@ OPTION(USE_PNG "Enable LibPNG support" ON)
 OPTION(USE_VORBIS "Enable Vorbis support" ON)
 OPTION(USE_ICONV "Enable Iconv support" ON)
 
+#VCPKG dll deployment is circumvented because it doesn't currently work for gemrb
+IF(WIN32 AND _VCPKG_INSTALLED_DIR)
+	OPTION(VCPKG_AUTO_DEPLOY "Fix VCPKG dependency DLL locations" ON)
+	# This variable disables the built in VCPKG deployment script,
+	# which makes copies of the DLL files in places they are not ever found by the game
+	SET(VCPKG_APPLOCAL_DEPS OFF)
+ENDIF()
+
 # try to extract the version from the source
 FILE(READ ${CMAKE_CURRENT_SOURCE_DIR}/gemrb/includes/globals.h GLOBALS)
 SET(GEMRB_VERSION "")

--- a/gemrb/CMakeLists.txt
+++ b/gemrb/CMakeLists.txt
@@ -133,3 +133,8 @@ CONFIGURE_FILE(
 )
 
 INSTALL( TARGETS gemrb DESTINATION ${BIN_DIR} )
+
+# optional script to help deploy dependencies when building with windows.
+IF(VCPKG_AUTO_DEPLOY)
+	INCLUDE(vcpkg_deps.cmake)
+ENDIF()

--- a/gemrb/vcpkg_deps.cmake
+++ b/gemrb/vcpkg_deps.cmake
@@ -1,0 +1,73 @@
+# MSVC VCPKG Dependency DLL script
+# The existing default behaviour when using VCPKG copies the DLL files to the wrong place
+# Because of the way that GemRB is split into plugins, VCPKG makes copies of the DLL files in the /plugins/ directory
+# There is no way to override the output directory without changing the layout which has existed from the beginning
+# So the VCPKG DLL helper script is disabled and substituted here
+
+# This does not autodetect anything, it just relies on an expected set of filenames if using Visual Studio+VCPKG libraries
+# If the dll files cannot be found here, nothing happens.
+
+MESSAGE(STATUS "")
+MESSAGE(STATUS "Configuring rules for VCPKG dependency deployment")
+
+# we either want SDL1 or 2, no need to copy both
+IF(SDL_BACKEND MATCHES SDL2)
+	SET (DLL_SDL_VER 2)
+ENDIF()
+
+IF(CMAKE_BUILD_TYPE MATCHES "Debug")
+	SET(DLL_SET_DBG "d") # all the debug dll's just have 'd' somewhere in the filename if they are different at all
+	SET(DLL_DIR "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/bin/")
+ELSE()
+	UNSET(DLL_SET_DBG)
+	SET(DLL_DIR "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/")
+ENDIF()
+
+# lists of dll files to be deployed to the build/install directory for Win32 builds
+LIST(APPEND DLL_SET
+
+	${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/SDL${DLL_SDL_VER}.dll # Cmake doesn't actually find the sdl debug libs
+
+	${DLL_DIR}OpenAL32.dll
+	${DLL_DIR}zlib${DLL_SET_DBG}1.dll
+	${DLL_DIR}vorbisfile.dll
+	${DLL_DIR}ogg.dll
+	${DLL_DIR}vorbis.dll
+	${DLL_DIR}libpng16${DLL_SET_DBG}.dll
+	${DLL_DIR}freetype${DLL_SET_DBG}.dll
+	${DLL_DIR}bz2${DLL_SET_DBG}.dll
+	${DLL_DIR}libiconv.dll )
+
+FOREACH(ENTRY IN LISTS DLL_SET)
+
+	IF(NOT EXISTS ${ENTRY})
+		LIST(REMOVE_ITEM DLL_SET ${ENTRY})
+		CONTINUE()
+	ENDIF()
+
+ENDFOREACH()
+
+ADD_CUSTOM_COMMAND(TARGET gemrb POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different
+	${DLL_SET}
+	${CMAKE_BINARY_DIR}/gemrb/)
+
+# if a user decides to install, they also need a copy of the dll in their game directory.
+INSTALL(FILES ${DLL_SET} DESTINATION ${BIN_DIR})
+
+# the ogg plugin doesn't actually find the vorbisfile-1.dll built by vcpkg
+# after checking dependencies with dumpbin, turns out it is looking for a vorbisfile.dll
+# this may be because the .lib file differs in name from the .dll file
+IF(EXISTS ${DLL_DIR}vorbisfile-1.dll )
+
+	ADD_CUSTOM_COMMAND(TARGET gemrb POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		${DLL_DIR}vorbisfile-1.dll
+		${CMAKE_BINARY_DIR}/gemrb/vorbisfile.dll)
+
+	INSTALL(FILES ${DLL_DIR}vorbisfile-1.dll DESTINATION ${BIN_DIR} RENAME vorbisfile.dll)
+
+ENDIF()
+
+MESSAGE(STATUS "Dependency DLL's will be copied to the build and install directory")
+MESSAGE(STATUS "Disable option VCPKG_AUTO_DEPLOY to skip this")


### PR DESCRIPTION
I am suggesting this patch only as temporary fix to the only gripe I have with the almost serendipitious "VCPKG" package manager for Visual Studio. 

To be completely fair, It is actually a really nice package manager that works in general like apt or pacman etc, and works really well up until the point that it.... well.. doesn't

Unfortunately, GemRB seems to be outside of the use cases they may have tested. It makes a grand and well considered effort to place dependency dll files where they should be found, but it unfortunately fails to satisfy GemRB because of the fact that its plugins are in a different directory to the executable file. 

This is a really basic workaround that copies expected dll file names to the target directory so that the game can at least run. 

In the back of my mind, I was trying to consider how to make a script that tries to find all dependencies and deploy them as necessary, but then I realised I was only trying to plug a leak, and I'm probably not qualified for that anyway.

Please pick fault with this PR if you find any. I've made enough variations on the theme that I am probably blind to mistakes by now. I would be mortified if I messed up anyone's build environment though.
