### PR TITLE
Window.rc : the artwork directory is now one more level above relatively

### DIFF
--- a/platforms/windows/window.rc
+++ b/platforms/windows/window.rc
@@ -1,1 +1,1 @@
-GEMRB_ICON ICON "..\\artwork\\gemrb-logo.ico"
+GEMRB_ICON ICON "..\\..\\artwork\\gemrb-logo.ico"


### PR DESCRIPTION
Now that the platforms directory has been created, this fixes a tiny issue of MSVC not being able to find the program icon while building, as the artwork directory is now two levels above instead of one.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
