### PR TITLE
Some tweaks to palette handling for MSVC

### DIFF
--- a/gemrb/core/CharAnimations.cpp
+++ b/gemrb/core/CharAnimations.cpp
@@ -395,7 +395,7 @@ void CharAnimations::SetupColors(PaletteType type)
 		*/
 		for (int i = 0; i < colorcount; i++) {
 			const auto& pal32 = core->GetPalette32(Colors[i]);
-			palette[PAL_MAIN]->CopyColorRange(pal32.begin(), pal32.end(), dest);			
+			palette[PAL_MAIN]->CopyColorRange(&pal32[0], &pal32[32], dest);			
 			dest +=size;
 		}
 

--- a/gemrb/core/Palette.cpp
+++ b/gemrb/core/Palette.cpp
@@ -119,7 +119,7 @@ void Palette::SetupPaperdollColours(const ieDword* Colors, unsigned int type)
 
 	for (uint8_t idx = METAL; idx < END; ++idx) {
 		const auto& pal16 = core->GetPalette16(Colors[idx]>>s);
-		CopyColorRange(pal16.begin(), &pal16[numCols], 0x04 + (idx*12));
+		CopyColorRange(&pal16[0], &pal16[numCols], 0x04 + (idx*12));
 	}
 	
 	//minor

--- a/gemrb/core/ScriptedAnimation.cpp
+++ b/gemrb/core/ScriptedAnimation.cpp
@@ -490,7 +490,7 @@ void ScriptedAnimation::SetPalette(int gradient, int start)
 
 	constexpr int PALSIZE = 12;
 	const auto& pal16 = core->GetPalette16(gradient);
-	palette->CopyColorRange(pal16.begin(), &pal16[PALSIZE], start);
+	palette->CopyColorRange(&pal16[0], &pal16[PALSIZE], start);
 
 	if (twin) {
 		twin->SetPalette(gradient, start);

--- a/gemrb/core/WorldMap.cpp
+++ b/gemrb/core/WorldMap.cpp
@@ -83,7 +83,7 @@ void WMPAreaEntry::SetPalette(int gradient, Sprite2D* MapIcon)
 {
 	if (!MapIcon) return;
 	const auto& colors = core->GetPalette256(gradient);
-	MapIcon->SetPalette(new Palette(colors.begin(), colors.end()));
+	MapIcon->SetPalette(new Palette(&colors[0], &colors[256]));
 }
 
 Sprite2D *WMPAreaEntry::GetMapIcon(AnimationFactory *bam, bool overridePalette)

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -3595,7 +3595,7 @@ static PyObject* SetButtonBAM(Button* btn, const char *ResRef, int CycleIndex, i
 
 		Palette* newpal = Picture->GetPalette()->Copy();
 		const auto& pal16 = core->GetPalette16(col1);
-		newpal->CopyColorRange(pal16.begin(), &pal16[12], 4);
+		newpal->CopyColorRange(&pal16[0],&pal16[12], 4);
 		Picture->SetPalette( newpal );
 		newpal->release();
 	}


### PR DESCRIPTION
Related to the discussion in #767 , this allows compilation of some recent palette handling changes that work for gcc/clang but not for 'cl.exe'

This is the last blocking issue for the building this dev branch on Windows 

Tested on Torment and Icewind Dale. I would have tested on BG1/2 as well, but I stupidly forgot that I only have a disc version when I was tidying up files last, and I haven't had a CD/DVD drive for at least 10 years