### PR TITLE
pst/MessageWindow.py: PortraitPosition variable was missing

### DIFF
--- a/gemrb/GUIScripts/pst/MessageWindow.py
+++ b/gemrb/GUIScripts/pst/MessageWindow.py
@@ -61,7 +61,8 @@ def OnLoad():
 	GemRB.SetVar ("OptionsPosition", 1) #Bottom
 	GemRB.SetVar ("MessagePosition", 1) #Bottom
 	GemRB.SetVar ("OtherPosition", 0) #Left
-	
+	GemRB.SetVar ("PortraitPosition", 1)
+
 	GemRB.GameSetScreenFlags (0, OP_SET)
 	
 	CloseButton= MessageWindow.GetControl (0)


### PR DESCRIPTION
GameControl checks this variable every time the 'hidegui' function is run, causing it to complain

This has been mildly irritating/baffling me. I can't seem to work out how it is used, but without this, there are constant Error complaints in the log:

``` [GameControl/ERROR]: Invalid window or position: PortraitPosition:4 ```

This commit was enough to quiet them, but is it correct? I am assuming "1" is the lower position

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
