### PR TITLE
Add middle-mouse viewport scrolling #902

### DIFF
--- a/gemrb/core/GUI/EventMgr.h
+++ b/gemrb/core/GUI/EventMgr.h
@@ -63,6 +63,7 @@ class Window;
 
 // Mouse buttons
 #define GEM_MB_ACTION           1
+#define GEM_MB_PAN	            2
 #define GEM_MB_MENU             4
 #define GEM_MB_SCRLUP           8
 #define GEM_MB_SCRLDOWN         16

--- a/gemrb/core/GUI/GameControl.h
+++ b/gemrb/core/GUI/GameControl.h
@@ -115,6 +115,7 @@ private:
 	bool DrawSelectionRect;
 	bool FormationRotation;
 	bool MouseIsDown;
+	bool IsPanning;
 	bool DoubleClick;
 	Region SelectionRect;
 	Point FormationApplicationPoint;

--- a/gemrb/core/Video.cpp
+++ b/gemrb/core/Video.cpp
@@ -209,6 +209,11 @@ void Video::SetMouseGrayed(bool grayed)
 	}
 }
 
+/** Captures the mouse so that mouse movement and interaction is tracked even if out of the game window */
+void Video::CaptureMouse(bool enabled)
+{
+}
+
 /** Get the fullscreen mode */
 bool Video::GetFullscreenMode() const
 {

--- a/gemrb/core/Video.h
+++ b/gemrb/core/Video.h
@@ -233,6 +233,8 @@ public:
 
 	void SetMouseEnabled(int enabled);
 	void SetMouseGrayed(bool grayed);
+	virtual void CaptureMouse(bool enabled);
+
 	bool GetFullscreenMode() const;
 	/** Sets the mouse cursor sprite to be used for mouseUp, mouseDown, and mouseDrag. See VID_CUR_* defines. */
 	void SetCursor(Sprite2D* cur, enum CursorType curIdx);

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -735,10 +735,15 @@ int SDL20VideoDriver::ProcessEvent(const SDL_Event & event)
 				 * As being SDL2-only, try to query the clipboard state to
 				 * paste when middle clicking the mouse.
 				 */
+				//Balrog994: that's a pretty unstandard way of pasting text, seems pretty hacky to me...
+				//changing to require CTRL to be pressed
+				SDL_Keymod modstate = SDL_GetModState();
+
 				if (
 					   event.button.button == SDL_BUTTON_MIDDLE
 					&& event.type == SDL_MOUSEBUTTONDOWN
 					&& SDL_HasClipboardText()
+					&& ((modstate & KMOD_CTRL) == KMOD_CTRL)
 				) {
 					char *pasteValue = SDL_GetClipboardText();
 
@@ -890,6 +895,12 @@ float SDL20VideoDriver::ScaleCoordinateVertical(float y)
 bool SDL20VideoDriver::TouchInputEnabled() const
 {
 	return SDL_GetNumTouchDevices() > 0;
+}
+
+/** Captures the mouse so that mouse movement and interaction is tracked even if out of the game window */
+void SDL20VideoDriver::CaptureMouse(bool enabled)
+{
+	SDL_CaptureMouse((SDL_bool)enabled);
 }
 
 #ifndef USE_OPENGL

--- a/gemrb/plugins/SDLVideo/SDL20Video.h
+++ b/gemrb/plugins/SDLVideo/SDL20Video.h
@@ -80,6 +80,7 @@ public:
 	void ShowSoftKeyboard();
 	void HideSoftKeyboard();
 	void MoveMouse(unsigned int x, unsigned int y);
+	virtual void CaptureMouse(bool enabled);
 private:
 	bool SetSurfaceAlpha(SDL_Surface* surface, unsigned short alpha);
 


### PR DESCRIPTION
## Description
I was having a couple of free hours and was taking a look at the issue tracker and found a very simple enhancement I thought I could help with :)

Just tried to implement #902 in the current branch without touching anything critical.
I saw it was under development on the subviews branch but maybe the code can be used as a temporary implementation.

I tested the implementation and seems working but some more testing may be useful.

There is a *breaking change in the code for text pasting*. I had to require the user to keep CTRL pressed for pasting because it was interfearing with the middle mouse button handling in the event system.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes 
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
