### PR TITLE
Drag/drop improvements

### DIFF
--- a/gemrb/GUIScripts/InventoryCommon.py
+++ b/gemrb/GUIScripts/InventoryCommon.py
@@ -544,6 +544,39 @@ def OpenItemAmountWindow (btn, slot):
 	Window.ShowModal (MODAL_SHADOW_GRAY)
 	return
 
+# count goes up to 5 for all games except IWD2, which uses 6, and
+# PST, which does not use this function.
+def UpdateGroundSlots (Window, pc, count):
+	"""Updates the five (or six, for IWD2) inventory ground slots."""
+
+	Container = GemRB.GetContainer (pc, 1)
+	TopIndex = GemRB.GetVar ("TopIndex")
+	for i in range (count):
+		if i<5:
+			Button = Window.GetControl (i+68)
+		else:
+			Button = Window.GetControl (i+76)
+
+		if GemRB.IsDraggingItem ()==1:
+			Button.SetState (IE_GUI_BUTTON_FAKEPRESSED)
+		else:
+			Button.SetState (IE_GUI_BUTTON_ENABLED)
+		Button.SetAction (OnDragItemGround, IE_ACT_DRAG_DROP_DST)
+		Slot = GemRB.GetContainerItem (pc, i+TopIndex)
+
+		if Slot == None:
+			Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, None)
+			Button.SetEvent (IE_GUI_BUTTON_ON_RIGHT_PRESS, None)
+			Button.SetEvent (IE_GUI_BUTTON_ON_SHIFT_PRESS, None)
+		else:
+			Button.SetAction (OnDragItemGround, IE_ACT_DRAG_DROP_CRT)
+			Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, OnDragItemGround)
+			Button.SetEvent (IE_GUI_BUTTON_ON_RIGHT_PRESS, OpenGroundItemInfoWindow)
+			Button.SetEvent (IE_GUI_BUTTON_ON_SHIFT_PRESS, OpenGroundItemAmountWindow)
+
+		UpdateInventorySlot (pc, Button, Slot, "ground")
+	return
+
 def UpdateSlot (pc, slot):
 	"""Updates a specific slot."""
 

--- a/gemrb/GUIScripts/InventoryCommon.py
+++ b/gemrb/GUIScripts/InventoryCommon.py
@@ -43,7 +43,7 @@ UpdateInventoryWindow = None
 
 def OnDragItemGround (btn, slot):
 	"""Drops and item to the ground."""
-	
+
 	pc = GemRB.GameGetSelectedPCSingle ()
 	slot = slot + GemRB.GetVar ("TopIndex") - btn.ControlID
 
@@ -85,7 +85,7 @@ def OnDragItem (btn, slot):
 
 	pc = GemRB.GameGetSelectedPCSingle ()
 	slot_item = GemRB.GetSlotItem (pc, slot)
-	
+
 	if not GemRB.IsDraggingItem ():
 		item = GemRB.GetItem (slot_item["ItemResRef"])
 		GemRB.DragItem (pc, slot, item["ItemIcon"], 0, 0)
@@ -565,6 +565,7 @@ def UpdateGroundSlots (Window, pc, count):
 		Slot = GemRB.GetContainerItem (pc, i+TopIndex)
 
 		if Slot == None:
+			Button.SetAction (None, IE_ACT_DRAG_DROP_CRT)
 			Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, None)
 			Button.SetEvent (IE_GUI_BUTTON_ON_RIGHT_PRESS, None)
 			Button.SetEvent (IE_GUI_BUTTON_ON_SHIFT_PRESS, None)
@@ -636,7 +637,7 @@ def UpdateSlot (pc, slot):
 	UpdateInventorySlot (pc, Button, slot_item, "inventory", SlotType["Type"]&SLOT_INVENTORY == 0)
 
 	if slot_item:
-		Button.SetAction(OnDragItem, IE_ACT_DRAG_DROP_CRT)
+		Button.SetAction (OnDragItem, IE_ACT_DRAG_DROP_CRT)
 		Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, OnDragItem)
 		Button.SetEvent (IE_GUI_BUTTON_ON_RIGHT_PRESS, OpenItemInfoWindow)
 		Button.SetEvent (IE_GUI_BUTTON_ON_SHIFT_PRESS, OpenItemAmountWindow)
@@ -664,6 +665,7 @@ def UpdateSlot (pc, slot):
 			Button.SetTooltip ("")
 			itemname = ""
 
+		Button.SetAction (None, IE_ACT_DRAG_DROP_CRT)
 		Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, None)
 		Button.SetEvent (IE_GUI_BUTTON_ON_RIGHT_PRESS, None)
 		Button.SetEvent (IE_GUI_BUTTON_ON_SHIFT_PRESS, None)

