### PR TITLE
Improve formation movement and right-click moves in general

### DIFF
--- a/gemrb/core/Core.cpp
+++ b/gemrb/core/Core.cpp
@@ -59,24 +59,16 @@ namespace GemRB {
 
 double AngleFromPoints(const Point& p1, const Point& p2)
 {
-	double angle = 0.0;
-	Point diff = p1 - p2;
-	if (diff.y == 0) {
-		if (diff.x > 0) {
-			angle = M_PI_2;
-		} else {
-			angle = -M_PI_2;
-		}
-	} else {
-		angle = std::atan(diff.x / diff.y);
-		if (diff.y < 0) angle += M_PI;
-	}
+	double xdiff = p1.x - p2.x;
+	double ydiff = p1.y - p2.y;
+
+	double angle = std::atan2(ydiff, xdiff);
 	return angle;
 }
 
 Point RotatePoint(const Point& p, double angle)
 {
-	int newx = -p.x * std::cos(angle) + p.y * std::sin(angle);
+	int newx = p.x * std::cos(angle) - p.y * std::sin(angle);
 	int newy = p.x * std::sin(angle) + p.y * std::cos(angle);
 	return Point(newx, newy);
 }

--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -184,6 +184,9 @@ Point GameControl::GetFormationPoint(const Point& origin, size_t pos, double ang
 	Point stepVec;
 	int direction = (pos % 2 == 0) ? 1 : -1;
 
+	/* Correct for the innate orientation of the points.  */
+	angle += M_PI / 2;
+
 	if (pos < FORMATIONSIZE) {
 		// calculate new coordinates by rotating formation around (0,0)
 		vec = RotatePoint(formations[formation][pos], angle);
@@ -608,7 +611,9 @@ void GameControl::DrawSelf(Region screen, const Region& /*clip*/)
 	Point gameMousePos = GameMousePos();
 	// draw reticles
 	if (isFormationRotation) {
-		double angle = AngleFromPoints(gameMousePos, gameClickPoint);
+		double angle = formationBaseAngle;
+		if (Distance (gameMousePos, gameClickPoint) > 5)
+			angle = AngleFromPoints(gameMousePos, gameClickPoint);
 		DrawFormation(game->selected, gameClickPoint, angle);
 	} else {
 		int max = game->GetPartySize(false);
@@ -1469,7 +1474,7 @@ bool GameControl::OnMouseDrag(const MouseEvent& me)
 		Scroll(me.Delta());
 		return true;
 	}
-	
+
 	if (target_mode != TARGET_MODE_NONE) {
 		// we are in a target mode; nothing here applies
 		return true;
@@ -1479,23 +1484,8 @@ bool GameControl::OnMouseDrag(const MouseEvent& me)
 		return true;
 	}
 
-	if (me.ButtonState(GEM_MB_ACTION)) {
-		// PST uses alt + left click for formation rotation
-		// is there any harm in this being true in all games?
-		if (EventMgr::ModState(GEM_MOD_ALT)) {
-			isFormationRotation = true;
-		} else {
-			isSelectionRect = true;
-		}
-	}
-
-	if (me.ButtonState(GEM_MB_MENU)) {
-		isFormationRotation = true;
-	}
-
-	if (core->GetGame()->selected.size() <= 1) {
-		isFormationRotation = false;
-	}
+	if (me.ButtonState(GEM_MB_ACTION) && !isFormationRotation)
+		isSelectionRect = true;
 
 	if (isFormationRotation) {
 		SetCursor(core->Cursors[IE_CURSOR_USE]);
@@ -1558,8 +1548,8 @@ bool GameControl::OnTouchGesture(const GestureEvent& gesture)
 			if (core->GetGame()->selected.size() <= 1) {
 				isFormationRotation = false;
 			} else {
-				isFormationRotation = true;
 				screenMousePos = gesture.fingers[1].Pos();
+				InitFormation (screenMousePos);
 			}
 		} else { // scroll viewport
 			MoveViewportTo( vpOrigin - gesture.Delta(), false );
@@ -2038,6 +2028,33 @@ bool GameControl::HandleActiveRegion(InfoPoint *trap, Actor * actor, const Point
 	return false;
 }
 
+// Calculate the angle between a clicked point and the first selected character,
+// so that we can set a sensible orientation for the formation
+void GameControl::InitFormation (const Point &clickPoint)
+{
+	/* We get called on initial click, but also on drag.  Perform the setup only once.  */
+	if (isFormationRotation)
+		return;
+
+	if (core->GetGame()->selected.size() == 0) {
+		isFormationRotation = false;
+		return;
+	}
+
+	isFormationRotation = true;
+	Game* game = core->GetGame();
+	int max = game->GetPartySize(false);
+	formationBaseAngle = 0;
+	for (int idx = 1; idx <= max; idx++) {
+		Actor *act = game->FindPC(idx);
+		if (act->IsSelected()) {
+			formationBaseAngle = AngleFromPoints (clickPoint, act->Pos);
+			break;
+		}
+	}
+	SetCursor(core->Cursors[IE_CURSOR_USE]);
+}
+
 /** Mouse Button Down */
 bool GameControl::OnMouseDown(const MouseEvent& me, unsigned short Mod)
 {
@@ -2048,10 +2065,18 @@ bool GameControl::OnMouseDown(const MouseEvent& me, unsigned short Mod)
 	case GEM_MB_MENU: //right click.
 		if (core->HasFeature(GF_HAS_FLOAT_MENU) && !Mod) {
 			core->GetGUIScriptEngine()->RunFunction( "GUICommon", "OpenFloatMenuWindow", false, p);
+		} else {
+			InitFormation (gameClickPoint);
 		}
 		break;
 	case GEM_MB_ACTION:
 		isDoubleClick = me.repeats == 2;
+
+		// PST uses alt + left click for formation rotation
+		// is there any harm in this being true in all games?
+		if (!isDoubleClick && EventMgr::ModState(GEM_MOD_ALT))
+			InitFormation (gameClickPoint);
+
 		break;
 	}
 	return true;
@@ -2163,6 +2188,7 @@ bool GameControl::OnMouseUp(const MouseEvent& me, unsigned short Mod)
 			ClearMouseState();
 			return true;
 		}
+		InitFormation(p);
 	}
 
 	// handle movement/travel
@@ -2249,7 +2275,10 @@ void GameControl::CommandSelectedMovement(const Point& p, unsigned short Mod)
 
 	double angle = 0.0;
 	if (isFormationRotation) {
-		angle = AngleFromPoints(GameMousePos(), p);
+		angle = formationBaseAngle;
+		Point mp = GameMousePos ();
+		if (Distance (mp, p) > 5)
+			angle = AngleFromPoints(mp, p);
 	}
 
 	bool doWorldMap = ShouldTriggerWorldMap(party[0]);

--- a/gemrb/core/GUI/GameControl.h
+++ b/gemrb/core/GUI/GameControl.h
@@ -92,6 +92,7 @@ private:
 	Point screenMousePos;
 	Point vpOrigin;
 	bool updateVPTimer;
+	double formationBaseAngle;
 
 	// currently selected targeting type, such as talk, attack, cast, ...
 	// private to enforce proper cursor changes
@@ -221,6 +222,7 @@ public:
 	bool HandleActiveRegion(InfoPoint *trap, Actor *actor, const Point& p);
 
 	void MakeSelection(bool extend = false);
+	void InitFormation(const Point &);
 	Point GetFormationOffset(ieDword formation, ieDword pos);
 	/** calls MoveToPoint or RunToPoint */
 	void CreateMovement(Actor *actor, const Point &p, bool append=true);


### PR DESCRIPTION
## Description
A version of my formations patch against the subviews branch.
This is actually a little more complete than the previous one. The maths is simplified a bit more, and now right click, left click, and Alt-Leftclick all behave consistently, and as far as I can tell the behaviour matches the IE behaviour pretty well.

I modified the gestures code to be consistent as well, but I can't test it.