### PR TITLE
Pathfinder robustness upgrade

### DIFF
--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -2026,7 +2026,7 @@ unsigned int Map::GetBlockedInLine(const Point &s, const Point &d, bool stopOnIm
 		NormalizeDeltas(dx, dy, factor);
 		p.x += dx;
 		p.y += dy;
-		int blockStatus = GetBlockedInRadius(p.x, p.y, caller ? caller->size : 0, stopOnImpassable);
+		int blockStatus = GetBlockedNavmap(p.x, p.y);
 		if (stopOnImpassable && blockStatus == PATH_MAP_IMPASSABLE) {
 			return PATH_MAP_IMPASSABLE;
 		}

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -2022,7 +2022,7 @@ unsigned int Map::GetBlockedInLine(const Point &s, const Point &d, bool stopOnIm
 	while (p != d) {
 		double dx = d.x - p.x;
 		double dy = d.y - p.y;
-		double factor = caller ? double(gamedata->GetStepTime()) / double(caller->speed) : 1;
+		double factor = caller && caller->speed ? double(gamedata->GetStepTime()) / double(caller->speed) : 1;
 		NormalizeDeltas(dx, dy, factor);
 		p.x += dx;
 		p.y += dy;

--- a/gemrb/core/PathFinder.cpp
+++ b/gemrb/core/PathFinder.cpp
@@ -266,6 +266,10 @@ PathNode *Map::FindPath(const Point &s, const Point &d, unsigned int size, unsig
 		// but stop just before it
 		AdjustPositionNavmap(nmptDest);
 	}
+	if (!(GetBlockedInRadius(nmptDest.x, nmptDest.y, size) & PATH_MAP_PASSABLE)) {
+		Log(DEBUG, "FindPath", "%s can't fit in destination", caller ? caller->GetName(0) : "nullptr");
+		return nullptr;
+	}
 	if (nmptDest == nmptSource) return nullptr;
 	SearchmapPoint smptSource(nmptSource.x / 16, nmptSource.y / 12);
 	SearchmapPoint smptDest(nmptDest.x / 16, nmptDest.y / 12);

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -5168,6 +5168,7 @@ void Actor::SetMap(Map *map)
 {
 	//Did we have an area?
 	bool effinit=!GetCurrentArea();
+	if (area && BlocksSearchMap()) area->ClearSearchMapFor(this);
 	//now we have an area
 	Scriptable::SetMap(map);
 	//unless we just lost it, in that case clear up some fields and leave
@@ -5216,6 +5217,7 @@ void Actor::SetMap(Map *map)
 		inventory.EquipItem(inventory.GetEquippedSlot());
 		SetEquippedQuickSlot(inventory.GetEquipped(), inventory.GetEquippedHeader());
 	}
+	if (BlocksSearchMap()) map->BlockSearchMap(Pos, size, IsPartyMember() ? PATH_MAP_PC : PATH_MAP_NPC);
 }
 
 // Position should be a navmap point

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -2345,7 +2345,7 @@ void Movable::WalkTo(const Point &Des, int distance)
 	prevTicks = Ticks;
 	Destination = Des;
 
-	if (std::abs(Des.x - Pos.x) <= XEPS && std::abs(Des.y - Pos.y) <= YEPS) {
+	if (Pos.x / 16 == Des.x / 16 && Pos.y / 12 == Des.y / 12) {
 		ClearPath(true);
 		return;
 	}

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -2257,7 +2257,7 @@ void Movable::DoStep(unsigned int walkScale, ieDword time) {
 		}
 		if (BlocksSearchMap() && actorInTheWay && actorInTheWay != this && actorInTheWay->BlocksSearchMap()) {
 			// Give up instead of bumping if you are close to the goal
-			if (!(step->Next) && std::abs(nmptStep.x - Pos.x) < XEPS * 3 && std::abs(nmptStep.y - Pos.y) < YEPS * 3) {
+			if (!(step->Next) && std::abs(nmptStep.x - Pos.x) < XEPS && std::abs(nmptStep.y - Pos.y) < YEPS) {
 				ClearPath(true);
 				NewOrientation = Orientation;
 				return;

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -2335,7 +2335,7 @@ void Movable::AddWayPoint(const Point &Des)
 void Movable::WalkTo(const Point &Des, int distance)
 {
 
-	if (Ticks < prevTicks + 2) {
+	if (prevTicks && Ticks < prevTicks + 2) {
 		return;
 	}
 

--- a/gemrb/core/Scriptable/Scriptable.h
+++ b/gemrb/core/Scriptable/Scriptable.h
@@ -468,6 +468,7 @@ private: //these seem to be sensitive, so get protection
 	PathNode* step; //actual step
 	unsigned int prevTicks;
 	int bumpBackTries;
+	bool pathAbandoned;
 protected:
 	ieDword timeStartStep;
 	//the # of previous tries to pick up a new walkpath

--- a/gemrb/core/Scriptable/Scriptable.h
+++ b/gemrb/core/Scriptable/Scriptable.h
@@ -457,8 +457,8 @@ public:
 };
 
 class GEM_EXPORT Movable : public Selectable {
-	const int XEPS = 32;
-	const int YEPS = 12;
+	const int XEPS = 72;
+	const int YEPS = 36;
 private: //these seem to be sensitive, so get protection
 	unsigned char StanceID;
 	unsigned char Orientation, NewOrientation;


### PR DESCRIPTION
## Description

- Makes `IsWalkableTo` only check points directly on the line, leaving the caller the burden of checking for tight spaces. `FindPath` does this (`PathFinder.cpp:321`), `RunAway` calls `FindPath`, my `RandomWalk` never cared about LOS and just leaves the burden to `Movable::DoStep`. 
- Makes `Actor::SetMap` block the searchmap when appropriate. 
- Makes `Movable::WalkTo` check if the path has just been abandoned. Fixes #893.
- Makes `Map::FindPath` not try to path to places that are too small to fit. Fixes #890 .
- Allows for calling `Movable::WalkTo` with `prevTicks == 0`, i.e. if `Ticks` hasn't been updated yet
- Adds check for zero `speed` to `Map::GetBlockedInLine`. Fixes other bug mentioned in #893.
- Makes `Movable::WalkTo` give up at a smaller distance. Fixes #900 .

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary (N/A)
- [x] The proposed change builds also on our build bots (check after submission)
