### PR TITLE
Refactor Actor::CalculateSpeed (WIP)

### DIFF
--- a/gemrb/core/Inventory.cpp
+++ b/gemrb/core/Inventory.cpp
@@ -160,7 +160,7 @@ void Inventory::AddItem(CREItem *item)
 	CalculateWeight();
 }
 
-void Inventory::CalculateWeight() const
+void Inventory::CalculateWeight()
 {
 	Weight = 0;
 	for (size_t i = 0; i < Slots.size(); i++) {
@@ -1500,8 +1500,6 @@ void Inventory::dump(StringBuffer& buffer) const
 	}
 
 	buffer.appendFormatted("Equipped: %d       EquippedHeader: %d\n", Equipped, EquippedHeader);
-	Changed = true;
-	CalculateWeight();
 	buffer.appendFormatted( "Total weight: %d\n", Weight );
 }
 

--- a/gemrb/core/Inventory.cpp
+++ b/gemrb/core/Inventory.cpp
@@ -94,7 +94,6 @@ Inventory::Inventory()
 {
 	Owner = NULL;
 	InventoryType = INVENTORY_HEAP;
-	Changed = false;
 	Weight = 0;
 	Equipped = IW_NO_EQUIPPED;
 	EquippedHeader = 0;
@@ -139,7 +138,6 @@ void Inventory::CopyFrom(const Actor *source)
 	Equipped = source->inventory.GetEquipped();
 	EquippedHeader = source->inventory.GetEquippedHeader();
 
-	Changed = true;
 	CalculateWeight();
 }
 
@@ -151,7 +149,7 @@ CREItem *Inventory::GetItem(unsigned int slot)
 	}
 	CREItem *item = Slots[slot];
 	Slots.erase(Slots.begin()+slot);
-	Changed = true;
+	CalculateWeight();
 	return item;
 }
 
@@ -159,14 +157,11 @@ void Inventory::AddItem(CREItem *item)
 {
 	if (!item) return; //invalid items get no slot
 	Slots.push_back(item);
-	Changed = true;
+	CalculateWeight();
 }
 
 void Inventory::CalculateWeight() const
 {
-	if (!Changed) {
-		return;
-	}
 	Weight = 0;
 	for (size_t i = 0; i < Slots.size(); i++) {
 		CREItem *slot = Slots[i];
@@ -195,7 +190,10 @@ void Inventory::CalculateWeight() const
 			Weight += slot->Weight * ((slot->Usages[0] && slot->MaxStackAmount) ? slot->Usages[0] : 1);
 		}
 	}
-	Changed = false;
+
+	if (Owner) {
+		Owner->SetBase(IE_ENCUMBRANCE, Weight);
+	}
 }
 
 void Inventory::AddSlotEffects(ieDword index)
@@ -351,7 +349,8 @@ void Inventory::KillSlot(unsigned int index)
 	}
 
 	Slots[index] = NULL;
-	Changed = true;
+	CalculateWeight();
+
 	int effect = core->QuerySlotEffects( index );
 	if (!effect) {
 		return;
@@ -463,7 +462,7 @@ unsigned int Inventory::DestroyItem(const char *resref, ieDword flags, ieDword c
 			continue;
 		}
 		//we need to acknowledge that the item was destroyed
-		//use unequip stuff, decrease encumbrance etc,
+		//use unequip stuff etc,
 		//until that, we simply erase it
 		ieDword removed;
 
@@ -485,7 +484,7 @@ unsigned int Inventory::DestroyItem(const char *resref, ieDword flags, ieDword c
 		if (count && (destructed>=count) )
 			break;
 	}
-	if (Changed && Owner && Owner->InParty) displaymsg->DisplayConstantString(STR_LOSTITEM, DMC_BG2XPGREEN);
+	if (destructed && Owner && Owner->InParty) displaymsg->DisplayConstantString(STR_LOSTITEM, DMC_BG2XPGREEN);
 
 	return destructed;
 }
@@ -512,7 +511,7 @@ CREItem *Inventory::RemoveItem(unsigned int slot, unsigned int count)
 	CREItem *returned = new CREItem(*item);
 	item->Usages[0]-=count;
 	returned->Usages[0]=(ieWord) count;
