### PR TITLE
Tweak distance checks

### DIFF
--- a/gemrb/core/PathFinder.cpp
+++ b/gemrb/core/PathFinder.cpp
@@ -266,7 +266,7 @@ PathNode *Map::FindPath(const Point &s, const Point &d, unsigned int size, unsig
 		// but stop just before it
 		AdjustPositionNavmap(nmptDest);
 	}
-	if (!(GetBlockedInRadius(nmptDest.x, nmptDest.y, size) & (PATH_MAP_PASSABLE | PATH_MAP_ACTOR))) {
+	if (minDistance < size && !(GetBlockedInRadius(nmptDest.x, nmptDest.y, size) & (PATH_MAP_PASSABLE | PATH_MAP_ACTOR))) {
 		Log(DEBUG, "FindPath", "%s can't fit in destination", caller ? caller->GetName(0) : "nullptr");
 		return nullptr;
 	}

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -22,6 +22,7 @@
 #include "win32def.h"
 #include "strrefs.h"
 #include "ie_cursors.h"
+#include "voodooconst.h"
 
 #include "DialogHandler.h"
 #include "DisplayMessage.h"
@@ -2222,8 +2223,6 @@ void Movable::BumpBack()
 // for a random time (inspired by network media access control algorithms) or just stops if
 // the goal is close enough.
 void Movable::DoStep(unsigned int walkScale, ieDword time) {
-	const int XEPS = 72;
-	const int YEPS = 36;
 	Actor *actor = nullptr;
 	if (Type == ST_ACTOR) actor = (Actor*)this;
 	// Only bump back if not moving
@@ -2265,11 +2264,12 @@ void Movable::DoStep(unsigned int walkScale, ieDword time) {
 
 		if (BlocksSearchMap() && actorInTheWay && actorInTheWay != this && actorInTheWay->BlocksSearchMap()) {
 			// Give up instead of bumping if you are close to the goal
-			if (!(step->Next) && std::abs(nmptStep.x - Pos.x) < XEPS && std::abs(nmptStep.y - Pos.y) < YEPS) {
+			if (!(step->Next) && PersonalDistance(nmptStep, this) < MAX_OPERATING_DISTANCE) {
 				ClearPath(true);
 				NewOrientation = Orientation;
 				// Do not call ReleaseCurrentAction() since other actions
 				// than MoveToPoint can cause movement
+				Log(DEBUG, "PathFinderWIP", "Abandoning because I'm close to the goal");
 				pathAbandoned = true;
 				return;
 			}


### PR DESCRIPTION
## Description
- Tweaks a check that gives up on pathfinding to use `MAX_OPERATING_DISTANCE` in order to be consistent with the `Actions` code.
- Tweaks a "too big to fit" check in `Map::FindPath` to account for maximum allowed distance. Tested with the Draconis battle that prompted it in the first place.

Prompted by #952 


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary (NA)
- [x] The proposed change builds also on our build bots (check after submission)
