### PR TITLE
Movable: Minor bugfixes

### DIFF
--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -2338,9 +2338,8 @@ void Movable::AddWayPoint(const Point &Des)
 // Therefore it's rate-limited to avoid actors being stuck as they keep pathfinding
 void Movable::WalkTo(const Point &Des, int distance)
 {
-
-	Log(DEBUG, "WalkTo", "%s %d %d", GetName(0), Des.x, Des.y);
-	if (prevTicks && Ticks < prevTicks + 2) {
+	// Only rate-limit when moving
+	if ((GetPath() || InMove()) && prevTicks && Ticks < prevTicks + 2) {
 		return;
 	}
 
@@ -2357,7 +2356,6 @@ void Movable::WalkTo(const Point &Des, int distance)
 
 	if (Pos.x / 16 == Des.x / 16 && Pos.y / 12 == Des.y / 12) {
 		ClearPath(true);
-		SetOrientation(GetOrient(Des, Pos), true);
 		return;
 	}
 

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -2277,7 +2277,6 @@ void Movable::DoStep(unsigned int walkScale, ieDword time) {
 		if (BlocksSearchMap() && area->GetBlockedNavmap(Pos.x + dx, Pos.y + dy) & PATH_MAP_SIDEWALL) {
 			ClearPath(true);
 			NewOrientation = Orientation;
-			pathAbandoned = true;
 			return;
 		}
 		if (BlocksSearchMap()) {


### PR DESCRIPTION
## Description
- Makes `Movable::DoStep` not abandon path when stopping because of a door: actors should try and re-path, if possible.
- Makes `Movable::WalkTo` only be rate-limited while moving, since the purpose of rate-limiting is avoiding actors being stuck on a moving target.


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary N/A
- [x] The proposed change builds also on our build bots (check after submission)