-	Changed = true;
+	CalculateWeight();
 	return returned;
 }
 
@@ -553,10 +552,11 @@ void Inventory::SetSlotItem(CREItem* item, unsigned int slot)
 		InvalidSlot(slot);
 		return;
 	}
-	Changed = true;
 
 	delete Slots[slot];
 	Slots[slot] = item;
+
+	CalculateWeight();
 
 	//update the action bar next time
 	if (Owner->IsSelected()) {
@@ -665,7 +665,6 @@ int Inventory::AddStoreItem(STOItem* item, int action)
 		}
 		item->PurchasedAmount--;
 	}
-	CalculateWeight();
 	return ret;
 }
 
@@ -1409,7 +1408,6 @@ void Inventory::AddSlotItemRes(const ieResRef ItemResRef, int SlotID, int Charge
 				delete TmpItem;
 			}
 		}
-		CalculateWeight();
 	} else {
 		delete TmpItem;
 	}
@@ -1428,7 +1426,6 @@ void Inventory::SetSlotItemRes(const ieResRef ItemResRef, int SlotID, int Charge
 		//if the item isn't creatable, we still destroy the old item
 		KillSlot( SlotID );
 	}
-	CalculateWeight();
 }
 
 ieWord Inventory::GetShieldItemType() const
@@ -1927,8 +1924,8 @@ int Inventory::MergeItems(int slot, CREItem *item)
 		slotitem->Flags |= IE_INV_ITEM_ACQUIRED;
 		slotitem->Usages[0] = (ieWord) (slotitem->Usages[0] + chunk);
 		item->Usages[0] = (ieWord) (item->Usages[0] - chunk);
-		Changed = true;
 		EquipItem(slot);
+		CalculateWeight();
 		if (item->Usages[0] == 0) {
 			delete item;
 			return ASI_SUCCESS;

--- a/gemrb/core/Inventory.h
+++ b/gemrb/core/Inventory.h
@@ -212,10 +212,8 @@ private:
 	std::vector<CREItem*> Slots;
 	Actor* Owner;
 	int InventoryType;
-	/// Flag indicating whether weight needs to be recalculated
-	mutable int Changed;
 	/** Total weight of all items in Inventory */
-	mutable int Weight;
+	int Weight;
 
 	ieWordSigned Equipped;
 	ieWord EquippedHeader;
@@ -243,7 +241,6 @@ public:
 	 * flags: see ieCREItemFlagBits */
 	bool HasItem(const char *resref, ieDword flags) const;
 
-	void CalculateWeight(void) const;
 	void SetInventoryType(int arg);
 	void SetOwner(Actor* act) { Owner = act; }
 
@@ -375,6 +372,7 @@ public:
 	static int GetQuickSlot();
 	static int GetInventorySlot();
 private:
+	void CalculateWeight(void);
 	int FindRangedProjectile(unsigned int type) const;
 	// called by KillSlot
 	void RemoveSlotEffects( /*CREItem* slot*/ ieDword slot );

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -752,35 +752,7 @@ void Map::UpdateScripts()
 		actor->Update();
 
 		actor->UpdateActorState(game->GameTime);
-
-		int speed = actor->CalculateSpeed(false);
-		if (speed) {
-			speed = 1500/speed;
-		}
-		if (core->HasFeature(GF_RESDATA_INI)) {
-			ieDword animid = actor->BaseStats[IE_ANIMATION_ID];
-			if (core->HasFeature(GF_ONE_BYTE_ANIMID)) {
-				animid = animid & 0xff;
-			}
-			if (animid < (ieDword)CharAnimations::GetAvatarsCount()) {
-				AvatarStruct *avatar = CharAnimations::GetAvatarStruct(animid);
-				if (avatar->RunScale && (actor->GetInternalFlag() & IF_RUNNING)) {
-					speed = avatar->RunScale;
-				} else if (avatar->WalkScale) {
-					speed = avatar->WalkScale;
-				} else {
-					// 3 pst animations don't have a walkscale set, but they're immobile, so the default of 0 is fine
-				}
-				// the speeds are already inverted, so we need to increase them to slow down
-				int encumbranceFactor = actor->GetEncumbranceFactor(false);
-				if (encumbranceFactor <= 2) {
-					speed *= encumbranceFactor;
-				} else {
-					speed = 0;
-				}
-			}
-		}
-		actor->speed = speed;
+		actor->CalculateSpeed(false);
 	}
 
 	//clean up effects on dead actors too

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -725,11 +725,7 @@ void Actor::SetAnimationID(unsigned int AnimID)
 	}
 
 	// set internal speed too, since we may need it in the same tick (eg. csgolem in the bg2 intro)
