### PR TITLE
PST: Patch for Critical hit/miss annoyance #824

### DIFF
--- a/gemrb/unhardcoded/pst/vcremap.2da
+++ b/gemrb/unhardcoded/pst/vcremap.2da
@@ -7,3 +7,5 @@ SELR3     65            37
 SELR4     66            38
 RESP1     59            58      no second hostile response
 RESP2     60            58      no third hostile response
+CRITMISS  65            90      remap from pst rare select 3
+CRITHIT   66            91      remap from pst rare select 4


### PR DESCRIPTION

This fixes the annoyance of critical hits/misses playing the rare select 3/4 sounds #824

That side issue can then be closed, while the larger issue is pending.

Indexes 90/91 were simply picked as entries that seem have no existing usages in the cre data, no other particular reason, they could be subject to change as needed


- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
