### PR TITLE
Fix fallout from previous palette changes

### DIFF
--- a/gemrb/plugins/BAMImporter/BAMFontManager.h
+++ b/gemrb/plugins/BAMImporter/BAMFontManager.h
@@ -38,7 +38,7 @@ public:
 	~BAMFontManager(void);
 	BAMFontManager();
 
-	bool Open(DataStream* stream);
+	bool Open(DataStream* stream) override;
 
 	Font* GetFont(ieWord pxSize, FontStyle style, PaletteHolder pal = nullptr) override;
 };

--- a/gemrb/plugins/MVEPlayer/MVEPlayer.cpp
+++ b/gemrb/plugins/MVEPlayer/MVEPlayer.cpp
@@ -95,7 +95,7 @@ void MVEPlay::showFrame(unsigned char* buf, unsigned int bufw, unsigned int bufh
 	Size s = vidBuf->Size();
 	int dest_x = unsigned(s.w - bufw) >> 1;
 	int dest_y = unsigned(s.h - bufh) >> 1;
-	vidBuf->CopyPixels(Region(dest_x, dest_y, bufw, bufh), buf, NULL, g_palette);
+	vidBuf->CopyPixels(Region(dest_x, dest_y, bufw, bufh), buf, NULL, g_palette.get());
 }
 
 void MVEPlay::setPalette(unsigned char* p, unsigned start, unsigned count)

--- a/gemrb/plugins/SDLVideo/SDL12Video.h
+++ b/gemrb/plugins/SDLVideo/SDL12Video.h
@@ -136,7 +136,7 @@ public:
 			sprite = SDL_CreateRGBSurfaceFrom( const_cast<void*>(pixelBuf), bufDest.w, bufDest.h, 8, bufDest.w, 0, 0, 0, 0 );
 			va_list args;
 			va_start(args, pitch);
-			PaletteHolder pal = va_arg(args, PaletteHolder);
+			Palette *pal = va_arg(args, Palette *);
 			memcpy(sprite->format->palette->colors, pal->col, sprite->format->palette->ncolors * 4);
 			va_end(args);
 		}

--- a/gemrb/plugins/SDLVideo/SDL20Video.h
+++ b/gemrb/plugins/SDLVideo/SDL20Video.h
@@ -157,7 +157,7 @@ public:
 			// SDL_ConvertPixels doesn't support palettes... must do it ourselves
 			va_list args;
 			va_start(args, pitch);
-			PaletteHolder pal = va_arg(args, PaletteHolder);
+			Palette *pal = va_arg(args, Palette *);
 			va_end(args);
 
 			Uint32* dst = static_cast<Uint32*>(conversionBuffer->pixels);

--- a/gemrb/plugins/TTFImporter/TTFFontManager.h
+++ b/gemrb/plugins/TTFImporter/TTFFontManager.h
@@ -42,7 +42,7 @@ Public methods
 	~TTFFontManager(void);
 	TTFFontManager(void);
 
-	bool Open(DataStream* stream);
+	bool Open(DataStream* stream) override;
 	void Close();
 
 	Font* GetFont(unsigned short pxSize,


### PR DESCRIPTION
Clang has some warnings: the previous change added missing override
keywords to some functions, but that made two class definitions
inconsistent, and clang warns about this while gcc doesn't.

The other issue only clang warns about is passing PatternHolder to
a variadic function.  Fixed by passing Pattern * in that particular
case only.