-	int walkSpeed = CalculateSpeed(false);
-	if (walkSpeed) {
-		walkSpeed = 1500/walkSpeed;
-	}
-	speed = walkSpeed;
+	CalculateSpeed(false);
 }
 
 CharAnimations* Actor::GetAnims() const
@@ -5436,18 +5432,56 @@ int Actor::GetEncumbranceFactor(bool feedback) const
 	return 123456789; // large enough to round to 0 when used as a divisor
 }
 
-// NOTE: for ini-based speed users this will only update their encumbrance, speed will be 0
 int Actor::CalculateSpeed(bool feedback)
 {
-	int speed = GetStat(IE_MOVEMENTRATE);
+	if (core->HasFeature(GF_RESDATA_INI)) {
+		CalculateSpeedFromINI(feedback);
+	} else {
+		CalculateSpeedFromRate(feedback);
+	}
+	return speed;
+}
 
+// NOTE: for ini-based speed users this will only update their encumbrance, speed will be 0
+void Actor::CalculateSpeedFromRate(bool feedback)
+{
+	int movementRate = GetStat(IE_MOVEMENTRATE);
+	int encumbranceFactor = GetEncumbranceFactor(feedback);
 	if (BaseStats[IE_EA] > EA_GOODCUTOFF && !third) {
 		// cheating bastards (drow in ar2401 for example)
-		return speed;
+	} else {
+		movementRate /= encumbranceFactor;
 	}
+	if (movementRate) {
+		speed = 1500 / movementRate;
+	} else {
+		speed = 0;
+	}
+}
 
+void Actor::CalculateSpeedFromINI(bool feedback)
+{
 	int encumbranceFactor = GetEncumbranceFactor(feedback);
-	return speed / encumbranceFactor;
+	ieDword animid = BaseStats[IE_ANIMATION_ID];
+	if (core->HasFeature(GF_ONE_BYTE_ANIMID)) {
+		animid = animid & 0xff;
+	}
+	assert(animid < (ieDword)CharAnimations::GetAvatarsCount());
+	AvatarStruct *avatar = CharAnimations::GetAvatarStruct(animid);
+	if (avatar->RunScale && (GetInternalFlag() & IF_RUNNING)) {
+		speed = avatar->RunScale;
+	} else if (avatar->WalkScale) {
+		speed = avatar->WalkScale;
+	} else {
+		// 3 pst animations don't have a walkscale set, but they're immobile, so the default of 0 is fine
+		speed = 0;
+	}
+	// the speeds are already inverted, so we need to increase them to slow down
+	if (encumbranceFactor <= 2) {
+		speed *= encumbranceFactor;
+	} else {
+		speed = 0;
+	}
 }
 
 //receive turning

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -5446,11 +5446,7 @@ int Actor::CalculateSpeed(bool feedback)
 		return speed;
 	}
 
-	inventory.CalculateWeight();
-	int encumbrance = inventory.GetWeight();
 	int encumbranceFactor = GetEncumbranceFactor(feedback);
-	SetStat(IE_ENCUMBRANCE, encumbrance, false);
-
 	return speed / encumbranceFactor;
 }
 
@@ -6279,7 +6275,6 @@ void Actor::InitStatsOnLoad()
 			SetStance( IE_ANI_AWAKE );
 		}
 	}