--- a/gemrb/GUIScripts/bg1/GUIINV.py
+++ b/gemrb/GUIScripts/bg1/GUIINV.py
@@ -244,29 +244,7 @@ def RefreshInventoryWindow (Window):
 	Color = GemRB.GetPlayerStat (pc, IE_MINOR_COLOR, 1) & 0xFF
 	Button.SetBAM ("COLGRAD", 0, 0, Color)
 
-	# update ground inventory slots
-	Container = GemRB.GetContainer (pc, 1)
-	TopIndex = GemRB.GetVar ("TopIndex")
-	for i in range (5):
-		Button = Window.GetControl (i+68)
-		if GemRB.IsDraggingItem ()==1:
-			Button.SetState (IE_GUI_BUTTON_FAKEPRESSED)
-		else:
-			Button.SetState (IE_GUI_BUTTON_ENABLED)
-		Button.SetAction (InventoryCommon.OnDragItemGround, IE_ACT_DRAG_DROP_DST)
-		Slot = GemRB.GetContainerItem (pc, i+TopIndex)
-
-		if Slot == None:
-			Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, None)
-			Button.SetEvent (IE_GUI_BUTTON_ON_RIGHT_PRESS, None)
-			Button.SetEvent (IE_GUI_BUTTON_ON_SHIFT_PRESS, None)
-		else:
-			Button.SetAction(InventoryCommon.OnDragItemGround, IE_ACT_DRAG_DROP_CRT)
-			Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, InventoryCommon.OnDragItemGround)
-			Button.SetEvent (IE_GUI_BUTTON_ON_RIGHT_PRESS, InventoryCommon.OpenGroundItemInfoWindow)
-			Button.SetEvent (IE_GUI_BUTTON_ON_SHIFT_PRESS, InventoryCommon.OpenGroundItemAmountWindow)
-
-		InventoryCommon.UpdateInventorySlot (pc, Button, Slot, "ground")
+	InventoryCommon.UpdateGroundSlots (Window, pc, 5)
 
 	# making window visible/shaded depending on the pc's state
 	GUICommon.AdjustWindowVisibility (Window, pc, False)

--- a/gemrb/GUIScripts/bg2/GUIINV.py
+++ b/gemrb/GUIScripts/bg2/GUIINV.py
@@ -222,30 +222,7 @@ def RefreshInventoryWindow (Window):
 	Color = GemRB.GetPlayerStat (pc, IE_MINOR_COLOR, 1) & 0xFF
 	Button.SetBAM ("COLGRAD", 0, 0, Color)
 
-	# update ground inventory slots
-	Container = GemRB.GetContainer (pc, 1)
-	TopIndex = GemRB.GetVar ("TopIndex")
-	for i in range (5):
-		Button = Window.GetControl (i+68)
-		if GemRB.IsDraggingItem ()==1:
-			Button.SetState (IE_GUI_BUTTON_FAKEPRESSED)
-		else:
-			Button.SetState (IE_GUI_BUTTON_ENABLED)
-		
-		Button.SetAction (InventoryCommon.OnDragItemGround, IE_ACT_DRAG_DROP_DST)
-		Slot = GemRB.GetContainerItem (pc, i+TopIndex)
-
-		if Slot == None:
-			Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, None)
-			Button.SetEvent (IE_GUI_BUTTON_ON_RIGHT_PRESS, None)
-			Button.SetEvent (IE_GUI_BUTTON_ON_SHIFT_PRESS, None)
-		else:
-			Button.SetAction(InventoryCommon.OnDragItemGround, IE_ACT_DRAG_DROP_CRT)
-			Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, InventoryCommon.OnDragItemGround)
-			Button.SetEvent (IE_GUI_BUTTON_ON_RIGHT_PRESS, InventoryCommon.OpenGroundItemInfoWindow)
-			Button.SetEvent (IE_GUI_BUTTON_ON_SHIFT_PRESS, InventoryCommon.OpenGroundItemAmountWindow)
-
-		InventoryCommon.UpdateInventorySlot (pc, Button, Slot, "ground")
+	InventoryCommon.UpdateGroundSlots (Window, pc, 5)
 
 	# making window visible/shaded depending on the pc's state
 	GUICommon.AdjustWindowVisibility (Window, pc, False)

--- a/gemrb/GUIScripts/iwd/GUIINV.py
+++ b/gemrb/GUIScripts/iwd/GUIINV.py
@@ -221,29 +221,7 @@ def RefreshInventoryWindow (Window):
 	Color = GemRB.GetPlayerStat (pc, IE_MINOR_COLOR, 1) & 0xFF
 	Button.SetBAM ("COLGRAD", 1, 0, Color)
 
