### PR TITLE
PST: Make sure the information panels pause the game

### DIFF
--- a/gemrb/GUIScripts/pst/GUIINV.py
+++ b/gemrb/GUIScripts/pst/GUIINV.py
@@ -35,6 +35,7 @@ from ie_slots import *
 InventoryWindow = None
 ItemAmountWindow = None
 OverSlot = None
+PauseState = None
 
 def OpenInventoryWindowClick ():
 	tmp = GemRB.GetVar ("PressedPortrait")
@@ -69,7 +70,7 @@ def OpenInventoryWindow ():
 	"""Opens the inventory window."""
 
 	global AvSlotsTable
-	global InventoryWindow
+	global InventoryWindow, PauseState
 
 	AvSlotsTable = GemRB.LoadTable ('avslots')
 
@@ -82,7 +83,11 @@ def OpenInventoryWindow ():
 		GemRB.SetVar ("MessageLabel", -1)
 		GUICommonWindows.SetSelectionChangeHandler (None)
 		GemRB.UnhideGUI ()
-		return
+		GemRB.GamePause (PauseState, 3)
+		return	
+
+	PauseState = GemRB.GamePause (3, 1)
+	GemRB.GamePause (1, 3)
 
 	GemRB.HideGUI ()
 	GemRB.LoadWindowPack ("GUIINV")

--- a/gemrb/GUIScripts/pst/GUIJRNL.py
+++ b/gemrb/GUIScripts/pst/GUIJRNL.py
@@ -58,10 +58,12 @@ global BeastImage
 BeastImage = None
 StartTime = 0
 
+PauseState = None
+
 ###################################################
 def OpenJournalWindow ():
 	global JournalWindow, PortraitWindow, ActionsWindow
-	global StartTime
+	global StartTime, PauseState
 
 	Table = GemRB.LoadTable("YEARS")
 	StartTime = Table.GetValue("STARTTIME", "VALUE")
@@ -84,7 +86,11 @@ def OpenJournalWindow ():
 
 		GUICommon.GameWindow.SetVisible (WINDOW_VISIBLE)
 		GemRB.UnhideGUI ()
-		return
+		GemRB.GamePause (PauseState, 3)
+		return	
+
+	PauseState = GemRB.GamePause (3, 1)
+	GemRB.GamePause (1, 3)
 		
 	GemRB.HideGUI ()
 	GemRB.LoadWindowPack ("GUIJRNL")

--- a/gemrb/GUIScripts/pst/GUIMG.py
+++ b/gemrb/GUIScripts/pst/GUIMG.py
@@ -33,9 +33,10 @@ MageWindow = None
 MageSpellInfoWindow = None
 MageSpellLevel = 0
 MageSpellUnmemorizeWindow = None
+PauseState = None
 
 def OpenMageWindow ():
-	global MageWindow
+	global MageWindow, PauseState
 
 	if GUICommon.CloseOtherWindow (OpenMageWindow):
 		GemRB.HideGUI ()
@@ -47,7 +48,11 @@ def OpenMageWindow ():
 		GUICommonWindows.SetSelectionChangeHandler (None)
 		GUICommon.GameWindow.SetVisible (WINDOW_VISIBLE)
 		GemRB.UnhideGUI ()
-		return
+		GemRB.GamePause (PauseState, 3)
+		return	
+
+	PauseState = GemRB.GamePause (3, 1)
+	GemRB.GamePause (1, 3)
 		
 	GemRB.HideGUI ()
 	GemRB.LoadWindowPack ("GUIMG")

--- a/gemrb/GUIScripts/pst/GUIPR.py
+++ b/gemrb/GUIScripts/pst/GUIPR.py
@@ -34,10 +34,10 @@ PriestWindow = None
 PriestSpellInfoWindow = None
 PriestSpellLevel = 0
 PriestSpellUnmemorizeWindow = None
-
+PauseState = None
 
 def OpenPriestWindow ():
-	global PriestWindow
+	global PriestWindow, PauseState
 
 	if GUICommon.CloseOtherWindow (OpenPriestWindow):
 		GemRB.HideGUI ()
@@ -49,7 +49,11 @@ def OpenPriestWindow ():
 		GUICommonWindows.SetSelectionChangeHandler (None)
 		GUICommon.GameWindow.SetVisible (WINDOW_VISIBLE)
 		GemRB.UnhideGUI ()
-		return
+		GemRB.GamePause (PauseState, 3)
+		return	
+
+	PauseState = GemRB.GamePause (3, 1)
+	GemRB.GamePause (1, 3)
 		
 	GemRB.HideGUI ()
 	GemRB.LoadWindowPack ("GUIPR")

--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -78,11 +78,13 @@ LevelUpWindow = None
 RecordsWindow = None
 InformationWindow = None
 BiographyWindow = None
+PauseState = None
 
 ###################################################
 def OpenRecordsWindow ():
 	global RecordsWindow
 	global StatTable
+	global PauseState
 
 	StatTable = GemRB.LoadTable("abcomm")
 	
@@ -97,7 +99,11 @@ def OpenRecordsWindow ():
 		GUICommonWindows.SetSelectionChangeHandler (None)
 
 		GemRB.UnhideGUI ()
+		GemRB.GamePause (PauseState, 3)
 		return	
+
+	PauseState = GemRB.GamePause (3, 1)
+	GemRB.GamePause (1, 3)
 
 	GemRB.HideGUI ()
 	GemRB.LoadWindowPack ("GUIREC")


### PR DESCRIPTION
While working on level up, I got sidetracked by a mild annoyance...

Unlike the original game, the information panels don't currently set the pause state when they are open, so you often get interrupted by any event that happens while you are looking at them.

I couldn't think of any good reason why you would actually want time to pass while reading the record sheet, leveling up, reading the journal/bestiary, changing mage spells etc, it's basically just really easy to forget the game is running until whatever you are doing is rudely aborted.

I used the method already in GUIOPT, so that the panels do not unpause the game, if the game was paused already when opened.

I excluded the map, because I thought being able to watch the party traverse the map in real time is a positive change.


- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