-	inventory.CalculateWeight();
 	CreateDerivedStats();
 	Modified[IE_CON]=BaseStats[IE_CON]; // used by GetHpAdjustment
 	ieDword hp = BaseStats[IE_HITPOINTS] + GetHpAdjustment(GetXPLevel(false));

--- a/gemrb/core/Scriptable/Actor.h
+++ b/gemrb/core/Scriptable/Actor.h
@@ -448,6 +448,8 @@ private:
 	ieDword GetKitIndex (ieDword kit, ieDword baseclass=0) const;
 	char GetArmorCode() const;
 	const char* GetArmorSound() const;
+	void CalculateSpeedFromRate(bool feedback);
+	void CalculateSpeedFromINI(bool feedback);
 public:
 	Actor(void);
 	~Actor(void);

--- a/gemrb/plugins/AREImporter/AREImporter.cpp
+++ b/gemrb/plugins/AREImporter/AREImporter.cpp
@@ -791,8 +791,6 @@ Map* AREImporter::GetMap(const char *ResRef, bool day_or_night)
 			//cannot add directly to inventory (ground piles)
 			c->AddItem( core->ReadItem(str));
 		}
-		//update item flags (like movable flag)
-		c->inventory.CalculateWeight();
 
 		if (Type==IE_CONTAINER_PILE)
 			Script[0]=0;

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -9120,9 +9120,6 @@ static PyObject* GemRB_ChangeContainerItem(PyObject * /*self*/, PyObject* args)
 	if (Sound[0]) {
 		core->GetAudioDrv()->Play(Sound, SFX_CHAN_GUI);
 	}
-
-	//keep weight up to date
-	actor->CalculateSpeed(false);
 	Py_RETURN_NONE;
 }
 
@@ -9569,10 +9566,6 @@ static PyObject* GemRB_ChangeStoreItem(PyObject * /*self*/, PyObject* args)
 			store->RemoveItem(si);
 			delete si;
 		}
-		//keep encumbrance labels up to date
-		if (!rhstore) {
-			actor->CalculateSpeed(false);
-		}
 
 		// play the item's inventory sound
 		ieResRef Sound;
@@ -9687,8 +9680,6 @@ static PyObject* GemRB_ChangeStoreItem(PyObject * /*self*/, PyObject* args)
 				store->AddItem( si );
 			}
 			delete si;
-			//keep encumbrance labels up to date
-			actor->CalculateSpeed(false);
 			res = ASI_SUCCESS;
 		}
 		break;
@@ -11552,8 +11543,6 @@ static PyObject* GemRB_DragItem(PyObject * /*self*/, PyObject* args)
 		}
 		si = TryToUnequip( actor, core->QuerySlot(Slot), Count );
 		actor->RefreshEffects(NULL);
-		// make sure the encumbrance labels stay correct
-		actor->CalculateSpeed(false);
 		actor->ReinitQuickSlots();
 		core->SetEventFlag(EF_SELECTION);
 	}
@@ -11758,8 +11747,6 @@ static PyObject* GemRB_DropDraggedItem(PyObject * /*self*/, PyObject* args)
 	if (res) {
 		//release it only when fully placed
 		if (res==ASI_SUCCESS) {
-			// make sure the encumbrance labels stay correct
-			actor->CalculateSpeed(false);
 			core->ReleaseDraggedItem ();
 		}
 		// res == ASI_PARTIAL
@@ -11789,8 +11776,6 @@ static PyObject* GemRB_DropDraggedItem(PyObject * /*self*/, PyObject* args)
 			res = ASI_SWAPPED;
 			//EquipItem (in AddSlotItem) already called RefreshEffects
 			actor->RefreshEffects(NULL);
-			// make sure the encumbrance labels stay correct
-			actor->CalculateSpeed(false);
 			actor->ReinitQuickSlots();
 			core->SetEventFlag(EF_SELECTION);
 		} else {


### PR DESCRIPTION
## Description

I took an initial pass at #901 .

At first glance most of the GUIScript.cpp calls (namely to `Inventory::RemoveItem` and `Inventory::AddSlotItem`) don't recalculate the weight, so there's not much simplification there. I will try to take a look at their other calling points to check if they could do so, unless someone recommends against it.


## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
