### PR TITLE
Call LeaveDialog() when changing conversation target

### DIFF
--- a/gemrb/core/DialogHandler.cpp
+++ b/gemrb/core/DialogHandler.cpp
@@ -363,6 +363,7 @@ bool DialogHandler::DialogChoose(unsigned int choose)
 		//follow external linkage, if required
 		if (tr->Dialog[0] && strnicmp( tr->Dialog, dlg->ResRef, 8 )) {
 			//target should be recalculated!
+			target->LeaveDialog();
 			tgt = NULL;
 			tgta = NULL;
 			if (originalTargetID) {


### PR DESCRIPTION
## Description
Fix for #539 (endless conversation loop in PST AR0511).


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
