### PR TITLE
MSVC build tweaks

### DIFF
--- a/gemrb/includes/exports.h
+++ b/gemrb/includes/exports.h
@@ -65,6 +65,8 @@
 
 /// Disable silly MSVC warnings
 #if _MSC_VER >= 1000
+//  4138 disables the warning for */ found outside of comment, mostly in GameScript.h
+#	pragma warning( disable: 4138 )
 //  4267 disables the warnings related to conversion between size_t and other types 
 #	pragma warning( disable: 4267 )
 //	4251 disables the annoying warning about missing dll interface in templates

--- a/gemrb/vcpkg_deps.cmake
+++ b/gemrb/vcpkg_deps.cmake
@@ -84,7 +84,19 @@ INSTALL(FILES ${DLL_PATHS_DEBUG} CONFIGURATIONS Debug DESTINATION ${BIN_DIR})
 INSTALL(FILES ${DLL_PATHS_RELEASE} CONFIGURATIONS Release RelWithDebInfo DESTINATION ${BIN_DIR})
 
 # copy over python core modules, so the buildbot binaries work without python installed
-INSTALL(DIRECTORY ${VCPKG_DATAROOT}/share/python2/Lib DESTINATION ${BIN_DIR})
+
+#this copies the modules bundled with the standard python installer if found
+#otherwise, this uses the vcpkg bundled python modules if detected
+#site.py is searched for by name because the vcpkg uninstall process doesn't properly purge the folder
+#so if you switch between them for any reason, it will try to copy the wrong folder
+
+GET_FILENAME_COMPONENT(PYTHON_PARENT_DIR ${PYTHON_INCLUDE_DIR} DIRECTORY)
+
+IF(EXISTS ${PYTHON_PARENT_DIR}/Lib/site.py )
+	INSTALL(DIRECTORY ${PYTHON_PARENT_DIR}/Lib DESTINATION ${BIN_DIR})
+ELSEIF(EXISTS ${VCPKG_DATAROOT}/share/python2/Lib/site.py)
+	INSTALL(DIRECTORY ${VCPKG_DATAROOT}/share/python2/Lib DESTINATION ${BIN_DIR})
+ENDIF()
 
 MESSAGE(STATUS "Dependency DLL's will be copied to the build and install directory")
 MESSAGE(STATUS "Disable option VCPKG_AUTO_DEPLOY to skip this")

--- a/gemrb/vcpkg_deps.cmake
+++ b/gemrb/vcpkg_deps.cmake
@@ -66,6 +66,19 @@ FOREACH(ENTRY IN LISTS DLL_SET_RELEASE)
 	ENDIF()
 ENDFOREACH()
 
+# a custom target which copies the dll files to the build directory if needed, useful for rapid testing
+IF(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+	SET(DLL_SET ${DLL_PATHS_DEBUG} )
+ELSE()
+	SET(DLL_SET ${DLL_PATHS_RELEASE} )
+ENDIF()
+
+ADD_CUSTOM_COMMAND(TARGET gemrb POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different
+	${DLL_SET}
+	${CMAKE_BINARY_DIR}/gemrb/)
+
+
 # if a user decides to install, they also need a copy of the dll in their game directory.
 INSTALL(FILES ${DLL_PATHS_DEBUG} CONFIGURATIONS Debug DESTINATION ${BIN_DIR})
 INSTALL(FILES ${DLL_PATHS_RELEASE} CONFIGURATIONS Release DESTINATION ${BIN_DIR})

--- a/gemrb/vcpkg_deps.cmake
+++ b/gemrb/vcpkg_deps.cmake
@@ -81,7 +81,7 @@ ADD_CUSTOM_COMMAND(TARGET gemrb POST_BUILD
 
 # if a user decides to install, they also need a copy of the dll in their game directory.
 INSTALL(FILES ${DLL_PATHS_DEBUG} CONFIGURATIONS Debug DESTINATION ${BIN_DIR})
-INSTALL(FILES ${DLL_PATHS_RELEASE} CONFIGURATIONS Release DESTINATION ${BIN_DIR})
+INSTALL(FILES ${DLL_PATHS_RELEASE} CONFIGURATIONS Release RelWithDebInfo DESTINATION ${BIN_DIR})
 
 # copy over python core modules, so the buildbot binaries work without python installed
 INSTALL(DIRECTORY ${VCPKG_DATAROOT}/share/python2/Lib DESTINATION ${BIN_DIR})


### PR DESCRIPTION
Various tweaks for building with MSVC - these were just some other small things I had to change to get back to normal

1: Renables deployment of dll's to the build directory for quick testing. I think the original purpose of this probably didn't appear clear, so it went away with the cleanup.

2: Disables a new warning related to gamescript.h, hundreds of "c4138: /* found outside of comment" messages. Not sure what suddenly caused them to start appearing.

3: When 'installing' Dll deployment was not happening when RelWithDebInfo option is used. I tend to use this one, it uses the same release library set

4: Prefer copying the system python version if it exists, otherwise use the vcpkg version. I hope this change works fine with appveyor, am I correct in thinking that making a pull request will test that/show what happens in the log?

For what it's worth, I did manage to finally get mine building with the vcpkg version of python, it was all down to an annoying Visual studio quirk that was saving some of my old variables even after purging the cmake cache. The only downside is that it doesn't work from the build dir unless you manually set the pythonhome variable to point the the Lib folder, because it doesn't actually set itself to work system wide. However, it does work fine if you hit 'install', since the change to copying the Lib folder over as well. 

I'm not 100% sure what to suggest. I am also not quite certain what happens with appveyor if you don't use the vcpkg version of python. So I am just putting this here for feedback.


## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
