### PR TITLE
Use Holder/Held refcounting for Palette

### DIFF
--- a/gemrb/core/AnimationFactory.cpp
+++ b/gemrb/core/AnimationFactory.cpp
@@ -141,9 +141,8 @@ Sprite2D* AnimationFactory::GetPaperdollImage(ieDword *Colors,
 		return NULL;
 	}
 	if (Colors) {
-		Palette* palette = Picture2->GetPalette();
+		PaletteHolder palette = Picture2->GetPalette();
 		palette->SetupPaperdollColours(Colors, type);
-		palette->release();
 	}
 
 	Picture2->Frame.x = (short)frames[second]->Frame.x;
@@ -151,9 +150,8 @@ Sprite2D* AnimationFactory::GetPaperdollImage(ieDword *Colors,
 
 	Sprite2D* spr = frames[first]->copy();
 	if (Colors) {
-		Palette* palette = spr->GetPalette();
+		PaletteHolder palette = spr->GetPalette();
 		palette->SetupPaperdollColours(Colors, type);
-		palette->release();
 	}
 
 	spr->Frame.x = (short)frames[first]->Frame.x;

--- a/gemrb/core/CharAnimations.cpp
+++ b/gemrb/core/CharAnimations.cpp
@@ -351,7 +351,7 @@ void CharAnimations::CheckColorMod()
 
 void CharAnimations::SetupColors(PaletteType type)
 {
-	Palette* pal = palette[type];
+	PaletteHolder pal = palette[type];
 
 	if (!pal) {
 		return;
@@ -425,7 +425,7 @@ void CharAnimations::SetupColors(PaletteType type)
 				}
 			}
 			strlwr(PaletteResRef[type]);
-			Palette *tmppal = gamedata->GetPalette(PaletteResRef[type]);
+			PaletteHolder tmppal = gamedata->GetPalette(PaletteResRef[type]);
 			if (tmppal) {
 				gamedata->FreePalette(palette[type], oldResRef);
 				palette[type] = tmppal;
@@ -475,7 +475,7 @@ void CharAnimations::SetupColors(PaletteType type)
 
 }
 
-Palette* CharAnimations::GetPartPalette(int part)
+PaletteHolder CharAnimations::GetPartPalette(int part)
 {
 	int actorPartCount = GetActorPartCount();
 	PaletteType type = PAL_MAIN;
@@ -496,7 +496,7 @@ Palette* CharAnimations::GetPartPalette(int part)
 	return palette[type];
 }
 
-Palette* CharAnimations::GetShadowPalette() const {
+PaletteHolder CharAnimations::GetShadowPalette() const {
 	return shadowPalette;
 }
 

--- a/gemrb/core/CharAnimations.h
+++ b/gemrb/core/CharAnimations.h
@@ -170,9 +170,9 @@ public:
 	RGBModifier GlobalColorMod; // global color modification effect
 
 	bool change[PAL_MAX];
-	Palette* palette[PAL_MAX];
-	Palette* modifiedPalette[PAL_MAX];
-	Palette* shadowPalette;
+	PaletteHolder palette[PAL_MAX];
+	PaletteHolder modifiedPalette[PAL_MAX];
+	PaletteHolder shadowPalette;
 	unsigned int AvatarsRowNum;
 	unsigned char ArmorType, WeaponType, RangedType;
 	ieResRef ResRef;
@@ -202,8 +202,8 @@ public:
 	Animation** GetShadowAnimation(unsigned char Stance, unsigned char Orient);
 
 	// returns Palette for a given part (unlocked)
-	Palette* GetPartPalette(int part); // TODO: clean this up
-	Palette* GetShadowPalette() const;
+	PaletteHolder GetPartPalette(int part); // TODO: clean this up
+	PaletteHolder GetShadowPalette() const;
 
 public: //attribute functions
 	static int GetAvatarsCount();

--- a/gemrb/core/ControlAnimation.cpp
+++ b/gemrb/core/ControlAnimation.cpp
@@ -136,17 +136,15 @@ void ControlAnimation::UpdateAnimationSprite () {
 	}
 
 	if (has_palette) {
-		Palette* palette = pic->GetPalette();
+		PaletteHolder palette = pic->GetPalette();
 		palette->SetupPaperdollColours(colors, 0);
 		if (is_blended) {
 			palette->CreateShadedAlphaChannel();
 		}
-		palette->release();
 	} else {
 		if (is_blended) {
-			Palette* palette = pic->GetPalette();
+			PaletteHolder palette = pic->GetPalette();
 			palette->CreateShadedAlphaChannel();
-			palette->release();
 		}
 	}
 

--- a/gemrb/core/FontManager.h
+++ b/gemrb/core/FontManager.h
@@ -37,7 +37,7 @@ public:
 	FontManager();
 	virtual ~FontManager(void);
 
-	virtual Font* GetFont(ieWord pxSize, FontStyle style, Palette* = NULL)=0;
+	virtual Font* GetFont(ieWord pxSize, FontStyle style, PaletteHolder = nullptr)=0;
 };
 
 }