-	# update ground inventory slots
-	Container = GemRB.GetContainer (pc, 1)
-	TopIndex = GemRB.GetVar ("TopIndex")
-	for i in range (5):
-		Button = Window.GetControl (i+68)
-		if GemRB.IsDraggingItem ()==1:
-			Button.SetState (IE_GUI_BUTTON_FAKEPRESSED)
-		else:
-			Button.SetState (IE_GUI_BUTTON_ENABLED)
-		Button.SetAction (InventoryCommon.OnDragItemGround, IE_ACT_DRAG_DROP_DST)
-		Slot = GemRB.GetContainerItem (pc, i+TopIndex)
-
-		if Slot == None:
-			Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, None)
-			Button.SetEvent (IE_GUI_BUTTON_ON_RIGHT_PRESS, None)
-			Button.SetEvent (IE_GUI_BUTTON_ON_SHIFT_PRESS, None)
-		else:
-			Button.SetAction(InventoryCommon.OnDragItemGround, IE_ACT_DRAG_DROP_CRT)
-			Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, InventoryCommon.OnDragItemGround)
-			Button.SetEvent (IE_GUI_BUTTON_ON_RIGHT_PRESS, InventoryCommon.OpenGroundItemInfoWindow)
-			Button.SetEvent (IE_GUI_BUTTON_ON_SHIFT_PRESS, InventoryCommon.OpenGroundItemAmountWindow)
-
-		InventoryCommon.UpdateInventorySlot (pc, Button, Slot, "ground")
+	InventoryCommon.UpdateGroundSlots (Window, pc, 5)
 
 	# making window visible/shaded depending on the pc's state
 	GUICommon.AdjustWindowVisibility (Window, pc, False)

--- a/gemrb/GUIScripts/iwd2/GUIINV.py
+++ b/gemrb/GUIScripts/iwd2/GUIINV.py
@@ -236,33 +236,7 @@ def RefreshInventoryWindow ():
 	Color = GemRB.GetPlayerStat (pc, IE_SKIN_COLOR, 1) & 0xFF
 	Button.SetBAM ("COLGRAD", 0, 0, Color)
 
-	# update ground inventory slots
-	Container = GemRB.GetContainer(pc, 1)
-	TopIndex = GemRB.GetVar ("TopIndex")
-	for i in range (6):
-		if i<5:
-			Button = Window.GetControl (i+68)
-		else:
-			Button = Window.GetControl (i+76)
-
-		if GemRB.IsDraggingItem ()==1:
-			Button.SetState (IE_GUI_BUTTON_FAKEPRESSED)
-		else:
-			Button.SetState (IE_GUI_BUTTON_ENABLED)
-		Button.SetAction (InventoryCommon.OnDragItemGround, IE_ACT_DRAG_DROP_DST)
-
-		Slot = GemRB.GetContainerItem (pc, i+TopIndex)
-		if Slot == None:
-			Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, None)
-			Button.SetEvent (IE_GUI_BUTTON_ON_RIGHT_PRESS, None)
-			Button.SetEvent (IE_GUI_BUTTON_ON_SHIFT_PRESS, None)
-		else:
-			Button.SetAction(InventoryCommon.OnDragItemGround, IE_ACT_DRAG_DROP_CRT)
-			Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, InventoryCommon.OnDragItemGround)
-			Button.SetEvent (IE_GUI_BUTTON_ON_RIGHT_PRESS, InventoryCommon.OpenGroundItemInfoWindow)
-			Button.SetEvent (IE_GUI_BUTTON_ON_SHIFT_PRESS, InventoryCommon.OpenGroundItemAmountWindow)
-
-		InventoryCommon.UpdateInventorySlot (pc, Button, Slot, "ground")
+	InventoryCommon.UpdateGroundSlots (Window, pc, 6)
 
 	#if actor is uncontrollable, make this grayed
 	GUICommon.AdjustWindowVisibility (Window, pc, False)

--- a/gemrb/core/GUI/Button.cpp
+++ b/gemrb/core/GUI/Button.cpp
@@ -447,6 +447,13 @@ void Button::CompleteDragOperation(const DragOp& dop)
 	Control::CompleteDragOperation(dop);
 }
 
