### PR TITLE
PST Level up thief skills initial support

### DIFF
--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -72,6 +72,7 @@ import NewLife
 from GUIDefines import *
 from ie_stats import *
 import GUIWORLD
+import LUSkillsSelection
 
 ###################################################
 LevelUpWindow = None
@@ -877,8 +878,18 @@ def AcceptLevelUp():
 		GemRB.SetPlayerStat (pc, IE_LEVEL, GemRB.GetPlayerStat (pc, IE_LEVEL)+NumOfPrimLevUp)
 		if avatar_header['SecoLevel'] != 0:
 			GemRB.SetPlayerStat (pc, IE_LEVEL2, GemRB.GetPlayerStat (pc, IE_LEVEL2)+NumOfSecoLevUp)
+	
+	LUSkillsSelection.SkillsSave (pc)
 	UpdateRecordsWindow ()
 
+def RedrawSkills():
+	DoneButton = LevelUpWindow.GetControl(0)
+
+	if GemRB.GetVar ("SkillPointsLeft") == 0:
+		DoneButton.SetState(IE_GUI_BUTTON_ENABLED)
+	else:
+		DoneButton.SetState(IE_GUI_BUTTON_DISABLED)
+	return
 
 def OpenLevelUpWindow ():
 	global LevelUpWindow
@@ -981,9 +992,8 @@ def OpenLevelUpWindow ():
 	Label = Window.GetControl (0x1000000E)
 	Label.SetText (str (GemRB.GetPlayerStat (pc, IE_LOCKPICKING)) + '%')
 	# Plus and Minus buttons
-	for i in range (8):
-		Button = Window.GetControl (16 + i)
-		Button.SetState (IE_GUI_BUTTON_LOCKED)
+	LUSkillsSelection.SetupSkillsWindow (pc, LUSkillsSelection.LUSKILLS_TYPE_LEVELUP, LevelUpWindow, RedrawSkills, [0,0,0], [1,1,1], 0, False)
+	RedrawSkills()
 
 	# Is avatar multi-class?
 	if avatar_header['SecoLevel'] == 0:


### PR DESCRIPTION
This is not meant to be an actual pull request for this issue, it's just so far all I have been able to come up with. It works, but I hate it.

The common LUSkills script very almost nearly works with PST apart from a few annoying stumbling blocks:

1: The + and - buttons are reversed left to right

2: Instead of the name labels and point fields being separate sequences in the CHU file, they are instead in label, number, label, number order.

3: There is no text description area or associated hint text to display, so that part must be disabled

When I originally got this to work, I dropped it to look at other stuff because I was in gaming/testing mode, but deep down I am still convinced it could be a lot better and cleaner.

It gets frustrating having to add if/else blocks that reference PST by name all the time... but I also don't have any good ideas of how to keep this code 'one size fits all'. The more I stare at all the different UI files, the more my head spins. I was tempted to reference every control ID explicitly since I thought there were only four, but then I looked at IWD2, with its extended skill display, and I went off the idea. 

Sometimes it's like trying to design a saddle that fits both horses and camels...and then also ostriches. It should be simple, right?

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
