### PR TITLE
PST: TNO Avatar Reassignment is using the wrong table row

### DIFF
--- a/gemrb/GUIScripts/GUICommonWindows.py
+++ b/gemrb/GUIScripts/GUICommonWindows.py
@@ -1290,7 +1290,7 @@ def UpdateAnimation ():
 
 	BioTable = GemRB.LoadTable ("BIOS")
 	Specific = GemRB.GetPlayerStat (pc, IE_SPECIFIC)
-	AvatarName = BioTable.GetRowName (Specific+1)
+	AvatarName = BioTable.GetRowName (Specific)
 	AnimTable = GemRB.LoadTable ("ANIMS")
 	if animid=="":
 		animid="*"


### PR DESCRIPTION
BioTable.GetRowName (Specific+1) was returning VHAILOR

Deleting a single character is enough to close #522

Whoops.