### PR TITLE
BG: disables mission pack button in menu when not installed

### DIFF
--- a/gemrb/GUIScripts/GameCheck.py
+++ b/gemrb/GUIScripts/GameCheck.py
@@ -20,7 +20,7 @@
 # GameCheck.py - functions to check GameType
 
 import GemRB
-from ie_restype import RES_WMP, RES_ARE
+from ie_restype import RES_WMP, RES_ARE, RES_2DA
 
 MAX_PARTY_SIZE = GemRB.GetVar ("MaxPartySize")
 
@@ -65,3 +65,6 @@ def HasBGT ():
 
 def HasTutu ():
 	return GemRB.HasResource ("fw0125", RES_ARE)
+
+def HasTOTSC ():
+	return GemRB.HasResource ("toscst", RES_2DA)

--- a/gemrb/GUIScripts/bg1/MessageWindow.py
+++ b/gemrb/GUIScripts/bg1/MessageWindow.py
@@ -22,7 +22,7 @@ import GUICommon
 import GUICommonWindows
 import CommonWindow
 import GUIClasses
-from GameCheck import MAX_PARTY_SIZE
+from GameCheck import MAX_PARTY_SIZE, HasTOTSC
 from GUIDefines import *
 from ie_restype import RES_2DA
 
@@ -145,5 +145,3 @@ def GameExpansion():
 	GemRB.UpdateWorldMap("WORLDMAP", "AR1000")
 	return
 
-def HasTOTSC ():
-	return GemRB.HasResource ("toscst", RES_2DA)

--- a/gemrb/GUIScripts/bg1/Start.py
+++ b/gemrb/GUIScripts/bg1/Start.py
@@ -18,6 +18,7 @@
 #
 import GemRB
 from GUIDefines import *
+from GameCheck import HasTOTSC
 
 StartWindow = 0
 QuitWindow = 0
@@ -74,11 +75,14 @@ def SinglePlayerPress():
 	ExitButton.SetText(15416)
 	MultiPlayerButton.SetEvent(IE_GUI_BUTTON_ON_PRESS, LoadSingle)
 	SinglePlayerButton.SetEvent(IE_GUI_BUTTON_ON_PRESS, NewSingle)
-	MoviesButton.SetEvent(IE_GUI_BUTTON_ON_PRESS, MissionPack)
 	ExitButton.SetEvent(IE_GUI_BUTTON_ON_PRESS, BackToMain)
 	ExitButton.SetFlags(IE_GUI_BUTTON_CANCEL, OP_OR)
-	if GemRB.GetString(24110) == "": # TODO: better way to detect lack of mission pack?
+	if HasTOTSC():
+		MoviesButton.SetEvent(IE_GUI_BUTTON_ON_PRESS, MissionPack)
+	else:
 		MoviesButton.SetFlags(IE_GUI_BUTTON_NO_IMAGE, OP_OR)
+		MoviesButton.SetStatus(IE_GUI_BUTTON_DISABLED)
+
 	return
 
 def MultiPlayerPress():


### PR DESCRIPTION
## Description
fixes #758 

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
