### PR TITLE
Make hitpoint display go away when Tab is released

### DIFF
--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -1110,6 +1110,7 @@ bool GameControl::OnKeyRelease(const KeyboardEvent& Key, unsigned short Mod)
 		}
 		return true; //return from cheatkeys
 	}
+	Game* game = core->GetGame();
 	switch (Key.keycode) {
 //FIXME: move these to guiscript
 		case ' ': //soft pause
@@ -1120,6 +1121,13 @@ bool GameControl::OnKeyRelease(const KeyboardEvent& Key, unsigned short Mod)
 		case 'c': // show containers in ANDROID, GEM_ALT is not possible to use
 #endif
 			DebugFlags &= ~(DEBUG_SHOW_CONTAINERS|DEBUG_SHOW_DOORS);
+			break;
+		case GEM_TAB: // remove overhead partymember hp/maxhp
+			for (int pm = 0; pm < game->GetPartySize(false); pm++) {
+				Actor *pc = game->GetPC(pm, true);
+				if (!pc) continue;
+				pc->DisplayOverheadText(false);
+			}
 			break;
 		default:
 			return false;

--- a/gemrb/plugins/SDLVideo/SDLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDLVideo.cpp
@@ -68,6 +68,74 @@ int SDLVideoDriver::PollEvents()
 	return ret;
 }
 
+static SDL_Keycode TranslateKeycode(SDLKey sym)
+{
+	switch (sym) {
+		case SDLK_ESCAPE:
+			return GEM_ESCAPE;
+		case SDLK_END:
+		case SDLK_KP1:
+			return GEM_END;
+		case SDLK_HOME:
+		case SDLK_KP7:
+			return GEM_HOME;
+		case SDLK_UP:
+		case SDLK_KP8:
+			return GEM_UP;
+		case SDLK_DOWN:
+		case SDLK_KP2:
+			return GEM_DOWN;
+		case SDLK_LEFT:
+		case SDLK_KP4:
+			return GEM_LEFT;
+		case SDLK_RIGHT:
+		case SDLK_KP6:
+			return GEM_RIGHT;
+		case SDLK_DELETE:
+#if TARGET_OS_IPHONE < 1
+			//iOS currently doesnt have a backspace so we use delete.
+			//This change should be future proof in the event apple changes the delete key to a backspace.
+			return GEM_DELETE;
+#endif
+		case SDLK_BACKSPACE:
+			return GEM_BACKSP;
+		case SDLK_RETURN:
+		case SDLK_KP_ENTER:
+			return GEM_RETURN;
+		case SDLK_LALT:
+		case SDLK_RALT:
+			return GEM_ALT;
+		case SDLK_TAB:
+			return GEM_TAB;
+		case SDLK_PAGEUP:
+		case SDLK_KP9:
+			return GEM_PGUP;
+		case SDLK_PAGEDOWN:
+		case SDLK_KP3:
+			return GEM_PGDOWN;
+		case SDLK_SCROLLOCK:
+			return GEM_GRAB;
+		case SDLK_F1:
+		case SDLK_F2:
+		case SDLK_F3:
+		case SDLK_F4:
+		case SDLK_F5:
+		case SDLK_F6:
+		case SDLK_F7:
+		case SDLK_F8:
+		case SDLK_F9:
+		case SDLK_F10:
+		case SDLK_F11:
+		case SDLK_F12:
+			//assuming they come sequentially,
+			//also, there is no need to ever produce more than 12
+			return GEM_FUNCTIONX(1) + sym-SDLK_F1;
+		default:
+			break;
+	}
+	return sym;
+}
+
 int SDLVideoDriver::ProcessEvent(const SDL_Event & event)
 {
 	if (!EvntManager)
@@ -89,20 +157,7 @@ int SDLVideoDriver::ProcessEvent(const SDL_Event & event)
 			core->AskAndExit();
 			return GEM_OK;
 		case SDL_KEYUP:
-			switch(sym) {
-				case SDLK_LALT:
-				case SDLK_RALT:
-					key = GEM_ALT;
-					break;
-				case SDLK_SCROLLOCK:
-					key = GEM_GRAB;
-					break;
-				default:
-					if (sym < 256) {
-						key = sym;
-					}
-					break;
-			}
+			key = TranslateKeycode(sym);
 			if (key != 0) {
 				Event e = EvntManager->CreateKeyEvent(key, false, modstate);
 				EvntManager->DispatchEvent(e);
@@ -124,85 +179,7 @@ int SDLVideoDriver::ProcessEvent(const SDL_Event & event)
 					default: break;
 				}
 			}
-			switch (sym) {
-				case SDLK_ESCAPE:
-					key = GEM_ESCAPE;
-					break;
-				case SDLK_END:
-				case SDLK_KP1:
-					key = GEM_END;
-					break;
-				case SDLK_HOME:
-				case SDLK_KP7:
-					key = GEM_HOME;
-					break;
-				case SDLK_UP:
-				case SDLK_KP8:
-					key = GEM_UP;
-					break;
-				case SDLK_DOWN:
-				case SDLK_KP2:
-					key = GEM_DOWN;
-					break;
-				case SDLK_LEFT:
-				case SDLK_KP4:
-					key = GEM_LEFT;
-					break;
-				case SDLK_RIGHT:
-				case SDLK_KP6:
-					key = GEM_RIGHT;
-					break;
-				case SDLK_DELETE:
-#if TARGET_OS_IPHONE < 1
-					//iOS currently doesnt have a backspace so we use delete.
-					//This change should be future proof in the event apple changes the delete key to a backspace.
-					key = GEM_DELETE;
-					break;
-#endif
-				case SDLK_BACKSPACE:
-					key = GEM_BACKSP;
-					break;
-				case SDLK_RETURN:
-				case SDLK_KP_ENTER:
-					key = GEM_RETURN;
-					break;
-				case SDLK_LALT:
-				case SDLK_RALT:
-					key = GEM_ALT;
-					break;
-				case SDLK_TAB:
-					key = GEM_TAB;
-					break;
-				case SDLK_PAGEUP:
-				case SDLK_KP9:
-					key = GEM_PGUP;
-					break;
-				case SDLK_PAGEDOWN:
-				case SDLK_KP3:
-					key = GEM_PGDOWN;
-					break;
-				case SDLK_SCROLLOCK:
-					key = GEM_GRAB;
-					break;
-				case SDLK_F1:
-				case SDLK_F2:
-				case SDLK_F3:
-				case SDLK_F4:
-				case SDLK_F5:
-				case SDLK_F6:
-				case SDLK_F7:
-				case SDLK_F8:
-				case SDLK_F9:
-				case SDLK_F10:
-				case SDLK_F11:
-				case SDLK_F12:
-					//assuming they come sequentially,
-					//also, there is no need to ever produce more than 12
-					key = GEM_FUNCTIONX(1) + sym-SDLK_F1;
-					break;
-				default:
-					break;
-			}
+			key = TranslateKeycode(sym);
 
 			e = EvntManager->CreateKeyEvent(key, true, modstate);
 			if (e.keyboard.character) {


### PR DESCRIPTION
## Description
This fixes what seems to be a simple oversight and brings behaviour in line with the IE. When the Tab key is released, the overhead hitpoint display should disappear.

There were two problems, fixed in two separate commits - there was no code to hide the hitpoints in the KeyUp handler, and SDL didn't properly translate its keycodes. The code in SDL could probably be improved further, but I think what I have is the minimum safe fix.