### PR TITLE
Moved a GUIFactory.h #include to appease Visual Studio

### DIFF
--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -72,7 +72,6 @@
 #include "GUI/Button.h"
 #include "GUI/Console.h"
 #include "GUI/EventMgr.h"
-#include "GUI/GUIFactory.h"
 #include "GUI/GameControl.h"
 #include "GUI/GUIScriptInterface.h"
 #include "GUI/Label.h"

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -35,6 +35,7 @@
 #include "GameData.h"
 #include "GUI/Tooltip.h"
 #include "GUI/Window.h"
+#include "GUI/GUIFactory.h"
 #include "Holder.h"
 #include "ImageMgr.h"
 #include "InterfaceConfig.h"
@@ -74,7 +75,6 @@ class Font;
 class Game;
 class GameControl;
 class GlobalTimer;
-class GUIFactory;
 class ITMExtHeader;
 class Image;
 class Item;


### PR DESCRIPTION
One more complaint from Visual Studio's compiler.

One less thing stopping subviews from building on VS2019.

This is all that was needed to close  #766 

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code [ no actual code here]
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