+View::UniqueDragOp Button::DragOperation()
+{
+	if (IS_PORTRAIT)
+		return std::unique_ptr<ControlDragOp>(new ControlDragOp(this));
+	return Control::DragOperation();
+}
+
 Holder<Sprite2D> Button::DragCursor() const
 {
 	if (IS_PORTRAIT) {

--- a/gemrb/core/GUI/Button.cpp
+++ b/gemrb/core/GUI/Button.cpp
@@ -449,12 +449,10 @@ void Button::CompleteDragOperation(const DragOp& dop)
 
 Holder<Sprite2D> Button::DragCursor() const
 {
-	if (IS_PORTRAIT == false && Picture) {
-		// TODO: would it be an enhancement to actually use the portrait for the drag icon?
-		return Picture;
+	if (IS_PORTRAIT) {
+			return Control::DragCursor();
 	}
-	
-	return Control::DragCursor();
+	return nullptr;
 }
 
 /** Mouse Button Down */

--- a/gemrb/core/GUI/Button.h
+++ b/gemrb/core/GUI/Button.h
@@ -143,6 +143,7 @@ public:
 	String QueryText() const { return Text; }
 	String TooltipText() const;
 
+	View::UniqueDragOp DragOperation() override;
 	bool AcceptsDragOperation(const DragOp&) const;
 	void CompleteDragOperation(const DragOp&);
 	Holder<Sprite2D> DragCursor() const;

--- a/gemrb/core/GUI/Control.cpp
+++ b/gemrb/core/GUI/Control.cpp
@@ -208,7 +208,7 @@ Timer* Control::StartActionTimer(const ControlEventHandler& action, unsigned int
 	// this way we have consistent behavior for the initial delay prior to switching to a faster delay
 	return &core->SetTimer(h, (delay) ? delay : ActionRepeatDelay);
 }
-	
+
 bool Control::HitTest(const Point& p) const
 {
 	if (!(flags & (IgnoreEvents | Invisible))) {
@@ -222,19 +222,20 @@ View::UniqueDragOp Control::DragOperation()
 	if (actionTimer) {
 		return nullptr;
 	}
-	
-	ActionKey key(Action::DragDropCreate);
-	
-	if (SupportsAction(key)) {
-		// we have to use a timer so that the dragop is set before the callback is called
-		EventHandler h = [this, key] () {
-			actionTimer->Invalidate();
-			actionTimer = nullptr;
-			return actions[key](this);
-		};
 
-		actionTimer = &core->SetTimer(h, 0, 0);
+	ActionKey key(Action::DragDropCreate);
+	if (!SupportsAction(key)) {
+		return nullptr;
 	}
+
+	// we have to use a timer so that the dragop is set before the callback is called
+	EventHandler h = [this, key] () {
+		actionTimer->Invalidate();
+		actionTimer = nullptr;
+		return actions[key](this);
+	};
+
+	actionTimer = &core->SetTimer(h, 0, 0);
 	return std::unique_ptr<ControlDragOp>(new ControlDragOp(this));
 }
 
@@ -246,7 +247,7 @@ bool Control::AcceptsDragOperation(const DragOp& dop) const
 		// if 2 controls share the same VarName we assume they are swappable...
 		return (strnicmp(VarName, cdop->Source()->VarName, MAX_VARIABLE_LENGTH-1) == 0);
 	}
-	
+
 	return View::AcceptsDragOperation(dop);
 }
 

--- a/gemrb/core/GUI/Control.cpp
+++ b/gemrb/core/GUI/Control.cpp
@@ -228,6 +228,8 @@ View::UniqueDragOp Control::DragOperation()
 	if (SupportsAction(key)) {
 		// we have to use a timer so that the dragop is set before the callback is called
 		EventHandler h = [this, key] () {
+			actionTimer->Invalidate();
+			actionTimer = nullptr;
 			return actions[key](this);
 		};
 

--- a/gemrb/core/GUI/Window.cpp
+++ b/gemrb/core/GUI/Window.cpp
@@ -351,7 +351,7 @@ void Window::DispatchMouseMotion(View* target, const MouseEvent& me)
 		// tracking will eat this event
 		if (me.buttonStates) {
 			trackingView->MouseDrag(me);
-			if (trackingView == target && drag == nullptr) {
+			if (drag == nullptr) {
 				drag = trackingView->DragOperation();
 			}
 		} else {


### PR DESCRIPTION
## Description
One of the things I noticed very soon is that inventory drag/drop behaves differently than in BG2 running on the real Infinity Engine (and every other drag/drop implementation). GemRB always requires an extra click, which makes things cumbersome.

This set of changes fixes most of the problem by improving item drag support in the Button class and in Window::DispatchMouseUp. The old behaviour seems to be still supported - if you click and release without dragging the mouse, the item is picked up as previously.

One problem remains, which is dragging to a portrait: for some reason the MouseUp event doesn't find the portrait button, and an extra click is still required there.

The final change is purely optional - I originally modified some Python code as well and ended up unifying four blocks of code identical in three cases and near identical in IWD2. Feel free to drop it if there's some reason not to do this. I tested with BG2 only.