### PR TITLE
Make '1'..'6' hotkeys for the portrait buttons

### DIFF
--- a/gemrb/GUIScripts/GUICommonWindows.py
+++ b/gemrb/GUIScripts/GUICommonWindows.py
@@ -1707,7 +1707,7 @@ def OpenPortraitWindow (needcontrols=0, pos=WINDOW_RIGHT|WINDOW_VCENTER):
 	SelectionChanged ()
 	return Window
 
-def UpdatePortraitWindow ():
+def UpdatePortraitWindow (indialog = False):
 	"""Updates all of the portraits."""
 
 	Window = PortraitWindow
@@ -1718,9 +1718,13 @@ def UpdatePortraitWindow ():
 	PortraitButtons = GetPortraitButtonPairs (Window)
 	for i, Button in PortraitButtons.iteritems():
 		pcID = i + 1
+		if indialog:
+			Button.SetHotKey(None)
 		if (pcID <= GemRB.GetPartySize()):
 			Button.SetAction(lambda btn, val, pc=pcID: GemRB.GameControlLocateActor(pc), IE_ACT_MOUSE_ENTER);
 			Button.SetAction(lambda: GemRB.GameControlLocateActor(-1), IE_ACT_MOUSE_LEAVE);
+			if (i < 6 and not indialog):
+				Button.SetHotKey(chr(ord('1') + i), 0, True)
 
 		if GameCheck.IsPST():
 			UpdateAnimatedPortrait(Window, i)

--- a/gemrb/GUIScripts/GUIWORLD.py
+++ b/gemrb/GUIScripts/GUIWORLD.py
@@ -68,7 +68,7 @@ def DialogStarted ():
 	GemRB.GameSetScreenFlags(GS_DIALOG, OP_OR)
 
 	if GUICommonWindows.PortraitWindow:
-		GUICommonWindows.UpdatePortraitWindow ()
+		GUICommonWindows.UpdatePortraitWindow (True)
 
 	ContinueWindow = OpenDialogButton(9)
 

--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -762,18 +762,12 @@ bool GameControl::OnKeyPress(const KeyboardEvent& Key, unsigned short mod)
 				case '=':
 					SelectActor(-1);
 					break;
-				case '1':
-				case '2':
-				case '3':
-				case '4':
-				case '5':
-				case '6':
-					game->SelectPCSingle(keycode-'0');
-					SelectActor(keycode-'0');
-					break;
 				case '7': // 1 & 2
 				case '8': // 3 & 4
 				case '9': // 5 & 6
+					// We do not handle the range 1..6, these are handled as hotkeys
+					// for the portrait buttons, so that they remain working when the
+					// inventory screen is open.
 					game->SelectActor( NULL, false, SELECT_NORMAL );
 					i = game->GetPartySize(false);
 					pc = 2*(keycode - '6')-1;

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -3031,6 +3031,7 @@ static PyObject* GemRB_Button_SetHotKey(PyObject* self, PyObject* args)
 
 	if (arg1 == Py_None) {
 		btn = GetView<Button>(PyTuple_GetItem(args, 0));
+		btn->SetHotKey (0, 0, false);
 		Py_RETURN_NONE;
 	} // work around a bug in cpython where PyArg_ParseTuple doesnt return as expected when 'c' format doesn't match
 	else if (PyObject_TypeCheck(arg1, &PyString_Type) && PyString_Size(arg1) == 1) {


### PR DESCRIPTION
## Description

I noticed a regression from master: the keys '1'..'6' no longer work in the inventory (or on the character screen). The problem is that they are handled in GameControl, but that gets disabled when a top window is added.
Adding hotkeys to the portrait buttons seems to fix it.

Out of curiousity, where exactly are the hotkeys 'I' and 'R' added? No matter how hard I grep I just can't find the location. I'm guessing it's InitOptionButton, but if so, where does it get the keys 'I' and 'R'?