--- a/gemrb/core/GUI/Button.cpp
+++ b/gemrb/core/GUI/Button.cpp
@@ -245,7 +245,7 @@ void Button::DrawSelf(Region rgn, const Region& /*clip*/)
 
 	// Button label
 	if (hasText && ! ( flags & IE_GUI_BUTTON_NO_TEXT )) {
-		Palette* ppoi = normal_palette;
+		PaletteHolder ppoi = normal_palette;
 		ieByte align = 0;
 
 		if (State == IE_GUI_BUTTON_DISABLED || IsDisabled())

--- a/gemrb/core/GUI/Button.h
+++ b/gemrb/core/GUI/Button.h
@@ -40,6 +40,7 @@
 namespace GemRB {
 
 class Palette;
+using PaletteHolder = Holder<Palette>;
 
 // NOTE: keep these synchronized with GUIDefines.py!!!
 #define IE_GUI_BUTTON_UNPRESSED 0
@@ -181,8 +182,8 @@ private: // Private attributes
 	Font* font;
 	bool ToggleState;
 	bool pulseBorder;
-	Palette* normal_palette;
-	Palette* disabled_palette;
+	PaletteHolder normal_palette;
+	PaletteHolder disabled_palette;
 	Sprite2D* buttonImages[BUTTON_IMAGE_TYPE_COUNT];
 	/** Pictures to Apply when the hasPicture flag is set */
 	Sprite2D* Picture;

--- a/gemrb/core/GUI/Console.cpp
+++ b/gemrb/core/GUI/Console.cpp
@@ -53,9 +53,8 @@ Console::Console(const Region& frame, TextArea* ta)
 	feedback.AssignScriptingRef(1, "CONSOLE");
 	feedback.SetFlags(TextArea::AutoScroll | TextArea::ClearHistory, OP_OR);
 
-	Palette* palette = new Palette( ColorWhite, ColorBlack );
+	PaletteHolder palette = new Palette( ColorWhite, ColorBlack );
 	textContainer.SetPalette(palette);
-	palette->release();
 	textContainer.SetMargin(3);
 
 	textContainer.SetAlignment(align);

--- a/gemrb/core/GUI/Label.h
+++ b/gemrb/core/GUI/Label.h
@@ -36,6 +36,7 @@
 namespace GemRB {
 
 class Palette;
+using PaletteHolder = Holder<Palette>;
 
 // !!! Keep these synchronized with GUIDefines.py !!!
 #define IE_GUI_LABEL_ON_PRESS      0x06000000
@@ -72,7 +73,7 @@ private: // Private attributes
 	/** Font for Text Writing */
 	Font* font;
 	/** Foreground & Background Colors */
-	Palette* palette;
+	PaletteHolder palette;
 
 	/** Alignment Variable */
 	unsigned char Alignment;

--- a/gemrb/core/GUI/TextArea.cpp
+++ b/gemrb/core/GUI/TextArea.cpp
@@ -417,7 +417,6 @@ void TextArea::SetPalette(const Color* color, PALETTE_TYPE idx)
 	assert(idx < PALETTE_TYPE_COUNT);
 	if (color) {
 		palettes[idx] = new Palette( *color, ColorBlack );
-		palettes[idx]->release();
 	} else if (idx > PALETTE_NORMAL) {
 		// default to normal
 		palettes[idx] = palettes[PALETTE_NORMAL];

--- a/gemrb/core/GUI/TextEdit.cpp
+++ b/gemrb/core/GUI/TextEdit.cpp
@@ -42,9 +42,8 @@ TextEdit::TextEdit(const Region& frame, unsigned short maxLength, Point p)
 
 	//Original engine values
 	//Color white = {0xc8, 0xc8, 0xc8, 0x00}, black = {0x3c, 0x3c, 0x3c, 0x00};
-	Palette* palette = new Palette( ColorWhite, ColorBlack );
+	PaletteHolder palette = new Palette( ColorWhite, ColorBlack );
 	textContainer.SetPalette(palette);
-	palette->release();
 	max = maxLength;
 	textContainer.SetMargin(p.y, p.x);
 

--- a/gemrb/core/GUI/TextSystem/Font.cpp
+++ b/gemrb/core/GUI/TextSystem/Font.cpp
@@ -141,7 +141,7 @@ void Font::GlyphAtlasPage::DumpToScreen(const Region& r)
 #endif
 
 
-Font::Font(Palette* pal, ieWord lineheight, ieWord baseline)
+Font::Font(PaletteHolder pal, ieWord lineheight, ieWord baseline)
 : palette(NULL), LineHeight(lineheight), Baseline(baseline)
 {
 	CurrentAtlasPage = NULL;
@@ -529,7 +529,7 @@ Sprite2D* Font::RenderTextAsSprite(const String& string, const Size& size,
 	return canvas;
 }
 
-void Font::SetAtlasPalette(Palette* pal) const
+void Font::SetAtlasPalette(PaletteHolder pal) const
 {
 	GlyphAtlas::const_iterator it;
 	for (it = Atlas.begin(); it != Atlas.end(); ++it) {
@@ -540,7 +540,7 @@ void Font::SetAtlasPalette(Palette* pal) const
 }
 
 size_t Font::Print(Region rgn, const String& string,
-				   Palette* color, ieByte alignment, Point* point) const
+				   PaletteHolder color, ieByte alignment, Point* point) const
 {
 	if (rgn.Dimensions().IsEmpty()) return 0;
 
@@ -570,7 +570,7 @@ size_t Font::Print(Region rgn, const String& string,
 		}
 	}
 
-	Palette* restore = NULL;
+	PaletteHolder restore = nullptr;
 	if (color) {
 		// we set palette in this way because we want all the Atlas pages to inherit the change
 		restore = palette;
@@ -720,10 +720,8 @@ Holder<Palette> Font::GetPalette() const
 	return palette;
 }
 
-void Font::SetPalette(Palette* pal)
+void Font::SetPalette(PaletteHolder pal)
 {
-	if (pal) pal->acquire();
-	if (palette) palette->release();
 	palette = pal;
 }
 

--- a/gemrb/core/GUI/TextSystem/Font.h
+++ b/gemrb/core/GUI/TextSystem/Font.h
@@ -50,6 +50,7 @@ enum FontStyle {
 };
 
 class Palette;
+using PaletteHolder = Holder<Palette>;
 
 #define IE_FONT_ALIGN_LEFT   0x00
 #define IE_FONT_ALIGN_CENTER 0x01
@@ -149,7 +150,7 @@ private:
 	GlyphAtlas Atlas;
 
 protected:
-	mutable Palette* palette;
+	mutable PaletteHolder palette;
 
 public:
 	const int LineHeight;
@@ -164,10 +165,10 @@ private:
 	size_t RenderLine(const String& string, const Region& rgn,
 					  Point& dp, ieByte** canvas = NULL) const;
 
-	void SetAtlasPalette(Palette* pal) const;
+	void SetAtlasPalette(PaletteHolder pal) const;
 
 public:
-	Font(Palette*, ieWord lineheight, ieWord baseline);
+	Font(PaletteHolder, ieWord lineheight, ieWord baseline);
 	virtual ~Font();
 
 	const Glyph& CreateGlyphForCharSprite(ieWord chr, const Sprite2D*);
@@ -178,8 +179,8 @@ public:
 	//allow reading but not setting glyphs
 	virtual const Glyph& GetGlyph(ieWord chr) const;
 
-	Holder<Palette> GetPalette() const;
-	void SetPalette(Palette* pal);
+	PaletteHolder GetPalette() const;
+	void SetPalette(PaletteHolder pal);
 
 	virtual int GetKerningOffset(ieWord /*leftChr*/, ieWord /*rightChr*/) const {return 0;};
 
@@ -190,7 +191,7 @@ public:
 	// the "point" parameter can be passed with a start point for rendering
 	// it will be filled with the point inside 'rgn' where the string ends upon return
 	size_t Print(Region rgn, const String& string,
-				 Palette* hicolor, ieByte Alignment, Point* point = NULL) const;
+				 PaletteHolder hicolor, ieByte Alignment, Point* point = nullptr) const;
 
 	/** Returns size of the string rendered in this font in pixels */
 	struct StringSizeMetrics {

--- a/gemrb/core/GUI/TextSystem/GemMarkup.h
+++ b/gemrb/core/GUI/TextSystem/GemMarkup.h
@@ -37,12 +37,12 @@ public:
 	};
 
 	GemMarkupParser();
-	GemMarkupParser(const Font* ftext, Palette* textPal = NULL,
-					const Font* finit = NULL, Palette* initPal = NULL);
+	GemMarkupParser(const Font* ftext, PaletteHolder textPal = nullptr,
+					const Font* finit = nullptr, PaletteHolder initPal = nullptr);
 	~GemMarkupParser() {};
 
-	void ResetAttributes(const Font* ftext = NULL, Holder<Palette> textPal = NULL,
-						 const Font* finit = NULL, Holder<Palette> initPal = NULL);
+	void ResetAttributes(const Font *ftext = nullptr, PaletteHolder textPal = nullptr,
+						 const Font *finit = nullptr, PaletteHolder initPal = nullptr);
 
 	void Reset();
 
@@ -60,8 +60,8 @@ private:
 		const Font* SwapFont;
 
 		public:
-		TextAttributes(const Font* text, Holder<Palette> textPal = NULL,
-					   const Font* init = NULL, Holder<Palette> initPal = NULL)
+		TextAttributes(const Font* text, PaletteHolder textPal = nullptr,
+					   const Font *init = nullptr, PaletteHolder initPal = nullptr)
 		: palette(textPal), swapPalette(initPal)
 		{
 			TextFont = text;

--- a/gemrb/core/GUI/WorldMapControl.cpp
+++ b/gemrb/core/GUI/WorldMapControl.cpp
@@ -91,11 +91,10 @@ void WorldMapControl::DrawSelf(Region rgn, const Region& /*clip*/)
 		Sprite2D* icon = m->GetMapIcon(worldmap->bam, OverrideIconPalette);
 		if( icon ) {
 			if (m == Area && m->HighlightSelected()) {
-				Palette *pal = icon->GetPalette();
+				PaletteHolder pal = icon->GetPalette();
 				icon->SetPalette(pal_selected.get());
 				video->BlitSprite( icon, xOffs, yOffs, &rgn );
 				icon->SetPalette(pal);
-				pal->release();
 			} else {
 				video->BlitSprite( icon, xOffs, yOffs, &rgn );
 			}
@@ -129,7 +128,7 @@ void WorldMapControl::DrawSelf(Region rgn, const Region& /*clip*/)
 		if (!m->GetCaption())
 			continue;
 
-		Palette* text_pal = pal_normal.get();
+		PaletteHolder text_pal = pal_normal;
 
 		if (Area == m) {
 			text_pal = pal_selected.get();

--- a/gemrb/core/GameData.h
+++ b/gemrb/core/GameData.h
@@ -33,6 +33,7 @@
 #include "TableMgr.h"
 
 #include <map>
+#include <unordered_map>
 #include <vector>
 
 namespace GemRB {
@@ -45,6 +46,7 @@ class Factory;
 class FactoryObject;
 class Item;
 class Palette;
+using PaletteHolder = Holder<Palette>;
 class ScriptedAnimation;
 class Spell;
 class Sprite2D;
@@ -84,9 +86,9 @@ public:
 	/** Frees a Loaded Table, returns false on error, true on success */
 	bool DelTable(unsigned int index);
 
-	Palette* GetPalette(const ieResRef resname);
-	void FreePalette(Palette *&pal, const ieResRef name=NULL);
-	
+	PaletteHolder GetPalette(const ResRef resname);
+	void FreePalette(PaletteHolder &pal, const ieResRef name=NULL);
+
 	Item* GetItem(const ieResRef resname, bool silent=false);
 	void FreeItem(Item const *itm, const ieResRef name, bool free=false);
 	Spell* GetSpell(const ieResRef resname, bool silent=false);
@@ -133,7 +135,7 @@ private:
 	Cache ItemCache;
 	Cache SpellCache;
 	Cache EffectCache;
-	Cache PaletteCache;
+	std::unordered_map<const ResRef, PaletteHolder, ResRef::Hash> PaletteCache;
 	Factory* factory;
 	std::vector<Table> tables;
 	typedef std::map<const char*, Store*, iless> StoreMap;

--- a/gemrb/core/Holder.h
+++ b/gemrb/core/Holder.h
@@ -116,6 +116,12 @@ inline bool operator==(std::nullptr_t, const Holder<T>& rhs) noexcept
 }
 
 template<class T>
+inline bool operator!=(const Holder<T>& lhs, const Holder<T>& rhs) noexcept
+{
+	return lhs.get() != rhs.get();
+}
+
+template<class T>
 inline bool operator!=(const Holder<T>& lhs, std::nullptr_t) noexcept
 {
     return bool(lhs);

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -960,7 +960,7 @@ void Interface::Main()
 	time = GetTickCount();
 	timebase = time;
 	double frames = 0.0;
-	Palette* palette = new Palette( ColorWhite, ColorBlack );
+	PaletteHolder palette = new Palette( ColorWhite, ColorBlack );
 
 	do {
 		std::deque<Timer>::iterator it;
@@ -1184,7 +1184,7 @@ int Interface::LoadFonts()
 		ieWord font_size = atoi( tab->QueryField( rowName, "PX_SIZE" ) ); // not available in BAM fonts.
 		FontStyle font_style = (FontStyle)atoi( tab->QueryField( rowName, "STYLE" ) ); // not available in BAM fonts.
 
-		Palette* pal = NULL;
+		PaletteHolder pal;
 		if (needpalette) {
 			Color fore = ColorWhite;
 			Color back = ColorBlack;
@@ -2870,7 +2870,7 @@ int Interface::PlayMovie(const char* resref)
 		mutable String* cachedSub;
 
 	public:
-		IESubtitles(class Font* fnt, ResRef resref, Palette* pal = nullptr)
+		IESubtitles(class Font* fnt, ResRef resref, PaletteHolder pal = nullptr)
 		: MoviePlayer::SubtitleSet(fnt, pal)
 		{
 			AutoTable sttable(resref);
@@ -2925,9 +2925,8 @@ int Interface::PlayMovie(const char* resref)
 			// FIXME: this doesn't look very good (IWD2), wrong font?
 			Color bg = Color(ieByte(r), ieByte(g), ieByte(b), 0);
 			Color fg = Color(0, 0, 0, 0xff);
-			Palette* pal = new Palette(fg, bg);
+			PaletteHolder pal = new Palette(fg, bg);
 			mp->SetSubtitles(new IESubtitles(font, resref, pal));
-			pal->release();
 		} else {
 			mp->SetSubtitles(new IESubtitles(font, resref));
 		}

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -83,6 +83,7 @@ class Label;
 class Map;
 class MusicMgr;
 class Palette;
+using PaletteHolder = Holder<Palette>;
 class ProjectileServer;
 class Resource;
 class SPLExtHeader;
@@ -414,7 +415,7 @@ public:
 	Holder<StringMgr> strings;
 	Holder<StringMgr> strings2;
 	GlobalTimer * timer;
-	Palette *InfoTextPalette;
+	PaletteHolder InfoTextPalette;
 	int SaveAsOriginal; //if true, saves files in compatible mode
 	int QuitFlag;
 	int EventFlag;

--- a/gemrb/core/Map.h
+++ b/gemrb/core/Map.h
@@ -47,6 +47,7 @@ class Image;
 class IniSpawn;
 class MapReverb;
 class Palette;
+using PaletteHolder = Holder<Palette>;
 class Particles;
 struct PathNode;
 class Projectile;
@@ -313,7 +314,7 @@ public:
 	ieResRef BAM; //not only for saving back (StaticSequence depends on this)
 	ieResRef PaletteRef;
 	// TODO: EE stores also the width/height for WBM and PVRZ resources (see Flags bit 13/15)
-	Palette* palette;
+	PaletteHolder palette;
 	AreaAnimation();
 	AreaAnimation(AreaAnimation *src);
 	~AreaAnimation();

--- a/gemrb/core/MoviePlayer.h
+++ b/gemrb/core/MoviePlayer.h
@@ -50,11 +50,11 @@ public:
 	static const TypeID ID;
 
 	class SubtitleSet {
-		Holder<Palette> pal;
+		PaletteHolder pal;
 		Font* font;
 	
 	public:
-		SubtitleSet(Font* fnt, Palette* pal = nullptr)
+		SubtitleSet(Font* fnt, PaletteHolder pal = nullptr)
 		: pal(pal) {
 			font = fnt;
 			assert(font);

--- a/gemrb/core/Palette.cpp
+++ b/gemrb/core/Palette.cpp
@@ -116,7 +116,7 @@ void Palette::Darken()
 	version++;
 }
 
-Palette* Palette::Copy() const
+PaletteHolder Palette::Copy() const
 {
 	return new Palette(std::begin(col), std::end(col));
 }
@@ -251,7 +251,7 @@ static inline void applyMod(const Color& src, Color& dest,
 	}
 }
 
-void Palette::SetupRGBModification(const Palette* src, const RGBModifier* mods,
+void Palette::SetupRGBModification(const PaletteHolder src, const RGBModifier* mods,
 	unsigned int type)
 {
 	const RGBModifier* tmods = mods+(8*type);
@@ -302,7 +302,7 @@ void Palette::SetupRGBModification(const Palette* src, const RGBModifier* mods,
 	version++;
 }
 
-void Palette::SetupGlobalRGBModification(const Palette* src,
+void Palette::SetupGlobalRGBModification(const PaletteHolder src,
 	const RGBModifier& mod)
 {
 	int i;

--- a/gemrb/core/Projectile.cpp
+++ b/gemrb/core/Projectile.cpp
@@ -243,7 +243,7 @@ void Projectile::CreateOrientedAnimations(Animation **anims, AnimationFactory *a
 }
 
 //apply gradient colors
-void Projectile::SetupPalette(Animation *anim[], Palette *&pal, const ieByte *gradients)
+void Projectile::SetupPalette(Animation *anim[], PaletteHolder &pal, const ieByte *gradients)
 {
 	ieDword Colors[7];
 
@@ -256,7 +256,7 @@ void Projectile::SetupPalette(Animation *anim[], Palette *&pal, const ieByte *gr
 	}
 }
 
-void Projectile::GetPaletteCopy(Animation *anim[], Palette *&pal)
+void Projectile::GetPaletteCopy(Animation *anim[], PaletteHolder &pal)
 {
 	if (pal)
 		return;
@@ -1913,7 +1913,7 @@ void Projectile::Draw(Sprite2D* spr, const Point& p,
 		  unsigned int flags, Color tint) const
 {
 	Video *video = core->GetVideoDriver();
-	Palette* pal = (spr->Bpp == 8) ? palette : NULL;
+	PaletteHolder pal = (spr->Bpp == 8) ? palette : nullptr;
 	video->BlitGameSpriteWithPalette(spr, pal, p.x, p.y, flags|BLIT_BLENDED, tint, NULL);
 }
 

--- a/gemrb/core/Projectile.h
+++ b/gemrb/core/Projectile.h
@@ -232,7 +232,7 @@ public:
 	//these are public but not in the .pro file
 	ProjectileExtension* Extension;
 	bool autofree;
-	Palette* palette;
+	PaletteHolder palette;
 	//internals
 protected:
 	ieResRef smokebam;
@@ -364,7 +364,7 @@ private:
 	void CreateCompositeAnimation(Animation **anims, AnimationFactory *af, int Seq);
 	//oriented animations (also simple ones)
 	void CreateOrientedAnimations(Animation **anims, AnimationFactory *af, int Seq);
-	void GetPaletteCopy(Animation *anim[], Palette *&pal);
+	void GetPaletteCopy(Animation *anim[], PaletteHolder &pal);
 	void GetSmokeAnim();
 	void SetBlend(int brighten);
 	//apply spells and effects on the target, only in single travel mode
@@ -407,7 +407,7 @@ private:
 
 	Actor *GetTarget();
 	void NextTarget(const Point &p);
-	void SetupPalette(Animation *anim[], Palette *&pal, const ieByte *gradients);
+	void SetupPalette(Animation *anim[], PaletteHolder &pal, const ieByte *gradients);
 
 private:
 	void Draw(Sprite2D* spr, const Point& p,

--- a/gemrb/core/Resource.cpp
+++ b/gemrb/core/Resource.cpp
@@ -36,4 +36,17 @@ Resource::~Resource(void)
 	}
 }
 
+// Very similar to Cache::MyHashKey, but returns size_t and can be used from
+// things like unordered_map.
+size_t ResRef::Hash::operator() (const ResRef &k) const
+{
+	size_t nHash = 0;
+	for (char c: k.ref) {
+		if (c == 0)
+			break;
+		nHash = (nHash << 5) ^ tolower(c);
+	}
+	return nHash;
+}
+
 }

--- a/gemrb/core/Resource.h
+++ b/gemrb/core/Resource.h
@@ -66,12 +66,18 @@ public:
 		operator=(str);
 	};
 
+	struct Hash
+	{
+		size_t operator() (const ResRef &) const;
+	};
+	friend struct Hash;
+
 	bool IsEmpty() {
 		return (ref[0] == '\0');
 	}
 
 	const char* CString() const { return ref; }
-	
+
 	operator const char*() const {
 		return (ref[0] == '\0') ? NULL : ref;
 	}

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -618,7 +618,7 @@ void Actor::SetName(int strref, unsigned char type)
 void Actor::SetAnimationID(unsigned int AnimID)
 {
 	//if the palette is locked, then it will be transferred to the new animation
-	Palette *recover = NULL;
+	PaletteHolder recover = nullptr;
 	ieResRef paletteResRef;
 
 	if (anims) {
@@ -8474,7 +8474,7 @@ void Actor::DrawActorSprite(int cx, int cy, uint32_t flags,
 
 	for (const auto& part : anims) {
 		Animation* anim = part.first;
-		Palette* palette = part.second;
+		PaletteHolder palette = part.second;
 
 		Sprite2D* currentFrame = anim->CurrentFrame();
 		if (currentFrame) {
@@ -8484,13 +8484,12 @@ void Actor::DrawActorSprite(int cx, int cy, uint32_t flags,
 				video->BlitGameSpriteWithPalette(currentFrame, palette, cx, cy, flags, tint);
 				palette->col[1].a = tmpa;
 			} else if (TranslucentShadows) {
-				Palette* cpy = palette->Copy();
+				PaletteHolder cpy = palette->Copy();
 				cpy->col[1].a = tint.a / 2;
 				for (int i = 2; i < 256; ++i) {
 					cpy->col[i].a = tint.a;
 				}
 				video->BlitGameSpriteWithPalette(currentFrame, cpy, cx, cy, flags, tint);
-				cpy->release();
 			} else {
 				video->BlitGameSpriteWithPalette(currentFrame, palette, cx, cy, flags, tint);
 			}

--- a/gemrb/core/Scriptable/Actor.h
+++ b/gemrb/core/Scriptable/Actor.h
@@ -387,7 +387,7 @@ private:
 	//this stuff doesn't get saved
 	CharAnimations* anims;
 	
-	using AnimationPart = std::pair<Animation*, Palette*>;
+	using AnimationPart = std::pair<Animation*, PaletteHolder>;
 	struct {
 		std::vector<AnimationPart> anim;
 		std::vector<AnimationPart> shadow;

--- a/gemrb/core/Scriptable/Container.cpp
+++ b/gemrb/core/Scriptable/Container.cpp
@@ -100,12 +100,11 @@ void Container::DrawPile(bool highlight, const Region& vp, uint32_t flags, Color
 				video->BlitGameSprite(icon, Pos.x - vp.x, Pos.y - vp.y, flags, tint);
 			} else {
 				const Color trans;
-				Palette* p = icon->GetPalette();
+				PaletteHolder p = icon->GetPalette();
 				Color tmpc = p->col[1];
 				p->CopyColorRange(&trans, &trans + 1, 1);
 				video->BlitGameSprite(icon, Pos.x - vp.x, Pos.y - vp.y, flags, tint);
 				p->CopyColorRange(&tmpc, &tmpc + 1, 1);
-				p->release();
 			}
 		}
 	}

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -257,7 +257,7 @@ void Scriptable::DrawOverheadText()
 		return;
 
 	unsigned long time = core->GetGame()->Ticks;
-	Palette *palette = NULL;
+	PaletteHolder palette;
 
 	time -= timeStartDisplaying;
 	if (time >= MAX_DELAY) {
@@ -279,7 +279,6 @@ void Scriptable::DrawOverheadText()
 
 	if (!palette) {
 		palette = core->InfoTextPalette;
-		palette->acquire();
 	}
 
 	Point p = (overHeadTextPos.isempty()) ? Pos : overHeadTextPos;
@@ -287,8 +286,6 @@ void Scriptable::DrawOverheadText()
 	Region rgn(p - Point(100, cs) - vp.Origin(), Size(200, 400));
 	core->GetTextFont()->Print( rgn, OverheadText, palette,
 							   IE_FONT_ALIGN_CENTER | IE_FONT_ALIGN_TOP );
-
-	palette->release();
 }
 
 Region Scriptable::DrawingRegion() const

--- a/gemrb/core/Sprite2D.h
+++ b/gemrb/core/Sprite2D.h
@@ -73,8 +73,8 @@ public:
 	virtual void* LockSprite();
 	virtual void UnlockSprite() const;
 
-	virtual Palette *GetPalette() const = 0;
-	virtual void SetPalette(Palette *pal) = 0;
+	virtual PaletteHolder GetPalette() const = 0;
+	virtual void SetPalette(PaletteHolder pal) = 0;
 	virtual Color GetPixel(const Point&) const = 0;
 	Color GetPixel(int x, int y) const;
 	virtual bool HasTransparency() const = 0;

--- a/gemrb/core/Video.cpp
+++ b/gemrb/core/Video.cpp
@@ -247,15 +247,14 @@ void Video::BlitTiled(Region rgn, const Sprite2D* img)
 	}
 }
 
-void Video::BlitGameSpriteWithPalette(Sprite2D* spr, Palette* pal, int x, int y,
+void Video::BlitGameSpriteWithPalette(Sprite2D* spr, PaletteHolder pal, int x, int y,
 							   uint32_t flags, Color tint, const Region* clip)
 {
 	if (pal) {
-		Palette* oldpal = spr->GetPalette();
+		PaletteHolder oldpal = spr->GetPalette();
 		spr->SetPalette(pal);
 		BlitGameSprite(spr, x, y, flags, tint, clip);
 		spr->SetPalette(oldpal);
-		if (oldpal) oldpal->release();
 	} else {
 		BlitGameSprite(spr, x, y, flags, tint, clip);
 	}

--- a/gemrb/core/Video.h
+++ b/gemrb/core/Video.h
@@ -40,7 +40,8 @@ namespace GemRB {
 
 class EventMgr;
 class Palette;
-
+using PaletteHolder = Holder<Palette>;
+  
 // Note: not all these flags make sense together.
 // Specifically: BLIT_GREY overrides BLIT_SEPIA
 enum SpriteBlitFlags : uint32_t {
@@ -189,7 +190,7 @@ public:
 		ieDword gMask, ieDword bMask, ieDword aMask, void* pixels,
 		bool cK = false, int index = 0) = 0;
 	virtual Sprite2D* CreateSprite8(const Region&, void* pixels,
-									Palette* palette, bool cK = false, int index = 0) = 0;
+									PaletteHolder palette, bool cK = false, int index = 0) = 0;
 	virtual Sprite2D* CreatePalettedSprite(const Region&, int bpp, void* pixels,
 										   Color* palette, bool cK = false, int index = 0) = 0;
 	virtual bool SupportsBAMSprites() { return false; }
@@ -206,7 +207,7 @@ public:
 								uint32_t flags, Color tint,
 								const Region* clip = NULL) = 0;
 
-	void BlitGameSpriteWithPalette(Sprite2D* spr, Palette* pal, int x, int y,
+	void BlitGameSpriteWithPalette(Sprite2D* spr, PaletteHolder pal, int x, int y,
 				   uint32_t flags, Color tint, const Region* clip = NULL);
 
 	virtual void BlitVideoBuffer(const VideoBufferPtr& buf, const Point& p, uint32_t flags,

--- a/gemrb/plugins/BAMImporter/BAMFontManager.cpp
+++ b/gemrb/plugins/BAMImporter/BAMFontManager.cpp
@@ -46,7 +46,7 @@ bool BAMFontManager::Open(DataStream* stream)
 }
 
 Font* BAMFontManager::GetFont(unsigned short /*ptSize*/,
-							  FontStyle /*style*/, Palette* pal)
+							  FontStyle /*style*/, PaletteHolder pal)
 {
 	AnimationFactory* af = bamImp->GetAnimationFactory(resRef, IE_NORMAL, false); // released by BAMFont
 	// FIXME: this test only exists to let the minimal test pass
@@ -98,14 +98,10 @@ Font* BAMFontManager::GetFont(unsigned short /*ptSize*/,
 	}
 
 	spr = af->GetFrameWithoutCycle(0);
-	Font* fnt = NULL;
 	if (!pal) {
 		pal = spr->GetPalette();
-		fnt = new Font(pal, lineHeight, baseLine);
-		pal->release();
-	} else {
-		fnt = new Font(pal, lineHeight, baseLine);
 	}
+	Font* fnt = new Font(pal, lineHeight, baseLine);
 	spr->release();
 
 	std::map<Sprite2D*, ieWord> tmp;

--- a/gemrb/plugins/BAMImporter/BAMFontManager.h
+++ b/gemrb/plugins/BAMImporter/BAMFontManager.h
@@ -40,7 +40,7 @@ public:
 
 	bool Open(DataStream* stream);
 
-	Font* GetFont(ieWord pxSize, FontStyle style, Palette* pal = NULL);
+	Font* GetFont(ieWord pxSize, FontStyle style, PaletteHolder pal = nullptr) override;
 };
 
 }

--- a/gemrb/plugins/BAMImporter/BAMImporter.cpp
+++ b/gemrb/plugins/BAMImporter/BAMImporter.cpp
@@ -163,9 +163,8 @@ Sprite2D* BAMImporter::GetFrameInternal(unsigned short findex, unsigned char mod
 	if (mode == IE_SHADED) {
 		// CHECKME: is this ever used? Should we modify the sprite's palette
 		// without creating a local copy for this sprite?
-		Palette* pal = spr->GetPalette();
+		PaletteHolder pal = spr->GetPalette();
 		pal->CreateShadedAlphaChannel();
-		pal->release();
 	}
 	return spr;
 }

--- a/gemrb/plugins/BAMImporter/BAMImporter.h
+++ b/gemrb/plugins/BAMImporter/BAMImporter.h
@@ -25,6 +25,7 @@
 
 #include "RGBAColor.h"
 #include "globals.h"
+#include "Holder.h"
 
 namespace GemRB {
 
@@ -37,6 +38,7 @@ struct FrameEntry {
 };
 
 class Palette;
+using PaletteHolder = Holder<Palette>;
 
 class BAMImporter : public AnimationMgr {
 private:
@@ -45,7 +47,7 @@ private:
 	CycleEntry* cycles;
 	ieWord FramesCount;
 	ieByte CyclesCount;
-	Palette* palette;
+	PaletteHolder palette;
 	ieByte CompressedColorIndex;
 	ieDword FramesOffset, PaletteOffset, FLTOffset;
 	unsigned long DataStart;

--- a/gemrb/plugins/BAMImporter/BAMSprite2D.cpp
+++ b/gemrb/plugins/BAMImporter/BAMSprite2D.cpp
@@ -26,10 +26,9 @@
 namespace GemRB {
 
 BAMSprite2D::BAMSprite2D(const Region& rgn, void* pixels,
-						 Palette* palette, ieDword ck)
+						 PaletteHolder palette, ieDword ck)
 	: Sprite2D(rgn, 8, pixels)
 {
-	palette->acquire();
 	pal = palette;
 	colorkey = ck;
 	BAM = true;
@@ -44,7 +43,6 @@ BAMSprite2D::BAMSprite2D(const BAMSprite2D &obj)
 	assert(obj.pal);
 
 	pal = obj.pal;
-	pal->acquire();
 	colorkey = obj.GetColorKey();
 
 	BAM = true;
@@ -56,29 +54,19 @@ BAMSprite2D* BAMSprite2D::copy() const
 	return new BAMSprite2D(*this);
 }
 
-BAMSprite2D::~BAMSprite2D()
-{
-	pal->release();
-}
-
 /** Get the Palette of a Sprite */
-Palette* BAMSprite2D::GetPalette() const
+PaletteHolder BAMSprite2D::GetPalette() const
 {
-	pal->acquire();
 	return pal;
 }
 
-void BAMSprite2D::SetPalette(Palette* palette)
+void BAMSprite2D::SetPalette(PaletteHolder palette)
 {
 	if (palette == NULL) {
 		Log(WARNING, "BAMSprite2D", "cannot set a NULL palette.");
 		return;
 	}
 
-	palette->acquire();
-	if (pal) {
-		pal->release();
-	}
 	pal = palette;
 }
 

--- a/gemrb/plugins/BAMImporter/BAMSprite2D.h
+++ b/gemrb/plugins/BAMImporter/BAMSprite2D.h
@@ -29,20 +29,19 @@ class AnimationFactory;
 
 class BAMSprite2D : public Sprite2D {
 private:
-	Palette* pal;
+	PaletteHolder pal;
 	ieByte colorkey;
 
 public:
 	// all BAMs have a palette and colorkey so force them at construction
 	// for BAMs the actual colorkey is always green (RGB(0,255,0)) so use colorkey to store the transparency index
 	BAMSprite2D(const Region&, void* pixels,
-				Palette* palette, ieDword colorkey);
+				PaletteHolder palette, ieDword colorkey);
 	BAMSprite2D(const BAMSprite2D &obj);
 	BAMSprite2D* copy() const;
-	~BAMSprite2D();
 
-	Palette *GetPalette() const;
-	void SetPalette(Palette *pal);
+	PaletteHolder GetPalette() const;
+	void SetPalette(PaletteHolder pal);
 	Color GetPixel(const Point&) const;
 	int32_t GetColorKey() const { return colorkey; };
 	void SetColorKey(ieDword ck) { colorkey = (ieByte)ck; };

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -3625,11 +3625,10 @@ static PyObject* SetButtonBAM(Button* btn, const char *ResRef, int CycleIndex, i
 		Picture = old->copy();
 		Sprite2D::FreeSprite(old);
 
-		Palette* newpal = Picture->GetPalette()->Copy();
+		PaletteHolder newpal = Picture->GetPalette()->Copy();
 		const auto& pal16 = core->GetPalette16(col1);
 		newpal->CopyColorRange(&pal16[0],&pal16[12], 4);
 		Picture->SetPalette( newpal );
-		newpal->release();
 	}
 
 	btn->SetPicture( Picture );

--- a/gemrb/plugins/MVEPlayer/MVEPlayer.cpp
+++ b/gemrb/plugins/MVEPlayer/MVEPlayer.cpp
@@ -52,7 +52,6 @@ MVEPlay::MVEPlay(void)
 
 MVEPlay::~MVEPlay(void)
 {
-	g_palette->release();
 }
 
 bool MVEPlay::Open(DataStream* stream)

--- a/gemrb/plugins/MVEPlayer/MVEPlayer.h
+++ b/gemrb/plugins/MVEPlayer/MVEPlayer.h
@@ -36,7 +36,7 @@ class MVEPlay : public MoviePlayer {
 	friend class MVEPlayer;
 	MVEPlayer decoder;
 	VideoBuffer* vidBuf;
-	Palette* g_palette;
+	PaletteHolder g_palette;
 
 private:
 	Video *video;

--- a/gemrb/plugins/SDLVideo/GLPaletteManager.cpp
+++ b/gemrb/plugins/SDLVideo/GLPaletteManager.cpp
@@ -8,7 +8,7 @@
 
 using namespace GemRB;
 
-GLuint GLPaletteManager::CreatePaletteTexture(Palette* palette, unsigned int colorKey, bool attached)
+GLuint GLPaletteManager::CreatePaletteTexture(PaletteHolder palette, unsigned int colorKey, bool attached)
 {
 	const PaletteKey key(palette, colorKey);
 	std::map<PaletteKey, GLuint, PaletteKey> *currentTextures;
@@ -59,7 +59,7 @@ GLuint GLPaletteManager::CreatePaletteTexture(Palette* palette, unsigned int col
 	return currentTextures->at(key);
 }
 
-void GLPaletteManager::RemovePaletteTexture(Palette* palette, unsigned int colorKey, bool attached)
+void GLPaletteManager::RemovePaletteTexture(PaletteHolder palette, unsigned int colorKey, bool attached)
 {
 	const PaletteKey key(palette, colorKey);
 
@@ -84,7 +84,6 @@ void GLPaletteManager::RemovePaletteTexture(Palette* palette, unsigned int color
 	{
 		if (!palette->IsShared())
 		{
-			palette->release();
 			currentIndexes->erase(currentTextures->at(key));
 			glDeleteTextures(1, &(currentTextures->at(key)));
 			currentTextures->erase(key);
@@ -116,7 +115,6 @@ void GLPaletteManager::RemovePaletteTexture(GLuint texture, bool attached)
 		PaletteKey key = currentIndexes->at(texture);
 		if (!key.palette->IsShared())
 		{
-			key.palette->release();
 			currentIndexes->erase(texture);
 			glDeleteTextures(1, &texture);
 			currentTextures->erase(key);
@@ -143,7 +141,6 @@ void GLPaletteManager::ClearUnused(bool attached)
 	{
 		if (!it->first.palette->IsShared())
 		{
-			it->first.palette->release();
 			glDeleteTextures(1, &(currentTextures->at(it->first)));
 			currentIndexes->erase(it->second);
 			currentTextures->erase(it++);
@@ -160,7 +157,6 @@ void GLPaletteManager::Clear()
 	std::map<PaletteKey, GLuint, PaletteKey>::iterator it = textures.begin();
 	while (it != textures.end())
 	{
-		it->first.palette->release();
 		glDeleteTextures(1, &(textures[it->first]));
 		it = textures.erase(it);
 	}
@@ -169,7 +165,6 @@ void GLPaletteManager::Clear()
 	it = a_textures.begin();
 	while (it != a_textures.end())
 	{
-		it->first.palette->release();
 		glDeleteTextures(1, &(a_textures[it->first]));
 		it = a_textures.erase(it);
 	}

--- a/gemrb/plugins/SDLVideo/GLPaletteManager.h
+++ b/gemrb/plugins/SDLVideo/GLPaletteManager.h
@@ -11,10 +11,10 @@ namespace GemRB
 
 	struct PaletteKey
 	{
-		Palette* palette;
+		PaletteHolder palette;
 		unsigned int colorKey;
-		bool operator () (const PaletteKey& lhs, const PaletteKey& rhs) const 
-		{ 
+		bool operator () (const PaletteKey& lhs, const PaletteKey& rhs) const
+		{
 			if (lhs.palette < rhs.palette) return true;
 			else
 			if (rhs.palette < lhs.palette) return false;
@@ -23,7 +23,7 @@ namespace GemRB
 			if (rhs.colorKey < lhs.colorKey) return false;
 			return false;
 		}
-		PaletteKey(Palette* pal, unsigned int key) { colorKey = key; palette = pal; }
+		PaletteKey(PaletteHolder pal, unsigned int key) { colorKey = key; palette = pal; }
 		PaletteKey() {}
 	};
 
@@ -40,8 +40,8 @@ namespace GemRB
 			std::map<GLuint, PaletteKey> a_indexes;
 
 		public:
-			GLuint CreatePaletteTexture(Palette* palette, unsigned int colorKey, bool attached = false);
-			void RemovePaletteTexture(Palette* palette, unsigned int colorKey, bool attached = false);
+			GLuint CreatePaletteTexture(PaletteHolder palette, unsigned int colorKey, bool attached = false);
+			void RemovePaletteTexture(PaletteHolder palette, unsigned int colorKey, bool attached = false);
 			void RemovePaletteTexture(GLuint texture, bool attached = false);
 			void ClearUnused(bool attached = false);
 			void Clear();

--- a/gemrb/plugins/SDLVideo/GLTextureSprite2D.cpp
+++ b/gemrb/plugins/SDLVideo/GLTextureSprite2D.cpp
@@ -32,8 +32,6 @@ GLTextureSprite2D::GLTextureSprite2D (int Width, int Height, int Bpp, void* pixe
 
 GLTextureSprite2D::~GLTextureSprite2D()
 {
-	if (currentPalette != NULL)
-		currentPalette->release();
 	MakeUnused();
 }
 
@@ -58,23 +56,17 @@ GLTextureSprite2D* GLTextureSprite2D::copy() const
 	return new GLTextureSprite2D(*this);
 }
 
-void GLTextureSprite2D::SetPalette(Palette *pal)
+void GLTextureSprite2D::SetPalette(PaletteHolder pal)
 {
 	if (!IsPaletted() || pal == NULL || currentPalette == pal) return;
-	pal->acquire();
-	if (currentPalette != NULL) 
-	{
-		currentPalette->release();
-	}
 	if (glPaletteTexture != 0) paletteManager->RemovePaletteTexture(glPaletteTexture);
 	glPaletteTexture = 0;
 	currentPalette = pal;
 }
 
-Palette* GLTextureSprite2D::GetPalette() const
+PaletteHolder GLTextureSprite2D::GetPalette() const
 {
 	if(!IsPaletted() || currentPalette == NULL) return NULL;
-	currentPalette->acquire();
 	return currentPalette;
 }
 

--- a/gemrb/plugins/SDLVideo/GLTextureSprite2D.h
+++ b/gemrb/plugins/SDLVideo/GLTextureSprite2D.h
@@ -13,7 +13,7 @@ namespace GemRB
 		GLuint glTexture;
 		GLuint glPaletteTexture;
 		GLuint glMaskTexture;
-		Palette* currentPalette;
+		PaletteHolder currentPalette;
 		Uint32 rMask, gMask, bMask, aMask;
 		ieDword colorKeyIndex;
 		GLPaletteManager* paletteManager;
@@ -26,8 +26,8 @@ namespace GemRB
 		GLuint GetPaletteTexture();
 		GLuint GetMaskTexture();
 		void SetPaletteTexture(int texture);
-		Palette* GetPalette() const;
-		void SetPalette(Palette *pal);
+		PaletteHolder GetPalette() const;
+		void SetPalette(PaletteHolder pal);
 		Color GetPixel(unsigned short x, unsigned short y) const;
 		ieDword GetColorKey() const { return colorKeyIndex; }
 		void SetColorKey(ieDword);

--- a/gemrb/plugins/SDLVideo/SDL12Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL12Video.cpp
@@ -185,7 +185,7 @@ void SDL12VideoDriver::BlitSpriteBAMClipped(const Sprite2D* spr, const Region& s
 
 	// other combinations use general case
 
-	Palette* palette = spr->GetPalette();
+	PaletteHolder palette = spr->GetPalette();
 	SDL_Surface* currentBuf = CurrentRenderBuffer();
 
 	SDL_Rect drect = RectFromRegion(dst);
@@ -243,7 +243,6 @@ void SDL12VideoDriver::BlitSpriteBAMClipped(const Sprite2D* spr, const Region& s
 	}
 
 	spr->UnlockSprite();
-	palette->release();
 	delete maskit;
 }
 

--- a/gemrb/plugins/SDLVideo/SDL12Video.h
+++ b/gemrb/plugins/SDLVideo/SDL12Video.h
@@ -136,7 +136,7 @@ public:
 			sprite = SDL_CreateRGBSurfaceFrom( const_cast<void*>(pixelBuf), bufDest.w, bufDest.h, 8, bufDest.w, 0, 0, 0, 0 );
 			va_list args;
 			va_start(args, pitch);
-			Palette* pal = va_arg(args, Palette*);
+			PaletteHolder pal = va_arg(args, PaletteHolder);
 			memcpy(sprite->format->palette->colors, pal->col, sprite->format->palette->ncolors * 4);
 			va_end(args);
 		}

--- a/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
@@ -228,19 +228,18 @@ Sprite2D* GLVideoDriver::CreatePalettedSprite(const Region& rgn, int bpp, void* 
 
 	GLTextureSprite2D* spr = new GLTextureSprite2D(rgn, bpp, pixels);
 	spr->SetPaletteManager(paletteManager);
-	Palette* pal = new Palette(palette);
+	PaletteHolder pal = new Palette(palette);
 	spr->SetPalette(pal);
-	pal->release();
 	if (cK) spr->SetColorKey(index);
 	return spr;
 }
 
-Sprite2D* GLVideoDriver::CreateSprite8(const Region& rgn, void* pixels, Palette* palette, bool cK, int index)
+Sprite2D* GLVideoDriver::CreateSprite8(const Region& rgn, void* pixels, PaletteHolder palette, bool cK, int index)
 {
 	return CreatePalettedSprite(rgn, 8, pixels, palette->col, cK, index);
 }
 
-void GLVideoDriver::GLBlitSprite(GLTextureSprite2D* spr, const Region& src, const Region& dst, Palette* attachedPal,
+void GLVideoDriver::GLBlitSprite(GLTextureSprite2D* spr, const Region& src, const Region& dst, PaletteHolder attachedPal,
 								 unsigned int flags, const Color* tint, GLTextureSprite2D* mask)
 {
 	// TODO: clip dst to the screen?
@@ -384,7 +383,7 @@ void GLVideoDriver::GLBlitSprite(GLTextureSprite2D* spr, const Region& src, cons
 	spritesPerFrame++;
 }
 
-void GLVideoDriver::BlitSprite(const Sprite2D* spr, const Region& src, const Region& dst, Palette* palette)
+void GLVideoDriver::BlitSprite(const Sprite2D* spr, const Region& src, const Region& dst, PaletteHolder palette)
 {
 	GLBlitSprite((GLTextureSprite2D*)spr, src, dst, palette);
 }
@@ -563,7 +562,7 @@ void GLVideoDriver::BlitTile(const Sprite2D* spr, int x, int y, const Region* cl
 }
 
 void GLVideoDriver::BlitGameSprite(const Sprite2D* spr, int x, int y, unsigned int flags, Color tint,
-								   SpriteCover* cover, Palette *palette, const Region* clip, bool anchor)
+								   SpriteCover* cover, PaletteHolder palette, const Region* clip, bool anchor)
 {
 	int tx = x - spr->Frame.x;
 	int ty = y - spr->Frame.y;

--- a/gemrb/plugins/SDLVideo/SDL20GLVideo.h
+++ b/gemrb/plugins/SDLVideo/SDL20GLVideo.h
@@ -47,7 +47,7 @@ namespace GemRB
 
 		void useProgram(GLSLProgram* program); // use this instead program->Use()
 		bool createPrograms();
-		void GLBlitSprite(GLTextureSprite2D* spr, const Region& src, const Region& dst, Palette* attachedPal = NULL, unsigned int flags = 0, const Color* tint = NULL, GLTextureSprite2D* mask = NULL);
+		void GLBlitSprite(GLTextureSprite2D* spr, const Region& src, const Region& dst, PaletteHolder attachedPal = NULL, unsigned int flags = 0, const Color* tint = NULL, GLTextureSprite2D* mask = NULL);
 		void clearRect(const Region& rgn, const Color& color);
 		void drawEllipse(int cx, int cy, unsigned short xr, unsigned short yr, float thickness, const Color& color);
 		void drawPolygon(Point* points, unsigned int count, const Color& color, PointDrawingMode mode);
@@ -56,11 +56,11 @@ namespace GemRB
 		~GLVideoDriver();
 		int SwapBuffers();
 		int CreateDisplay(int w, int h, int b, bool fs, const char* title);
-		void BlitSprite(const Sprite2D* spr, const Region& src, const Region& dst, Palette* palette);
-		void BlitGameSprite(const Sprite2D* spr, int x, int y, unsigned int flags, Color tint, SpriteCover* cover, Palette *palette = NULL,	const Region* clip = NULL, bool anchor = false);
+		void BlitSprite(const Sprite2D* spr, const Region& src, const Region& dst, PaletteHolder palette);
+		void BlitGameSprite(const Sprite2D* spr, int x, int y, unsigned int flags, Color tint, SpriteCover* cover, PaletteHolder palette = NULL, const Region* clip = NULL, bool anchor = false);
 		void BlitTile(const Sprite2D* spr, int x, int y, const Region* clip, unsigned int flags, const Color* tint = NULL);
 		Sprite2D* CreateSprite(const Region&, int bpp, ieDword rMask, ieDword gMask, ieDword bMask, ieDword aMask, void* pixels,	bool cK = false, int index = 0);
-		Sprite2D* CreateSprite8(const Region&, void* pixels,	Palette* palette, bool cK, int index);
+		Sprite2D* CreateSprite8(const Region&, void* pixels, PaletteHolder palette, bool cK, int index);
 		Sprite2D* CreatePalettedSprite(const Region&, int bpp, void* pixels, Color* palette, bool cK = false, int index = 0);
 		void DrawRect(const Region& rgn, const Color& color, bool fill = true, bool clipped = false);
 		void DrawHLine(short x1, short y, short x2, const Color& color, bool clipped = false);

--- a/gemrb/plugins/SDLVideo/SDL20Video.h
+++ b/gemrb/plugins/SDLVideo/SDL20Video.h
@@ -157,7 +157,7 @@ public:
 			// SDL_ConvertPixels doesn't support palettes... must do it ourselves
 			va_list args;
 			va_start(args, pitch);
-			Palette* pal = va_arg(args, Palette*);
+			PaletteHolder pal = va_arg(args, PaletteHolder);
 			va_end(args);
 
 			Uint32* dst = static_cast<Uint32*>(conversionBuffer->pixels);

--- a/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.cpp
+++ b/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.cpp
@@ -106,9 +106,9 @@ void SDLSurfaceSprite2D::UnlockSprite() const
 }
 
 /** Get the Palette of a Sprite */
-Palette* SDLSurfaceSprite2D::GetPalette() const
+PaletteHolder SDLSurfaceSprite2D::GetPalette() const
 {
-	Palette* palette = surface->palette.get();
+	PaletteHolder palette = surface->palette;
 	if (palette == NULL) {
 		SDL_PixelFormat* fmt = (*surface)->format;
 		if (fmt->BytesPerPixel != 1) {
@@ -119,7 +119,6 @@ Palette* SDLSurfaceSprite2D::GetPalette() const
 		const Color* end = begin + fmt->palette->ncolors;
 		palette = new Palette(begin, end);
 	}
-	palette->acquire();
 	surface->palette = palette;
 
 	return palette;
@@ -127,19 +126,18 @@ Palette* SDLSurfaceSprite2D::GetPalette() const
 
 bool SDLSurfaceSprite2D::IsPaletteStale() const
 {
-	Palette* pal = GetPalette();
+	PaletteHolder pal = GetPalette();
 	return pal && pal->GetVersion() != palVersion;
 }
 
-void SDLSurfaceSprite2D::SetPalette(Palette* pal)
+void SDLSurfaceSprite2D::SetPalette(PaletteHolder pal)
 {
-	Palette* palette = surface->palette.get();
+	PaletteHolder palette = surface->palette;
 
 	// we don't use shared palettes because it is a performance bottleneck on SDL2
 	assert(pal != palette);
 
 	if (palette) {
-		palette->release();
 		palette = nullptr;
 	}
 
@@ -296,15 +294,14 @@ void* SDLSurfaceSprite2D::NewVersion(version_t newversion) const
 	}
 
 	if (Bpp == 8) {
-		Palette* pal = GetPalette(); // generate the backup
-		pal->release();
-		
+		PaletteHolder pal = GetPalette(); // generate the backup
+
 		palVersion = pal->GetVersion();
-		
+
 		// we just allow overwritting the palette
 		return surface->surface->format->palette;
 	}
-	
+
 	palVersion = 0;
 
 	if (version != newversion) {

--- a/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.h
+++ b/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.h
@@ -36,7 +36,7 @@ protected:
 	struct SurfaceHolder : public Held<SurfaceHolder>
 	{
 		SDL_Surface* surface;
-		Holder<Palette> palette; // simply a cache for comparing against calls to SetPalette for performance reasons.
+		PaletteHolder palette; // simply a cache for comparing against calls to SetPalette for performance reasons.
 
 		SurfaceHolder(SDL_Surface* surf) : surface(surf), palette(NULL) {}
 		~SurfaceHolder() { SDL_FreeSurface(surface); }
@@ -62,9 +62,9 @@ public:
 	void* LockSprite();
 	void UnlockSprite() const;
 
-	Palette *GetPalette() const;
+	PaletteHolder GetPalette() const;
 	int SetPalette(const Color* pal) const;
-	void SetPalette(Palette *pal);
+	void SetPalette(PaletteHolder pal);
 	int32_t GetColorKey() const;
 	void SetColorKey(ieDword pxvalue);
 	bool HasTransparency() const;

--- a/gemrb/plugins/SDLVideo/SDLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDLVideo.cpp
@@ -258,9 +258,8 @@ Sprite2D* SDLVideoDriver::CreateSprite(const Region& rgn, int bpp, ieDword rMask
 }
 
 Sprite2D* SDLVideoDriver::CreateSprite8(const Region& rgn, void* pixels,
-										Palette* palette, bool cK, int index)
+										PaletteHolder palette, bool cK, int index)
 {
-	assert(palette);
 	return CreatePalettedSprite(rgn, 8, pixels, palette->col, cK, index);
 }
 

--- a/gemrb/plugins/SDLVideo/SDLVideo.h
+++ b/gemrb/plugins/SDLVideo/SDLVideo.h
@@ -69,7 +69,7 @@ public:
 		ieDword gMask, ieDword bMask, ieDword aMask, void* pixels,
 		bool cK = false, int index = 0) override;
 	Sprite2D* CreateSprite8(const Region& rgn, void* pixels,
-							Palette* palette, bool cK, int index) override;
+							PaletteHolder palette, bool cK, int index) override;
 	Sprite2D* CreatePalettedSprite(const Region& rgn, int bpp, void* pixels,
 								   Color* palette, bool cK = false, int index = 0) override;
 

--- a/gemrb/plugins/SDLVideo/SpriteRenderer.inl
+++ b/gemrb/plugins/SDLVideo/SpriteRenderer.inl
@@ -367,26 +367,26 @@ static void BlitSpriteRLE(const Sprite2D* spr, const Region& srect,
 
 	if (srect.Dimensions().IsEmpty())
 		return;
-	
+
 	if (drect.Dimensions().IsEmpty())
 		return;
-	
-	Palette* palette = spr->GetPalette();
+
+	PaletteHolder palette = spr->GetPalette();
 	const Uint8* rledata = (const Uint8*)spr->LockSprite();
 	uint8_t ck = spr->GetColorKey();
-	
+
 	bool partial = spr->Frame.Dimensions() != srect.Dimensions();
-		
+
 	IPixelIterator::Direction xdir = (flags&BLIT_MIRRORX) ? IPixelIterator::Reverse : IPixelIterator::Forward;
 	IPixelIterator::Direction ydir = (flags&BLIT_MIRRORY) ? IPixelIterator::Reverse : IPixelIterator::Forward;
-	
+
 	SDLPixelIterator dstit = SDLPixelIterator(xdir, ydir, RectFromRegion(drect), dst);
-	
+
 	static StaticAlphaIterator nomask(0);
 	if (cover == nullptr) {
 		cover = &nomask;
 	}
-	
+
 	switch (dstit.format->BytesPerPixel) {
 		case 4:
 		{
@@ -412,8 +412,6 @@ static void BlitSpriteRLE(const Sprite2D* spr, const Region& srect,
 			Log(ERROR, "SpriteRenderer", "Invalid Bpp");
 			break;
 	}
-	
-	palette->release();
 }
 
 #undef ADVANCE_ITERATORS

--- a/gemrb/plugins/TTFImporter/TTFFont.cpp
+++ b/gemrb/plugins/TTFImporter/TTFFont.cpp
@@ -196,7 +196,7 @@ int TTFFont::GetKerningOffset(ieWord leftChr, ieWord rightChr) const
 	return (int)(-kerning.x / 64);
 }
 
-TTFFont::TTFFont(Palette* pal, FT_Face face, int lineheight, int baseline)
+TTFFont::TTFFont(PaletteHolder pal, FT_Face face, int lineheight, int baseline)
 	: Font(pal, lineheight, baseline), face(face)
 {
 // on FT < 2.4.2 the manager will defer ownership to this object

--- a/gemrb/plugins/TTFImporter/TTFFont.h
+++ b/gemrb/plugins/TTFImporter/TTFFont.h
@@ -37,7 +37,7 @@ private:
 	const Glyph& AliasBlank(ieWord chr) const;
 
 public:
-	TTFFont(Palette* pal, FT_Face face, int lineheight, int baseline);
+	TTFFont(PaletteHolder pal, FT_Face face, int lineheight, int baseline);
 	~TTFFont(void);
 
 	const Glyph& GetGlyph(ieWord chr) const;

--- a/gemrb/plugins/TTFImporter/TTFFontManager.cpp
+++ b/gemrb/plugins/TTFImporter/TTFFontManager.cpp
@@ -116,7 +116,7 @@ void TTFFontManager::Close()
 }
 
 Font* TTFFontManager::GetFont(unsigned short pxSize,
-							  FontStyle /*style*/, Palette* pal)
+							  FontStyle /*style*/, PaletteHolder pal)
 {
 	if (!pal) {
 		pal = new Palette( ColorWhite, ColorBlack );

--- a/gemrb/plugins/TTFImporter/TTFFontManager.h
+++ b/gemrb/plugins/TTFImporter/TTFFontManager.h
@@ -46,7 +46,7 @@ Public methods
 	void Close();
 
 	Font* GetFont(unsigned short pxSize,
-				  FontStyle style, Palette* pal = NULL);
+				  FontStyle style, PaletteHolder pal = nullptr) override;
 
 	// freetype "callbacks"
 	static unsigned long read( FT_Stream       stream,


### PR DESCRIPTION
I left GemRB running overnight, and in the morning the system was deep
into swap.  Running with -fsanitize=address suggests there are large
leaks of Palette structures.

Examining the code, it uses its own refcounting mechanism, and requires
its users to get acquire/release calls correct.  This all seems
unnecessarily fragile.

This change changes Palette to use Holder/Held.  All instances of raw
Palette * pointers are replaced by PaletteHolder, and (hopefully all)
manual acquire/release calls are removed.  One Cache was replaced with
a std::unordered_map, since it appears Cache can't hold non-pointers
(it uses hard casts to void *).

Tested with BG2: playing movies, going through the various panes
(inventory, character, world map, etc.), and resting.
