### PR TITLE
PST Worldmapping: Fall back to regular area travel if worldmap is not allowed

### DIFF
--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -1937,6 +1937,12 @@ static std::map<std::string, std::vector<std::string>> pstWMapExits {
 // has to be a plain travel region and on the whitelist
 bool GameControl::ShouldTriggerWorldMap(const Actor *pc) const
 {
+
+	//if we havent reached the key area, we need return false to allow regular travel instead
+	Scriptable* Sender = (Scriptable*)pc;
+	bool keyAreaVisited = core->HasFeature(GF_TEAM_MOVEMENT) && CheckVariable(Sender, "AR0500_Visited", "GLOBAL") == 1;
+	if (!keyAreaVisited) return false;
+
 	if (!core->HasFeature(GF_TEAM_MOVEMENT)) return false;
 
 	bool teamMoved = (pc->GetInternalFlag() & IF_USEEXIT) && overInfoPoint && overInfoPoint->Type == ST_TRAVEL;


### PR DESCRIPTION
This is for #830

From the way I read it, the only thing going wrong here is that the "ShouldDoWorldMapping" check should return false if you haven't reached AR0500, because before that point, that's actually exactly the case.

What I think is happening is that the check is returning a false positive, i.e. it is saying "yes you can use the worldmap here", and then somewhere else is ignoring that and not allowing access to the worldmap, because it knows that is not true. 

So as a consequence, before you 'unlock' the worldmap, nothing actually happens when you click the map edge travel regions.

When you force the check to be false before AR0500, then all of the screen edges just behave like normal exits.  Then after reaching ar0500 they automatically adopt the new behavior. I don't even have do do anything specific, just "mta("ar0500") is enough, and that exactly matches the bottleneck from the original game that you have to pass through. (its kind of tricky to test though, cos if you warp into the wrong place the cutscene won't play out)

Areas like Baator, Carceri, Curst etc are unaffected by this, because none of those have exits that would trigger the worldmap in any case. They are just like 'room to room' transitions.

I have a really chronic lack of experience modding IE games, so I am never 100% sure what I should be looking at, but all of the edge transition exits in the hive do actually seem to have proper entrance points that work and are fine to use.