### PR TITLE
Actor.cpp: avoid trying to use null 'anims'

### DIFF
--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -7811,7 +7811,7 @@ void Actor::UpdateActorState()
 			}
 		}
 
-		if (anims[0]->endReached == false) {
+		if (anims && anims[0]->endReached == false) {
 			//check if walk sounds need to be played
 			//dialog, pause game
 			if (!(core->GetGameControl()->GetDialogueFlags()&(DF_IN_DIALOG|DF_FREEZE_SCRIPTS) ) ) {


### PR DESCRIPTION
Fixes crash from #797

As mentioned in that issue, it seems to just be a symptom of the incomplete PST animation code