### PR TITLE
Optionally use system encoding in QueryText

### DIFF
--- a/gemrb/GUIScripts/iwd/CharGen.py
+++ b/gemrb/GUIScripts/iwd/CharGen.py
@@ -2709,12 +2709,12 @@ def ImportDonePress():
 	global CharGenState, SkillsState, Portrait, ImportedChar, HasStrExtra
 
 	# Import the character from the chosen name
-	GemRB.CreatePlayer (CharImportList.QueryText(), MyChar|0x8000, 1)
+	GemRB.CreatePlayer (CharImportList.QueryText(True), MyChar|0x8000, 1)
 
-	GemRB.SetToken ("CHARNAME", GemRB.GetPlayerName (MyChar) )
-	GemRB.SetToken ("SmallPortrait", GemRB.GetPlayerPortrait (MyChar, 1) )
+	GemRB.SetToken ("CHARNAME", GemRB.GetPlayerName (MyChar))
+	GemRB.SetToken ("SmallPortrait", GemRB.GetPlayerPortrait (MyChar, 1))
 	PortraitName = GemRB.GetPlayerPortrait (MyChar, 0)
-	GemRB.SetToken ("LargePortrait", PortraitName )
+	GemRB.SetToken ("LargePortrait", PortraitName)
 	PortraitButton.SetPicture (PortraitName, "NOPORTLG")
 	Portrait = -1
 


### PR DESCRIPTION
## Description
This solves #764. I've added optional boolean parameter to QueryText(), my only concern is whether it should be positional argument, or keyword one. Initially, I wanted to use keyword one, but that requires changing method signature, and I run into issues [here](https://github.com/gemrb/gemrb/blob/5b0cf79e5d388f718585b96586535c1fe5970fb2/gemrb/plugins/GUIScript/GUIScript.cpp#L15801), so I would have add another macro that would cast it to PyCFunction, as it is described [here](https://docs.python.org/2/extending/extending.html#keyword-parameters-for-extension-functions), I suppose. Current `METHOD` macro expects PyCFunction, not PyCFunctionWithKeywords. Do you think positional optional argument is fine, or it should be keyword one, which would require a little more work?

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
