### PR TITLE
pst/guirec: increase maxhp before current hp

### DIFF
--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -854,10 +854,10 @@ def AcceptLevelUp():
 	GemRB.SetPlayerStat (pc, IE_SAVEVSPOLY, SavThrows[2])
 	GemRB.SetPlayerStat (pc, IE_SAVEVSBREATH, SavThrows[3])
 	GemRB.SetPlayerStat (pc, IE_SAVEVSSPELL, SavThrows[4])
-	oldhp = GemRB.GetPlayerStat (pc, IE_HITPOINTS, 1)
-	GemRB.SetPlayerStat (pc, IE_HITPOINTS, HPGained+oldhp)
 	oldhp = GemRB.GetPlayerStat (pc, IE_MAXHITPOINTS, 1)
 	GemRB.SetPlayerStat (pc, IE_MAXHITPOINTS, HPGained+oldhp)
+	oldhp = GemRB.GetPlayerStat (pc, IE_HITPOINTS, 1)
+	GemRB.SetPlayerStat (pc, IE_HITPOINTS, HPGained+oldhp)
 	#increase weapon proficiency if needed
 	if WeapProfType!=-1:
 		GemRB.SetPlayerStat (pc, WeapProfType, CurrWeapProf + WeapProfGained )


### PR DESCRIPTION
This fixes one small item from #825

When you level up, your total hitpoint limit is increased, but you are shortchanged being given the new HP because they are updated in the wrong order.

Only 60 more to go!