### PR TITLE
SDL20Video: ensure SDL_HINT_RENDER_BATCHING is supported at compile time

### DIFF
--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -72,9 +72,11 @@ int SDL20VideoDriver::CreateDriverDisplay(const Size& s, int bpp, const char* ti
 	SDL_SetHint(SDL_HINT_RENDER_DRIVER, driverName);
 #endif
 
+#if SDL_VERSION_ATLEAST(2, 0, 10)
 	if (sdl2_runtime_version >= SDL_VERSIONNUM(2,0,10)) {
 		SDL_SetHint(SDL_HINT_RENDER_BATCHING, "1");
 	}
+#endif
 
 	Uint32 winFlags = SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE;
 #if USE_OPENGL_BACKEND


### PR DESCRIPTION
Fixes compilation with SDL2 < 2.0.10, broken by https://github.com/gemrb/gemrb/pull/936.