### PR TITLE
Guard against scripts committing suicide before they're done running

### DIFF
--- a/gemrb/core/GameScript/GameScript.cpp
+++ b/gemrb/core/GameScript/GameScript.cpp
@@ -2422,14 +2422,6 @@ int Response::Execute(Scriptable* Sender)
 {
 	int ret = 0; // continue or not
 	for (size_t i = 0; i < actions.size(); i++) {
-		if (!CheckCanary()) {
-			// FIXME: hack to prevent crashing when a script deletes itself.
-			// this object has been deleted and this should not be considered a fix (it may cause unforseen problems too).
-			Log(ERROR, "GameScript", "Aborting response execution due to object deletion.\n \
-									  This should not happen and we need to fix it.");
-			ret = 0;
-			break;
-		}
 		Action* aC = actions[i];
 		switch (actionflags[aC->actionID] & AF_MASK) {
 			case AF_IMMEDIATE:

--- a/gemrb/core/GameScript/GameScript.cpp
+++ b/gemrb/core/GameScript/GameScript.cpp
@@ -2067,6 +2067,9 @@ static Condition* ReadCondition(DataStream* stream)
  * if you pass non-NULL parameters, continuing is set to whether we Continue()ed
  * (should start false and be passed to next script's Update),
  * and done is set to whether we processed a block without Continue()
+ *
+ * NOTE: After calling, callers should deallocate this object if `dead==true`.
+ *  Scripts can replace themselves while running but it's up to the caller to clean up.
  */
 bool GameScript::Update(bool *continuing, bool *done)
 {
@@ -2120,7 +2123,9 @@ bool GameScript::Update(bool *continuing, bool *done)
 				}
 				lastAction=a;
 			}
+			running = true;
 			continueExecution = ( rB->responseSet->Execute(MySelf) != 0);
+			running = false;
 			if (continuing) *continuing = continueExecution;
 			if (!continueExecution) {
 				if (done) *done = true;
@@ -2134,7 +2139,10 @@ bool GameScript::Update(bool *continuing, bool *done)
 //IE simply takes the first action's object for cutscene object
 //then adds these actions to its queue:
 // SetInterrupt(false), <actions>, SetInterrupt(true)
-
+/*
+ * NOTE: After calling, callers should deallocate this object if `dead==true`.
+ *  Scripts can replace themselves while running but it's up to the caller to clean up.
+ */
 void GameScript::EvaluateAllBlocks()
 {
 	if (!MySelf || !(MySelf->GetInternalFlag()&IF_ACTIVE) ) {

--- a/gemrb/core/GameScript/GameScript.h
+++ b/gemrb/core/GameScript/GameScript.h
@@ -547,6 +547,9 @@ public:
 	GameScript(const ieResRef ResRef, Scriptable* Myself,
 		int ScriptLevel = 0, bool AIScript = false);
 	~GameScript();
+	bool dead = false;      // Script replaced itself with another and should be deleted when done running
+	bool running = false;   // Script is currently running so defer any deletion to caller
+
 	const char *GetName() { return Name; }
 	static void ExecuteString(Scriptable* Sender, const char* String);
 	static int EvaluateString(Scriptable* Sender, char* String);

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -188,7 +188,11 @@ void Scriptable::SetScript(const ieResRef aScript, int idx, bool ai)
 	if (idx >= MAX_SCRIPTS) {
 		error("Scriptable", "Invalid script index!\n");
 	}
-	delete Scripts[idx];
+	if (Scripts[idx] && Scripts[idx]->running) {
+		Scripts[idx]->dead = true;
+	} else {
+		delete Scripts[idx];
+	}
 	Scripts[idx] = NULL;
 	// NONE is an 'invalid' script name, never used seriously
 	// This hack is to prevent flooding of the console
@@ -204,7 +208,11 @@ void Scriptable::SetScript(int index, GameScript* script)
 		Log(ERROR, "Scriptable", "Invalid script index!");
 		return;
 	}
-	delete Scripts[index];
+	if (Scripts[index] && Scripts[index]->running) {
+		Scripts[index]->dead = true;
+	} else {
+		delete Scripts[index];
+	}
 	Scripts[index] = script;
 }
 
@@ -435,6 +443,9 @@ void Scriptable::ExecuteScript(int scriptCount)
 		GameScript *Script = Scripts[scriptlevel];
 		if (Script) {
 			changed |= Script->Update(&continuing, &done);
+			if (Script->dead) {
+				delete Script;
+			}
 		}
 
 		/* scripts are not concurrent, see WAITPC override script for example */


### PR DESCRIPTION
## Description
Fix for #542 .
I added the same logic to both `SetScript` variants, even though I'm not sure the 2-arg variant is currently callable from within a script.

I think this eliminates the need for the `Canary` stuff; I can remove that in another commit or submit a separate PR if desirable.


## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
