### PR TITLE
PST clskills.2da fixes and skills.2da draft

### DIFF
--- a/gemrb/unhardcoded/pst/clskills.2da
+++ b/gemrb/unhardcoded/pst/clskills.2da
@@ -1,6 +1,6 @@
 2DA V1.0
 *
-                    HATERACE   CLERICSPELL MAGESPELL  STARTXP  BARD  THIEF    LAYHANDS  TURNLEVEL  BOOKTYPE  SAVEBONUS  SPONCAST
+                    HATERACE   CLERICSPELL MAGESPELL  STARTXP  BARDSKILL  THIEFSKILL    LAYHANDS  TURNLEVEL  BOOKTYPE  SAVEBONUS  SPONCAST
 UNUSED              *          *           *          *        *     *        *         0          0         0          *
 MAGE                *          *           MXSPLWIZ   0        *     *        *         0          1         0          *
 FIGHTER             *          *           *          0        *     *        *         0          0         0          *

--- a/gemrb/unhardcoded/pst/skills.2da
+++ b/gemrb/unhardcoded/pst/skills.2da
@@ -1,0 +1,9 @@
+2DA V1.0
+-1
+             DESC_REF CAP_REF  ID   THIEF    MAGE_THIEF FIGHTER_THIEF CLERIC_THIEF FIGHTER_MAGE_THIEF
+FIRST_LEVEL  *	      *        *    40       40         40            40           40
+RATE         *        *        *    40       40         40            40           40
+OPEN_LOCKS   *        38575    26   1        1          1             1            1
+STEALTH      *        38571    27   1        1          1             1            1
+FIND_TRAPS   *        38572    28   1        1          1             1            1
+PICK_POCKETS *        38574    29   1        1          1             1            1


### PR DESCRIPTION
This is the prerequisite first step of implementing the common skill scripts in PST

The first commit seems to be a simple oversight or typo

The second commit adds the skills.2da table that will be needed later with the correct label strrefs (there is no description text needed/used since the level up screen is much simplified)

I think the skill id's are correct, or at least, they match up with the entries for all the other games. This part I am not 100% sure how they are used or whether they would be any reason for them to be different for PST.


## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
