### PR TITLE
Use Holder for Sprites too (and some other fixes)

### DIFF
--- a/gemrb/core/Animation.cpp
+++ b/gemrb/core/Animation.cpp
@@ -54,9 +54,8 @@ Animation::Animation(int count)
 
 Animation::~Animation(void)
 {
-	for (unsigned int i = 0; i < indicesCount; i++) {
-		frames[i]->release();
-	}
+	// Empty, but having it here rather than defined implicitly means
+	// we don't have to include Sprite2D.h in the header.
 }
 
 void Animation::SetPos(unsigned int index)
@@ -69,13 +68,12 @@ void Animation::SetPos(unsigned int index)
 }
 
 /* when adding NULL, it means we already added a frame of index */
-void Animation::AddFrame(Sprite2D* frame, unsigned int index)
+void Animation::AddFrame(Holder<Sprite2D> frame, unsigned int index)
 {
 	if (index>=indicesCount) {
 		error("Animation", "You tried to write past a buffer in animation, BAD!\n");
 	}
-	Sprite2D::FreeSprite(frames[index]);
-	frames[index]=frame;
+	frames[index] = frame;
 
 	int x = -frame->Frame.x;
 	int y = -frame->Frame.y;
@@ -104,12 +102,12 @@ unsigned int Animation::GetCurrentFrameIndex() const
 	return pos;
 }
 
-Sprite2D* Animation::CurrentFrame() const
+Holder<Sprite2D> Animation::CurrentFrame() const
 {
 	return GetFrame(GetCurrentFrameIndex());
 }
 
-Sprite2D* Animation::LastFrame(void)
+Holder<Sprite2D> Animation::LastFrame(void)
 {
 	if (!(Flags&A_ANI_ACTIVE)) {
 		Log(MESSAGE, "Sprite2D", "Frame fetched while animation is inactive1!");
@@ -120,7 +118,7 @@ Sprite2D* Animation::LastFrame(void)
 	} else {
 		starttime = GetTickCount();
 	}
-	Sprite2D* ret;
+	Holder<Sprite2D> ret;
 	if (playReversed)
 		ret = frames[indicesCount-pos-1];
 	else
@@ -128,7 +126,7 @@ Sprite2D* Animation::LastFrame(void)
 	return ret;
 }
 
-Sprite2D* Animation::NextFrame(void)
+Holder<Sprite2D> Animation::NextFrame(void)
 {
 	if (!(Flags&A_ANI_ACTIVE)) {
 		Log(MESSAGE, "Sprite2D", "Frame fetched while animation is inactive2!");
@@ -141,7 +139,7 @@ Sprite2D* Animation::NextFrame(void)
 			starttime = GetTickCount();
 		}
 	}
-	Sprite2D* ret;
+	Holder<Sprite2D> ret;
 	if (playReversed)
 		ret = frames[indicesCount-pos-1];
 	else
@@ -181,13 +179,13 @@ Sprite2D* Animation::NextFrame(void)
 	return ret;
 }
 
-Sprite2D* Animation::GetSyncedNextFrame(Animation* master)
+Holder<Sprite2D> Animation::GetSyncedNextFrame(Animation* master)
 {
 	if (!(Flags&A_ANI_ACTIVE)) {
 		Log(MESSAGE, "Sprite2D", "Frame fetched while animation is inactive!");
 		return NULL;
 	}
-	Sprite2D* ret;
+	Holder<Sprite2D> ret;
 	if (playReversed)
 		ret = frames[indicesCount-pos-1];
 	else
@@ -208,7 +206,7 @@ void Animation::release(void)
 	delete this;
 }
 /** Gets the i-th frame */
-Sprite2D* Animation::GetFrame(unsigned int i) const
+Holder<Sprite2D> Animation::GetFrame(unsigned int i) const
 {
 	if (i >= indicesCount) {
 		return NULL;
@@ -221,9 +219,7 @@ void Animation::MirrorAnimation()
 	Video *video = core->GetVideoDriver();
 
 	for (size_t i = 0; i < indicesCount; i++) {
-		Sprite2D* tmp = frames[i];
-		frames[i] = video->MirrorSprite( tmp, BLIT_MIRRORX, true );
-		tmp->release();
+		frames[i] = video->MirrorSprite(frames[i], BLIT_MIRRORX, true);
 	}
 
 	// flip animArea horizontally as well
@@ -235,9 +231,7 @@ void Animation::MirrorAnimationVert()
 	Video *video = core->GetVideoDriver();
 
 	for (size_t i = 0; i < indicesCount; i++) {
-		Sprite2D* tmp = frames[i];
-		frames[i] = video->MirrorSprite( tmp, BLIT_MIRRORY, true );
-		tmp->release();
+		frames[i] = video->MirrorSprite(frames[i], BLIT_MIRRORY, true);
 	}
 
 	// flip animArea vertically as well

--- a/gemrb/core/Animation.cpp
+++ b/gemrb/core/Animation.cpp
@@ -32,8 +32,8 @@
 namespace GemRB {
 
 Animation::Animation(int count)
+: frames(count, nullptr)
 {
-	frames = (Sprite2D **) calloc(count, sizeof(Sprite2D *));
 	indicesCount = count;
 	if (count) {
 		pos = RAND(0, count-1);
@@ -57,7 +57,6 @@ Animation::~Animation(void)
 	for (unsigned int i = 0; i < indicesCount; i++) {
 		frames[i]->release();
 	}
-	free(frames);
 }
 
 void Animation::SetPos(unsigned int index)

--- a/gemrb/core/Animation.h
+++ b/gemrb/core/Animation.h
@@ -26,6 +26,7 @@
 #include "globals.h"
 
 #include "Region.h"
+#include "Holder.h"
 
 #include <vector>
 
@@ -37,7 +38,7 @@ class Sprite2D;
 
 class GEM_EXPORT Animation {
 private:
-	std::vector<Sprite2D *> frames;
+	std::vector<Holder<Sprite2D>> frames;
 	unsigned int indicesCount;
 	unsigned long starttime;
 public:
@@ -49,16 +50,17 @@ public:
 	bool gameAnimation;
 	Region animArea;
 	ieDword Flags;
+
 	Animation(int count);
-	~Animation(void);
-	void AddFrame(Sprite2D* frame, unsigned int index);
-	Sprite2D* CurrentFrame() const;
-	Sprite2D* LastFrame();
-	Sprite2D* NextFrame();
-	Sprite2D* GetSyncedNextFrame(Animation* master);
+	~Animation();
+	void AddFrame(Holder<Sprite2D> frame, unsigned int index);
+	Holder<Sprite2D> CurrentFrame() const;
+	Holder<Sprite2D> LastFrame();
+	Holder<Sprite2D> NextFrame();
+	Holder<Sprite2D> GetSyncedNextFrame(Animation* master);
 	void release(void);
 	/** Gets the i-th frame */
-	Sprite2D* GetFrame(unsigned int i) const;
+	Holder<Sprite2D> GetFrame(unsigned int i) const;
 	/** Mirrors all the frames vertically */
 	void MirrorAnimationVert();
 	/** Mirrors all the frames horizontally */

--- a/gemrb/core/Animation.h
+++ b/gemrb/core/Animation.h
@@ -37,7 +37,7 @@ class Sprite2D;
 
 class GEM_EXPORT Animation {
 private:
-	Sprite2D **frames;
+	std::vector<Sprite2D *> frames;
 	unsigned int indicesCount;
 	unsigned long starttime;
 public:

--- a/gemrb/core/AnimationFactory.cpp
+++ b/gemrb/core/AnimationFactory.cpp
@@ -36,9 +36,6 @@ AnimationFactory::AnimationFactory(const char* ResRef)
 
 AnimationFactory::~AnimationFactory(void)
 {
-	for (unsigned int i = 0; i < frames.size(); i++) {
-		frames[i]->release();
-	}
 	if (FLTable)
 		free( FLTable);
 
@@ -46,7 +43,7 @@ AnimationFactory::~AnimationFactory(void)
 		free( FrameData);
 }
 
-void AnimationFactory::AddFrame(Sprite2D* frame)
+void AnimationFactory::AddFrame(Holder<Sprite2D> frame)
 {
 	frames.push_back( frame );
 }
@@ -82,14 +79,13 @@ Animation* AnimationFactory::GetCycle(unsigned char cycle)
 	Animation* anim = new Animation( cycles[cycle].FramesCount );
 	int c = 0;
 	for (int i = ff; i < lf; i++) {
-		frames[FLTable[i]]->acquire();
-		anim->AddFrame( frames[FLTable[i]], c++ );
+		anim->AddFrame(frames[FLTable[i]], c++);
 	}
 	return anim;
 }
 
 /* returns the required frame of the named cycle, cycle defaults to 0 */
-Sprite2D* AnimationFactory::GetFrame(unsigned short index, unsigned char cycle) const
+Holder<Sprite2D> AnimationFactory::GetFrame(unsigned short index, unsigned char cycle) const
 {
 	if (cycle >= cycles.size()) {
 		return NULL;
@@ -98,23 +94,19 @@ Sprite2D* AnimationFactory::GetFrame(unsigned short index, unsigned char cycle) 
 	if(index >= fc) {
 		return NULL;
 	}
-	Sprite2D* spr = frames[FLTable[ff+index]];
-	spr->acquire();
-	return spr;
+	return frames[FLTable[ff+index]];
 }
 
-Sprite2D* AnimationFactory::GetFrameWithoutCycle(unsigned short index) const
+Holder<Sprite2D> AnimationFactory::GetFrameWithoutCycle(unsigned short index) const
 {
 	if(index >= frames.size()) {
 		return NULL;
 	}
-	Sprite2D* spr = frames[index];
-	spr->acquire();
-	return spr;
+	return frames[index];
 }
 
-Sprite2D* AnimationFactory::GetPaperdollImage(ieDword *Colors,
-		Sprite2D *&Picture2, unsigned int type) const
+Holder<Sprite2D> AnimationFactory::GetPaperdollImage(ieDword *Colors,
+		Holder<Sprite2D> &Picture2, unsigned int type) const
 {
 	if (frames.size()<2) {
 		return NULL;
@@ -148,7 +140,7 @@ Sprite2D* AnimationFactory::GetPaperdollImage(ieDword *Colors,
 	Picture2->Frame.x = (short)frames[second]->Frame.x;
 	Picture2->Frame.y = (short)frames[second]->Frame.y - 80;
 
-	Sprite2D* spr = frames[first]->copy();
+	Holder<Sprite2D> spr = frames[first]->copy();
 	if (Colors) {
 		PaletteHolder palette = spr->GetPalette();
 		palette->SetupPaperdollColours(Colors, type);

--- a/gemrb/core/AnimationFactory.h
+++ b/gemrb/core/AnimationFactory.h
@@ -32,26 +32,26 @@ namespace GemRB {
 
 class GEM_EXPORT AnimationFactory : public FactoryObject {
 private:
-	std::vector< Sprite2D*> frames;
-	std::vector< CycleEntry> cycles;
+	std::vector<Holder<Sprite2D>> frames;
+	std::vector<CycleEntry> cycles;
 	unsigned short* FLTable;	// Frame Lookup Table
 	unsigned char* FrameData;
 
 public:
 	AnimationFactory(const char* ResRef);
 	~AnimationFactory(void);
-	void AddFrame(Sprite2D* frame);
+	void AddFrame(Holder<Sprite2D> frame);
 	void AddCycle(CycleEntry cycle);
 	void LoadFLT(unsigned short* buffer, int count);
 	void SetFrameData(unsigned char* FrameData);
 	Animation* GetCycle(unsigned char cycle);
 	/** No descriptions */
-	Sprite2D* GetFrame(unsigned short index, unsigned char cycle=0) const;
-	Sprite2D* GetFrameWithoutCycle(unsigned short index) const;
+	Holder<Sprite2D> GetFrame(unsigned short index, unsigned char cycle=0) const;
+	Holder<Sprite2D> GetFrameWithoutCycle(unsigned short index) const;
 	size_t GetCycleCount() const { return cycles.size(); }
 	size_t GetFrameCount() const { return frames.size(); }
 	int GetCycleSize(size_t idx) const;
-	Sprite2D* GetPaperdollImage(ieDword *Colors, Sprite2D *&Picture2,
+	Holder<Sprite2D> GetPaperdollImage(ieDword *Colors, Holder<Sprite2D> &Picture2,
 		unsigned int type) const;
 
 };

--- a/gemrb/core/AnimationMgr.h
+++ b/gemrb/core/AnimationMgr.h
@@ -41,7 +41,7 @@ public:
 		unsigned char mode = IE_NORMAL, bool allowCompression = true) = 0;
 	/** Debug Function: Returns the Global Animation Palette as a Sprite2D Object.
 	If the Global Animation Palette is NULL, returns NULL. */
-	virtual Sprite2D* GetPalette() = 0;
+	virtual Holder<Sprite2D> GetPalette() = 0;
 	virtual int GetCycleCount() = 0;
 };
 

--- a/gemrb/core/ControlAnimation.cpp
+++ b/gemrb/core/ControlAnimation.cpp
@@ -117,7 +117,7 @@ void ControlAnimation::UpdateAnimation(bool paused)
 }
 
 void ControlAnimation::UpdateAnimationSprite () {
-	Sprite2D* pic = bam->GetFrame( (unsigned short) frame, (unsigned char) cycle );
+	Holder<Sprite2D> pic = bam->GetFrame((unsigned short) frame, (unsigned char) cycle);
 
 	if (pic == NULL) {
 		//stopping at end frame

--- a/gemrb/core/DialogHandler.cpp
+++ b/gemrb/core/DialogHandler.cpp
@@ -421,11 +421,10 @@ bool DialogHandler::DialogChoose(unsigned int choose)
 
 	if (tgta) {
 		// displaying npc text and portrait
-		Sprite2D* portrait = tgta->CopyPortrait(1);
+		Holder<Sprite2D> portrait = tgta->CopyPortrait(1);
 		ta->SetAnimPicture(portrait);
 		ta->AppendText(L"\n");
 		displaymsg->DisplayStringName( ds->StrRef, DMC_DIALOG, target, IE_STR_SOUND|IE_STR_SPEECH);
-		Sprite2D::FreeSprite(portrait);
 	}
 
 	int idx = 0;

--- a/gemrb/core/GUI/Button.h
+++ b/gemrb/core/GUI/Button.h
@@ -133,17 +133,17 @@ public:
 	bool IsOpaque() const;
 	/** Sets the 'type' Image of the Button to 'img'.
 	see 'BUTTON_IMAGE_TYPE' */
-	void SetImage(BUTTON_IMAGE_TYPE, Sprite2D* img);
+	void SetImage(BUTTON_IMAGE_TYPE, Holder<Sprite2D> img);
 	/** Sets the Button State */
 	void SetState(unsigned char state);
 	/** Sets the Text of the current control */
 	void SetText(const String& string);
 	/** Sets the Picture */
-	void SetPicture(Sprite2D* Picture);
+	void SetPicture(Holder<Sprite2D> Picture);
 	/** Clears the list of Pictures */
 	void ClearPictureList();
 	/** Add picture to the end of the list of Pictures */
-	void StackPicture(Sprite2D* Picture);
+	void StackPicture(Holder<Sprite2D> Picture);
 	/** Sets border/frame parameters */
 	void SetBorder(int index, const Region&, const Color &color, bool enabled = false, bool filled = false);
 	/** Sets horizontal overlay, used in portrait hp overlay */
@@ -160,7 +160,7 @@ public:
 	bool AcceptsDragOperation(const DragOp&) const;
 	void CompleteDragOperation(const DragOp&);
 
-	Sprite2D* Cursor() const;
+	Holder<Sprite2D> Cursor() const;
 
 	/** Refreshes the button from a radio group */
 	void UpdateState(unsigned int Sum);
@@ -184,11 +184,11 @@ private: // Private attributes
 	bool pulseBorder;
 	PaletteHolder normal_palette;
 	PaletteHolder disabled_palette;
-	Sprite2D* buttonImages[BUTTON_IMAGE_TYPE_COUNT];
+	Holder<Sprite2D> buttonImages[BUTTON_IMAGE_TYPE_COUNT];
 	/** Pictures to Apply when the hasPicture flag is set */
-	Sprite2D* Picture;
+	Holder<Sprite2D> Picture;
 	/** If non-empty, list of Pictures to draw when hasPicture is set */
-	std::vector<Sprite2D*> PictureList;
+	std::vector<Holder<Sprite2D>> PictureList;
 	/** The current state of the Button */
 	unsigned char State;
 	double Clipping;

--- a/gemrb/core/GUI/Control.cpp
+++ b/gemrb/core/GUI/Control.cpp
@@ -175,7 +175,7 @@ void Control::SetValueRange(ieDword min, ieDword max)
 	SetValueRange(ValueRange(min, max));
 }
 
-void Control::SetAnimPicture(Sprite2D* newpic)
+void Control::SetAnimPicture(Holder<Sprite2D> newpic)
 {
 	AnimPicture = newpic;
 	MarkDirty();

--- a/gemrb/core/GUI/Control.h
+++ b/gemrb/core/GUI/Control.h
@@ -145,7 +145,7 @@ public:
 
 	virtual String QueryText() const { return String(); }
 	/** Sets the animation picture ref */
-	virtual void SetAnimPicture(Sprite2D* Picture);
+	virtual void SetAnimPicture(Holder<Sprite2D> Picture);
 
 	typedef std::pair<ieDword, ieDword> ValueRange;
 	const static ValueRange MaxValueRange;

--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -367,7 +367,7 @@ void GameControl::DrawArrowMarker(Point p, const Color& color)
 		draw |= D_UP;
 	}
 
-	Sprite2D *spr = core->GetScrollCursorSprite(0,0);
+	Holder<Sprite2D> spr = core->GetScrollCursorSprite(0,0);
 	int tmp = spr->Frame.w;
 	if (p.x > vpOrigin.x + frame.w - tmp) {
 		p.x = vpOrigin.x + frame.w;
@@ -382,11 +382,9 @@ void GameControl::DrawArrowMarker(Point p, const Color& color)
 
 	if (arrow_orientations[draw]>=0) {
 		Video* video = core->GetVideoDriver();
-		Sprite2D *arrow = core->GetScrollCursorSprite(arrow_orientations[draw], 0);
+		Holder<Sprite2D> arrow = core->GetScrollCursorSprite(arrow_orientations[draw], 0);
 		video->BlitGameSprite(arrow, p.x - vpOrigin.x, p.y - vpOrigin.y, BLIT_TINTED | BLIT_BLENDED, color, NULL);
-		arrow->release();
 	}
-	spr->release();
 }
 
 void GameControl::DrawTargetReticle(int size, const Color& color, const Point& p) const
@@ -457,9 +455,7 @@ void GameControl::WillDraw()
 
 				if ((ScreenFlags & SF_ALWAYSCENTER) == 0) {
 					// set these cursors on game window so they are universal
-					Sprite2D* cursor = core->GetScrollCursorSprite(cursorFrame, numScrollCursor);
-					window->SetCursor(cursor);
-					Sprite2D::FreeSprite(cursor);
+					window->SetCursor(core->GetScrollCursorSprite(cursorFrame, numScrollCursor));
 
 					numScrollCursor = (numScrollCursor+1) % 15;
 				}
@@ -652,11 +648,10 @@ void GameControl::DrawSelf(Region screen, const Region& /*clip*/)
 
 	// Draw lightmap
 	if (DebugFlags & DEBUG_SHOW_LIGHTMAP) {
-		Sprite2D* spr = area->LightMap->GetSprite2D();
-		video->BlitSprite( spr, 0, 0 );
-		Sprite2D::FreeSprite( spr );
-		Region point( gameMousePos.x / 16, gameMousePos.y / 12, 2, 2 );
-		video->DrawRect( point, ColorRed );
+		Holder<Sprite2D> spr = area->LightMap->GetSprite2D();
+		video->BlitSprite(spr, 0, 0);
+		Region point(gameMousePos.x / 16, gameMousePos.y / 12, 2, 2);
+		video->DrawRect(point, ColorRed);
 	}
 
 	if (core->HasFeature(GF_ONSCREEN_TEXT) && DisplayText) {
@@ -1266,7 +1261,7 @@ int GameControl::GetCursorOverContainer(Container *overContainer) const
 	return IE_CURSOR_TAKE;
 }
 
-Sprite2D* GameControl::GetTargetActionCursor() const
+Holder<Sprite2D> GameControl::GetTargetActionCursor() const
 {
 	int curIdx = -1;
 	switch(target_mode) {
@@ -1292,9 +1287,9 @@ Sprite2D* GameControl::GetTargetActionCursor() const
 	return nullptr;
 }
 
-Sprite2D* GameControl::Cursor() const
+Holder<Sprite2D> GameControl::Cursor() const
 {
-	Sprite2D* cursor = View::Cursor();
+	Holder<Sprite2D> cursor = View::Cursor();
 	if (cursor == NULL && lastCursor != IE_CURSOR_INVALID) {
 		int idx = lastCursor & ~IE_CURSOR_GRAY;
 		if (EventMgr::MouseDown()) {

--- a/gemrb/core/GUI/GameControl.h
+++ b/gemrb/core/GUI/GameControl.h
@@ -216,8 +216,8 @@ public:
 	void UpdateTargetMode();
 
 	// returns the default cursor fitting the targeting mode
-	Sprite2D* GetTargetActionCursor() const;
-	Sprite2D* Cursor() const;
+	Holder<Sprite2D> GetTargetActionCursor() const;
+	Holder<Sprite2D> Cursor() const;
 
 	bool HandleActiveRegion(InfoPoint *trap, Actor *actor, const Point& p);
 

--- a/gemrb/core/GUI/MapControl.cpp
+++ b/gemrb/core/GUI/MapControl.cpp
@@ -201,7 +201,7 @@ void MapControl::DrawSelf(Region rgn, const Region& /*clip*/)
 
 			Point pos = ConvertPointFromGame(mn.Pos);
 
-			Sprite2D* anim = (flags) ? flags->GetFrame(0, mn.color) : NULL;
+			Holder<Sprite2D> anim = flags ? flags->GetFrame(0, mn.color) : nullptr;
 			if (anim) {
 				video->BlitSprite( anim, pos.x - anim->Frame.w/2, pos.y - anim->Frame.h/2, &rgn );
 			} else {
@@ -241,7 +241,7 @@ void MapControl::UpdateCursor()
 			SetCursor(core->Cursors[IE_CURSOR_GRAB]);
 			break;
 		default:
-			Sprite2D* cursor = (EventMgr::MouseButtonState(GEM_MB_ACTION)) ? core->Cursors[IE_CURSOR_PRESSED] : NULL;
+			Holder<Sprite2D> cursor = EventMgr::MouseButtonState(GEM_MB_ACTION) ? core->Cursors[IE_CURSOR_PRESSED] : nullptr;
 			SetCursor(cursor);
 			break;
 	}

--- a/gemrb/core/GUI/Progressbar.cpp
+++ b/gemrb/core/GUI/Progressbar.cpp
@@ -79,7 +79,7 @@ void Progressbar::DrawSelf(Region rgn, const Region& /*clip*/)
 	//animated progressbar (bg2)
 	Count=val*KnobStepsCount/100;
 	for(unsigned int i=0; i<Count ;i++ ) {
-		Sprite2D *Knob = PBarAnim->GetFrame(i);
+		Holder<Sprite2D> Knob = PBarAnim->GetFrame(i);
 		core->GetVideoDriver()->BlitSprite( Knob, 0, 0 );
 	}
 }
@@ -93,14 +93,14 @@ void Progressbar::UpdateState(unsigned int Sum)
 }
 
 /** Sets the selected image */
-void Progressbar::SetImage(Sprite2D* img, Sprite2D* img2)
+void Progressbar::SetImage(Holder<Sprite2D> img, Holder<Sprite2D> img2)
 {
 	BackGround = img;
 	BackGround2 = img2;
 	MarkDirty();
 }
 
-void Progressbar::SetBarCap(Sprite2D* img3)
+void Progressbar::SetBarCap(Holder<Sprite2D> img3)
 {
 	PBarCap = img3;
 }

--- a/gemrb/core/GUI/Progressbar.h
+++ b/gemrb/core/GUI/Progressbar.h
@@ -57,11 +57,11 @@ public:
 	bool IsOpaque() const { return BackGround && BackGround->HasTransparency() == false; }
 
 	/** Sets the background images */
-	void SetImage(Sprite2D * img, Sprite2D * img2);
+	void SetImage(Holder<Sprite2D> img, Holder<Sprite2D> img2);
 	/** Sets a bam resource for progressbar */
 	void SetAnimation(Animation *arg);
 	/** Sets a mos resource for progressbar cap */
-	void SetBarCap(Sprite2D *img3);
+	void SetBarCap(Holder<Sprite2D> img3);
 	/** Sets the mos coordinates for the progressbar filler mos/cap */
 	void SetSliderPos(int x, int y, int x2, int y2);
 	/** Refreshes a progressbar which is associated with VariableName */

--- a/gemrb/core/GUI/ScrollBar.cpp
+++ b/gemrb/core/GUI/ScrollBar.cpp
@@ -32,7 +32,7 @@
 
 namespace GemRB {
 
-ScrollBar::ScrollBar(const Region& frame, Sprite2D* images[IMAGE_COUNT])
+ScrollBar::ScrollBar(const Region& frame, Holder<Sprite2D> images[IMAGE_COUNT])
 : Control(frame)
 {
 	Init(images);

--- a/gemrb/core/GUI/ScrollBar.h
+++ b/gemrb/core/GUI/ScrollBar.h
@@ -62,7 +62,7 @@ public:
 
 	int StepIncrement;
 
-	ScrollBar(const Region& frame, Sprite2D*[IMAGE_COUNT]);
+	ScrollBar(const Region& frame, Holder<Sprite2D>[IMAGE_COUNT]);
 	ScrollBar(const ScrollBar& sb);
 	ScrollBar& operator=(const ScrollBar& sb);
 
@@ -86,8 +86,7 @@ private: //Private attributes
 	unsigned short State;
 
 private:
-	template <typename T>
-	void Init(T images) {
+	void Init(const Holder<Sprite2D> images[IMAGE_COUNT]) {
 		ControlType = IE_GUI_SCROLLBAR;
 		State = 0;
 		StepIncrement = 1;

--- a/gemrb/core/GUI/Slider.cpp
+++ b/gemrb/core/GUI/Slider.cpp
@@ -119,7 +119,7 @@ void Slider::UpdateState(unsigned int Sum)
 }
 
 /** Sets the selected image */
-void Slider::SetImage(unsigned char type, Sprite2D* img)
+void Slider::SetImage(unsigned char type, Holder<Sprite2D> img)
 {
 	switch (type) {
 		case IE_GUI_SLIDER_KNOB:

--- a/gemrb/core/GUI/Slider.h
+++ b/gemrb/core/GUI/Slider.h
@@ -63,7 +63,7 @@ public:
 	/** Sets the actual Slider Position trimming to the Max and Min Values */
 	void SetPosition(unsigned int pos);
 	/** Sets the selected image */
-	void SetImage(unsigned char type, Sprite2D * img);
+	void SetImage(unsigned char type, Holder<Sprite2D> img);
 	/** Sets the State of the Slider */
 	void SetState(int arg) { State=(unsigned char) arg; }
 	/** Refreshes a slider which is associated with VariableName */

--- a/gemrb/core/GUI/TextArea.cpp
+++ b/gemrb/core/GUI/TextArea.cpp
@@ -285,7 +285,7 @@ void TextArea::DrawSelf(Region drawFrame, const Region& /*clip*/)
 	}
 }
 
-void TextArea::SetAnimPicture(Sprite2D* pic)
+void TextArea::SetAnimPicture(Holder<Sprite2D> pic)
 {
 	if (core->HasFeature(GF_ANIMATED_DIALOG)) {
 		// FIXME: there isnt a specific reason why animatied dialog couldnt also use pics

--- a/gemrb/core/GUI/TextArea.h
+++ b/gemrb/core/GUI/TextArea.h
@@ -130,7 +130,7 @@ public:
 	void SelectAvailableOption(size_t idx);
 	/** Set Selectable */
 	void SetSelectable(bool val);
-	void SetAnimPicture(Sprite2D* Picture);
+	void SetAnimPicture(Holder<Sprite2D> Picture);
 
 	ContentContainer::Margin GetMargins() const;
 	void SetMargins(ContentContainer::Margin m);

--- a/gemrb/core/GUI/TextSystem/Font.cpp
+++ b/gemrb/core/GUI/TextSystem/Font.cpp
@@ -87,7 +87,7 @@ bool Font::GlyphAtlasPage::AddGlyph(ieWord chr, const Glyph& g)
 			const ieByte* pixels = static_cast<const ieByte*>(Sheet->LockSprite());
 			std::copy(pixels, pixels + (Sheet->Frame.w * Sheet->Frame.h), pageData);
 			Sheet->UnlockSprite();
-			Sprite2D::FreeSprite(Sheet);
+			Sheet = nullptr;
 		} else {
 			pageData = (ieByte*)realloc(pageData, SheetRegion.w * glyphH);
 		}
@@ -169,7 +169,7 @@ void Font::CreateGlyphIndex(ieWord chr, ieWord pageIdx, const Glyph* g)
 	AtlasIndex[chr] = GlyphIndexEntry(chr, pageIdx, g);
 }
 
-const Glyph& Font::CreateGlyphForCharSprite(ieWord chr, const Sprite2D* spr)
+const Glyph& Font::CreateGlyphForCharSprite(ieWord chr, const Holder<Sprite2D> spr)
 {
 	assert(AtlasIndex.size() <= chr || AtlasIndex[chr].pageIdx == static_cast<ieWord>(-1));
 	assert(spr);
@@ -452,7 +452,7 @@ size_t Font::RenderLine(const String& line, const Region& lineRgn,
 	return linePos;
 }
 
-Sprite2D* Font::RenderTextAsSprite(const String& string, const Size& size,
+Holder<Sprite2D> Font::RenderTextAsSprite(const String& string, const Size& size,
 								   ieByte alignment, size_t* numPrinted, Point* endPoint) const
 {
 	Size canvasSize = StringSize(string); // same as size(0, 0)
@@ -524,7 +524,7 @@ Sprite2D* Font::RenderTextAsSprite(const String& string, const Size& size,
 	} else if (alignment&IE_FONT_ALIGN_BOTTOM) {
 		rgn.y = -(size.h - rgn.h);
 	}
-	Sprite2D* canvas = core->GetVideoDriver()->CreateSprite8(rgn, canvasPx, palette, true, 0);
+	Holder<Sprite2D> canvas = core->GetVideoDriver()->CreateSprite8(rgn, canvasPx, palette, true, 0);
 
 	return canvas;
 }
@@ -533,7 +533,7 @@ void Font::SetAtlasPalette(PaletteHolder pal) const
 {
 	GlyphAtlas::const_iterator it;
 	for (it = Atlas.begin(); it != Atlas.end(); ++it) {
-		Sprite2D* sheet = (*it)->Sheet;
+		Holder<Sprite2D> sheet = (*it)->Sheet;
 		if (sheet)
 			sheet->SetPalette(pal);
 	}

--- a/gemrb/core/GUI/TextSystem/Font.h
+++ b/gemrb/core/GUI/TextSystem/Font.h
@@ -171,7 +171,7 @@ public:
 	Font(PaletteHolder, ieWord lineheight, ieWord baseline);
 	virtual ~Font();
 
-	const Glyph& CreateGlyphForCharSprite(ieWord chr, const Sprite2D*);
+	const Glyph& CreateGlyphForCharSprite(ieWord chr, Holder<Sprite2D>);
 	// BAM fonts use alisases a lot so this saves quite a bit of space
 	// Aliases are 2 glyphs that share identical frames such as 'ā' and 'a'
 	void CreateAliasForChar(ieWord chr, ieWord alias);
@@ -184,7 +184,7 @@ public:
 
 	virtual int GetKerningOffset(ieWord /*leftChr*/, ieWord /*rightChr*/) const {return 0;};
 
-	Sprite2D* RenderTextAsSprite(const String& string, const Size& size, ieByte alignment,
+	Holder<Sprite2D> RenderTextAsSprite(const String& string, const Size& size, ieByte alignment,
 								 size_t* numPrinted = NULL, Point* = NULL) const;
 
 	// return the number of glyphs printed

--- a/gemrb/core/GUI/TextSystem/TextContainer.cpp
+++ b/gemrb/core/GUI/TextSystem/TextContainer.cpp
@@ -256,11 +256,9 @@ void TextSpan::DrawContentsInRegions(const LayoutRegions& rgns, const Point& off
 	}
 }
 
-ImageSpan::ImageSpan(Sprite2D* im)
+ImageSpan::ImageSpan(Holder<Sprite2D> im)
 	: Content(im->Frame.Dimensions())
 {
-	assert(im);
-	im->acquire();
 	image = im;
 }
 
@@ -272,7 +270,7 @@ void ImageSpan::DrawContentsInRegions(const LayoutRegions& rgns, const Point& of
 	r.y += offset.y;
 	core->GetVideoDriver()->BlitSprite(image, r.x, r.y, &r);
 }
-	
+
 ContentContainer::ContentContainer(const Region& frame)
 : View(frame)
 {
@@ -702,9 +700,8 @@ void TextContainer::DrawSelf(Region drawFrame, const Region& clip)
 		Region sc = video->GetScreenClip();
 		video->SetScreenClip(NULL);
 
-		Sprite2D* cursor = core->GetCursorSprite();
+		Holder<Sprite2D> cursor = core->GetCursorSprite();
 		video->BlitSprite(cursor, drawFrame.x + margin.left, drawFrame.y + margin.top + cursor->Frame.y);
-		cursor->release();
 
 		video->SetScreenClip(&sc);
 	}
@@ -749,9 +746,8 @@ void TextContainer::DrawContents(const Layout& layout, const Point& dp)
 		Region sc = video->GetScreenClip();
 		video->SetScreenClip(NULL);
 
-		Sprite2D* cursor = core->GetCursorSprite();
+		Holder<Sprite2D> cursor = core->GetCursorSprite();
 		video->BlitSprite(cursor, cursorPoint.x + dp.x, cursorPoint.y + dp.y + cursor->Frame.y);
-		cursor->release();
 
 		video->SetScreenClip(&sc);
 	}

--- a/gemrb/core/GUI/TextSystem/TextContainer.h
+++ b/gemrb/core/GUI/TextSystem/TextContainer.h
@@ -105,10 +105,10 @@ private:
 class ImageSpan : public Content
 {
 private:
-	Sprite2D* image;
+	Holder<Sprite2D> image;
 
 public:
-	ImageSpan(Sprite2D* image);
+	ImageSpan(Holder<Sprite2D> image);
 
 protected:
 	void DrawContentsInRegions(const LayoutRegions&, const Point&) const override;

--- a/gemrb/core/GUI/View.cpp
+++ b/gemrb/core/GUI/View.cpp
@@ -71,7 +71,7 @@ View::~View()
 	}
 }
 
-void View::SetBackground(Sprite2D* bg, const Color* c)
+void View::SetBackground(Holder<Sprite2D> bg, const Color* c)
 {
 	background = bg;
 	if (c) backgroundColor = *c;
@@ -79,7 +79,7 @@ void View::SetBackground(Sprite2D* bg, const Color* c)
 	MarkDirty();
 }
 
-void View::SetCursor(Sprite2D* c)
+void View::SetCursor(Holder<Sprite2D> c)
 {
 	cursor = c;
 }

--- a/gemrb/core/GUI/View.h
+++ b/gemrb/core/GUI/View.h
@@ -195,7 +195,7 @@ public:
 	void SetFrame(const Region& r);
 	void SetFrameOrigin(const Point&);
 	void SetFrameSize(const Size&);
-	void SetBackground(Sprite2D*, const Color* = nullptr);
+	void SetBackground(Holder<Sprite2D>, const Color* = nullptr);
 
 	// FIXME: I don't think I like this being virtual. Currently required because ScrollView is "overriding" this
 	// we perhapps should instead have ScrollView implement SubviewAdded and move the view to its contentView there
@@ -248,8 +248,8 @@ public:
 	void SetTooltip(const String& string);
 	virtual String TooltipText() const { return tooltip; }
 	/* override the standard cursors. default does not override (returns NULL). */
-	virtual Sprite2D* Cursor() const { return cursor.get(); }
-	void SetCursor(Sprite2D* c);
+	virtual Holder<Sprite2D> Cursor() const { return cursor.get(); }
+	void SetCursor(Holder<Sprite2D> c);
 	void SetEventProxy(View* proxy);
 
 	// GUIScripting

--- a/gemrb/core/GUI/Window.cpp
+++ b/gemrb/core/GUI/Window.cpp
@@ -189,9 +189,9 @@ String Window::TooltipText() const
 	return ScrollView::TooltipText();
 }
 
-Sprite2D* Window::Cursor() const
+Holder<Sprite2D> Window::Cursor() const
 {
-	Sprite2D* cursor = ScrollView::Cursor();
+	Holder<Sprite2D> cursor = ScrollView::Cursor();
 	if (cursor == NULL && hoverView) {
 		cursor = hoverView->Cursor();
 	}

--- a/gemrb/core/GUI/Window.h
+++ b/gemrb/core/GUI/Window.h
@@ -125,7 +125,7 @@ public:
 
 	void SetPosition(WindowPosition);
 	String TooltipText() const override;
-	Sprite2D* Cursor() const override;
+	Holder<Sprite2D> Cursor() const override;
 	bool IsDisabledCursor() const override;
 	bool IsReceivingEvents() const override { return true; }
 

--- a/gemrb/core/GUI/WindowManager.cpp
+++ b/gemrb/core/GUI/WindowManager.cpp
@@ -505,12 +505,12 @@ void WindowManager::DrawWindowFrame() const
 
 	video->SetScreenClip( NULL );
 
-	Sprite2D* left_edge = WinFrameEdge(0);
+	Holder<Sprite2D> left_edge = WinFrameEdge(0);
 	if (left_edge) {
 		// we assume if one fails, they all do
-		Sprite2D *right_edge = WinFrameEdge(1);
-		Sprite2D *top_edge = WinFrameEdge(2);
-		Sprite2D *bot_edge = WinFrameEdge(3);
+		Holder<Sprite2D> right_edge = WinFrameEdge(1);
+		Holder<Sprite2D> top_edge = WinFrameEdge(2);
+		Holder<Sprite2D> bot_edge = WinFrameEdge(3);
 
 		int left_w = left_edge->Frame.w;
 		int right_w = right_edge->Frame.w;
@@ -615,9 +615,9 @@ void WindowManager::DrawWindows() const
 }
 
 //copies a screenshot into a sprite
-Sprite2D* WindowManager::GetScreenshot(Window* win)
+Holder<Sprite2D> WindowManager::GetScreenshot(Window* win)
 {
-	Sprite2D* screenshot = NULL;
+	Holder<Sprite2D> screenshot;
 	if (win) { // we dont really care if we are managing the window
 		// only a screen shot of passed win
 		auto& winBuf = win->DrawWithoutComposition();
@@ -634,7 +634,7 @@ Sprite2D* WindowManager::GetScreenshot(Window* win)
 	return screenshot;
 }
 
-Sprite2D* WindowManager::WinFrameEdge(int edge) const
+Holder<Sprite2D> WindowManager::WinFrameEdge(int edge) const
 {
 	std::string refstr = "STON";
 
@@ -665,7 +665,7 @@ Sprite2D* WindowManager::WinFrameEdge(int edge) const
 	static std::map<ResRef, FrameImage> frames;
 
 	ResRef ref = refstr.c_str();
-	Sprite2D* frame = NULL;
+	Holder<Sprite2D> frame;
 	if (frames.find(ref) != frames.end()) {
 		frame = frames[ref].get();
 	} else {

--- a/gemrb/core/GUI/WindowManager.h
+++ b/gemrb/core/GUI/WindowManager.h
@@ -88,7 +88,7 @@ private:
 
 private:
 	bool IsOpenWindow(Window* win) const;
-	Sprite2D* WinFrameEdge(int edge) const;
+	Holder<Sprite2D> WinFrameEdge(int edge) const;
 
 	inline void DrawWindowFrame() const;
 	inline void DrawMouse() const;
@@ -135,7 +135,7 @@ public:
 
 	Size ScreenSize() const { return screen.Dimensions(); }
 
-	Sprite2D* GetScreenshot(Window* win);
+	Holder<Sprite2D> GetScreenshot(Window* win);
 	Window* GetGameWindow() const { return gameWin; }
 
 	static void SetTooltipDelay(int);

--- a/gemrb/core/GUI/WorldMapControl.cpp
+++ b/gemrb/core/GUI/WorldMapControl.cpp
@@ -88,8 +88,8 @@ void WorldMapControl::DrawSelf(Region rgn, const Region& /*clip*/)
 
 		int xOffs = MAP_TO_SCREENX(m->X);
 		int yOffs = MAP_TO_SCREENY(m->Y);
-		Sprite2D* icon = m->GetMapIcon(worldmap->bam, OverrideIconPalette);
-		if( icon ) {
+		Holder<Sprite2D> icon = m->GetMapIcon(worldmap->bam, OverrideIconPalette);
+		if (icon) {
 			if (m == Area && m->HighlightSelected()) {
 				PaletteHolder pal = icon->GetPalette();
 				icon->SetPalette(pal_selected.get());
@@ -98,7 +98,6 @@ void WorldMapControl::DrawSelf(Region rgn, const Region& /*clip*/)
 			} else {
 				video->BlitSprite( icon, xOffs, yOffs, &rgn );
 			}
-			Sprite2D::FreeSprite( icon );
 		}
 
 		if (AnimPicture && (!strnicmp(m->AreaResRef, currentArea, 8)
@@ -114,14 +113,13 @@ void WorldMapControl::DrawSelf(Region rgn, const Region& /*clip*/)
 	for(i=0;i<ec;i++) {
 		WMPAreaEntry *m = worldmap->GetEntry(i);
 		if (! (m->GetAreaStatus() & WMP_ENTRY_VISIBLE)) continue;
-		Sprite2D *icon=m->GetMapIcon(worldmap->bam, OverrideIconPalette);
+		Holder<Sprite2D> icon = m->GetMapIcon(worldmap->bam, OverrideIconPalette);
 		int h=0,w=0,xpos=0,ypos=0;
 		if (icon) {
 			h=icon->Frame.h;
 			w=icon->Frame.w;
 			xpos=icon->Frame.x;
 			ypos=icon->Frame.y;
-			Sprite2D::FreeSprite( icon );
 		}
 
 		Region r2 = Region( MAP_TO_SCREENX(m->X-xpos), MAP_TO_SCREENY(m->Y-ypos), w, h );
@@ -156,7 +154,7 @@ void WorldMapControl::ScrollTo(const Point& pos)
 {
 	Pos = pos;
 	WorldMap* worldmap = core->GetWorldMap();
-	Sprite2D *MapMOS = worldmap->GetMapMOS();
+	Holder<Sprite2D> MapMOS = worldmap->GetMapMOS();
 
 	int maxx = MapMOS->Frame.w - frame.w;
 	int maxy = MapMOS->Frame.h - frame.h;
@@ -187,14 +185,13 @@ bool WorldMapControl::OnMouseOver(const MouseEvent& me)
 				continue; //invisible or inaccessible
 			}
 
-			Sprite2D *icon=ae->GetMapIcon(worldmap->bam, OverrideIconPalette);
+			Holder<Sprite2D> icon = ae->GetMapIcon(worldmap->bam, OverrideIconPalette);
 			Region rgn(ae->X, ae->Y, 0, 0);
 			if (icon) {
 				rgn.x -= icon->Frame.x;
 				rgn.y -= icon->Frame.y;
 				rgn.w = icon->Frame.w;
 				rgn.h = icon->Frame.h;
-				Sprite2D::FreeSprite( icon );
 			}
 			if (ftext && ae->GetCaption()) {
 				Size ts = ftext->StringSize(*ae->GetCaption());

--- a/gemrb/core/GameData.cpp
+++ b/gemrb/core/GameData.cpp
@@ -420,9 +420,9 @@ VEFObject* GameData::GetVEFObject(const char *effect, bool doublehint)
 
 // Return single BAM frame as a sprite. Use if you want one frame only,
 // otherwise it's not efficient
-Sprite2D* GameData::GetBAMSprite(const ieResRef ResRef, int cycle, int frame, bool silent)
+Holder<Sprite2D> GameData::GetBAMSprite(const ieResRef ResRef, int cycle, int frame, bool silent)
 {
-	Sprite2D *tspr;
+	Holder<Sprite2D> tspr;
 	AnimationFactory* af = ( AnimationFactory* )
 		GetFactoryResource( ResRef, IE_BAM_CLASS_ID, IE_NORMAL, silent );
 	if (!af) return 0;

--- a/gemrb/core/GameData.h
+++ b/gemrb/core/GameData.h
@@ -103,7 +103,7 @@ public:
 	VEFObject* GetVEFObject( const char *ResRef, bool doublehint);
 
 	/** returns a single sprite (not cached) from a BAM resource */
-	Sprite2D* GetBAMSprite(const ieResRef ResRef, int cycle, int frame, bool silent=false);
+	Holder<Sprite2D> GetBAMSprite(const ieResRef ResRef, int cycle, int frame, bool silent=false);
 
 	/** returns factory resource, currently works only with animations */
 	FactoryObject* GetFactoryResource(const char* resname, SClass_ID type,

--- a/gemrb/core/Image.cpp
+++ b/gemrb/core/Image.cpp
@@ -33,7 +33,7 @@ Image::~Image()
 	delete[] data;
 }
 
-Sprite2D* Image::GetSprite2D()
+Holder<Sprite2D> Image::GetSprite2D()
 {
 	union {
 		unsigned char color[sizeof(ieDword)];

--- a/gemrb/core/Image.h
+++ b/gemrb/core/Image.h
@@ -22,6 +22,8 @@
 #include "RGBAColor.h"
 #include "exports.h"
 
+#include "Holder.h"
+
 namespace GemRB {
 
 class Sprite2D;
@@ -53,7 +55,7 @@ public:
 	{
 		return width;
 	}
-	Sprite2D *GetSprite2D();
+	Holder<Sprite2D> GetSprite2D();
 private:
 	unsigned int height, width;
 	Color *data;

--- a/gemrb/core/ImageFactory.cpp
+++ b/gemrb/core/ImageFactory.cpp
@@ -24,22 +24,10 @@
 
 namespace GemRB {
 
-ImageFactory::ImageFactory(const char* ResRef, Sprite2D* bitmap_)
+ImageFactory::ImageFactory(const char* ResRef, Holder<Sprite2D> bitmap_)
 	: FactoryObject( ResRef, IE_BMP_CLASS_ID ), bitmap(bitmap_)
 {
 
 }
-
-ImageFactory::~ImageFactory(void)
-{
-	bitmap->release();
-}
-
-Sprite2D* ImageFactory::GetSprite2D() const
-{
-	bitmap->acquire();
-	return bitmap;
-}
-
 
 }

--- a/gemrb/core/ImageFactory.h
+++ b/gemrb/core/ImageFactory.h
@@ -31,12 +31,11 @@ namespace GemRB {
 
 class GEM_EXPORT ImageFactory : public FactoryObject {
 private:
-	Sprite2D* bitmap;
+	Holder<Sprite2D> bitmap;
 public:
-	ImageFactory(const char* ResRef, Sprite2D* bitmap);
-	~ImageFactory(void);
+	ImageFactory(const char* ResRef, Holder<Sprite2D> bitmap);
 
-	Sprite2D* GetSprite2D() const;
+	Holder<Sprite2D> GetSprite2D() const { return bitmap; }
 };
 
 }

--- a/gemrb/core/ImageMgr.cpp
+++ b/gemrb/core/ImageMgr.cpp
@@ -46,15 +46,13 @@ Bitmap* ImageMgr::GetBitmap()
 	Log(ERROR, "ImageMgr", "Don't know how to handle 24bit bitmap from %s...",
 		str->filename );
 
-	Sprite2D *spr = GetSprite2D();
+	Holder<Sprite2D> spr = GetSprite2D();
 
 	for (unsigned int y = 0; y < height; y++) {
 		for (unsigned int x = 0; x < width; x++) {
 			data->SetAt(x,y, spr->GetPixel(x,y).r);
 		}
 	}
-
-	spr->release();
 
 	return data;
 }
@@ -65,15 +63,13 @@ Image* ImageMgr::GetImage()
 	unsigned int width = GetWidth();
 	Image *data = new Image(width, height);
 
-	Sprite2D *spr = GetSprite2D();
+	Holder<Sprite2D> spr = GetSprite2D();
 
 	for (unsigned int y = 0; y < height; y++) {
 		for (unsigned int x = 0; x < width; x++) {
 			data->SetPixel(x,y, spr->GetPixel(x,y));
 		}
 	}
-
-	spr->release();
 
 	return data;
 }

--- a/gemrb/core/ImageMgr.h
+++ b/gemrb/core/ImageMgr.h
@@ -43,7 +43,7 @@ public:
 	ImageMgr(void);
 	virtual ~ImageMgr(void);
 	/** Returns a \ref Sprite2D containing the image. */
-	virtual Sprite2D* GetSprite2D() = 0;
+	virtual Holder<Sprite2D> GetSprite2D() = 0;
 	virtual Image* GetImage();
 	virtual Bitmap* GetBitmap();
 	/**

--- a/gemrb/core/ImageWriter.h
+++ b/gemrb/core/ImageWriter.h
@@ -31,7 +31,7 @@ public:
 	~ImageWriter(void);
 
 	/** Writes an Sprite2D to a stream and frees the sprite. */
-	virtual void PutImage(DataStream *output, Sprite2D *sprite) = 0;
+	virtual void PutImage(DataStream *output, Holder<Sprite2D> sprite) = 0;
 };
 
 }

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -152,9 +152,6 @@ Interface::Interface()
 
 	UseCorruptedHack = false;
 
-	CursorCount = 0;
-	Cursors = NULL;
-
 	mousescrollspd = 10;
 
 	GameType[0] = '\0';
@@ -210,8 +207,6 @@ Interface::Interface()
 	memset(GameFeatures, 0, sizeof( GameFeatures ));
 	//GameFeatures = 0;
 	//GameFeatures2 = 0;
-	memset( GroundCircles, 0, sizeof( GroundCircles ));
-	memset(FogSprites, 0, sizeof( FogSprites ));
 	memset(&Time, 0, sizeof(Time));
 	AreaAliasTable = NULL;
 	update_scripts = false;
@@ -358,11 +353,8 @@ Interface::~Interface(void)
 
 	delete sgiterator;
 
-	if (Cursors) {
-		for (int i = 0; i < CursorCount; i++) {
-			Sprite2D::FreeSprite( Cursors[i] );
-		}
-		delete[] Cursors;
+	for (auto &c: Cursors) {
+		Sprite2D::FreeSprite(c);
 	}
 
 	size_t i;
@@ -1042,12 +1034,13 @@ int Interface::LoadSprites()
 	Log(MESSAGE, "Core", "Loading Cursors...");
 	AnimationFactory* anim;
 	anim = (AnimationFactory*) gamedata->GetFactoryResource("cursors", IE_BAM_CLASS_ID);
+	int CursorCount = 0;
 	if (anim)
 	{
 		CursorCount = anim->GetCycleCount();
-		Cursors = new Sprite2D * [CursorCount];
+		Cursors.reserve(CursorCount);
 		for (int i = 0; i < CursorCount; i++) {
-			Cursors[i] = anim->GetFrame( 0, (ieByte) i );
+			Cursors.push_back(anim->GetFrame(0, (ieByte) i));
 		}
 	}
 

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -425,11 +425,9 @@ public:
 	ResRef GlobalScript;
 	ResRef WorldMapName[2];
 	Variables * AreaAliasTable;
-	Sprite2D **Cursors;
-	int CursorCount;
-	//Sprite2D *ArrowSprites[MAX_ORIENT/2];
-	Sprite2D *FogSprites[32];
-	Sprite2D *GroundCircles[MAX_CIRCLE_SIZE][6];
+	std::vector<Sprite2D *> Cursors;
+	Sprite2D *FogSprites[32] {};
+	Sprite2D *GroundCircles[MAX_CIRCLE_SIZE][6] {};
 	std::vector<char *> musiclist;
 	std::multimap<ieDword, DamageInfoStruct> DamageInfoMap;
 	TimeStruct Time;

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -425,9 +425,9 @@ public:
 	ResRef GlobalScript;
 	ResRef WorldMapName[2];
 	Variables * AreaAliasTable;
-	std::vector<Sprite2D *> Cursors;
-	Sprite2D *FogSprites[32] {};
-	Sprite2D *GroundCircles[MAX_CIRCLE_SIZE][6] {};
+	std::vector<Holder<Sprite2D> > Cursors;
+	Holder<Sprite2D> FogSprites[32] {};
+	Holder<Sprite2D> GroundCircles[MAX_CIRCLE_SIZE][6] {};
 	std::vector<char *> musiclist;
 	std::multimap<ieDword, DamageInfoStruct> DamageInfoMap;
 	TimeStruct Time;
@@ -627,9 +627,9 @@ public:
 	/** is an area loaded? (prefer Game::GetCurrentArea if including Game.h makes sense) */
 	bool HasCurrentArea() const;
 	/** returns a cursor sprite (not cached) */
-	Sprite2D *GetCursorSprite();
+	Holder<Sprite2D> GetCursorSprite();
 	/** returns a scroll cursor sprite */
-	Sprite2D *GetScrollCursorSprite(int frameNum, int spriteNum);
+	Holder<Sprite2D> GetScrollCursorSprite(int frameNum, int spriteNum);
 	/** returns 0 for unmovable, -1 for movable items, otherwise it
 	returns gold value! */
 	int CanMoveItem(const CREItem *item) const;

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -722,6 +722,7 @@ private:
 					palettes[row][col] = image->GetPixel(col, row);
 				}
 			}
+			delete image;
 			return true;
 		}
 		return false;

--- a/gemrb/core/Map.h
+++ b/gemrb/core/Map.h
@@ -363,7 +363,7 @@ public:
 	TileMap* TMap;
 	Image* LightMap;
 	Bitmap* HeightMap;
-	Sprite2D* SmallMap;
+	Holder<Sprite2D> SmallMap;
 	IniSpawn *INISpawn;
 	ieDword AreaFlags;
 	ieWord AreaType;
@@ -377,7 +377,7 @@ public:
 	bool DayNight;
 	//movies for day/night (only in ToB)
 	ieResRef Dream[2];
-	Sprite2D *Background;
+	Holder<Sprite2D> Background;
 	ieDword BgDuration;
 	ieDword LastGoCloser;
 	MapReverb *reverb;
@@ -422,9 +422,9 @@ public:
 	bool ChangeMap(bool day_or_night);
 	void SeeSpellCast(Scriptable *caster, ieDword spell);
 	/* low level function to perform the daylight changes */
-	void ChangeTileMap(Image* lm, Sprite2D* sm);
+	void ChangeTileMap(Image *lm, Holder<Sprite2D> sm);
 	/* sets all the auxiliary maps and the tileset */
-	void AddTileMap(TileMap* tm, Image* lm, Bitmap* sr, Sprite2D* sm, Bitmap* hm);
+	void AddTileMap(TileMap *tm, Image *lm, Bitmap *sr, Holder<Sprite2D> sm, Bitmap *hm);
 	void AutoLockDoors();
 	void UpdateScripts();
 	void ResolveTerrainSound(ieResRef &sound, Point &pos);

--- a/gemrb/core/PalettedImageMgr.h
+++ b/gemrb/core/PalettedImageMgr.h
@@ -45,7 +45,7 @@ public:
 	 * @param[in] type Type of palette to use.
 	 * @param[in] paletteIndex Array of palettes to use.
 	 */
-	virtual Sprite2D* GetSprite2D(unsigned int type, ieDword paletteIndex[8]) = 0;
+	virtual Holder<Sprite2D> GetSprite2D(unsigned int type, ieDword paletteIndex[8]) = 0;
 };
 
 }

--- a/gemrb/core/Particles.cpp
+++ b/gemrb/core/Particles.cpp
@@ -232,7 +232,7 @@ void Particles::Draw(const Region &vp)
 		case SP_TYPE_BITMAP:
 			/*
 			if (bitmap[state]) {
-				Sprite2D *frame = bitmap[state]->GetFrame(points[i].state&255);
+				Holder<Sprite2D> frame = bitmap[state]->GetFrame(points[i].state&255);
 				video->BlitGameSprite(frame,
 					points[i].pos.x+screen.x,
 					points[i].pos.y+screen.y, 0, clr,
@@ -244,7 +244,7 @@ void Particles::Draw(const Region &vp)
 				Animation** anims = fragments->GetAnimation( IE_ANI_CAST, i );
 				if (anims) {
 					Animation* anim = anims[0];
-					Sprite2D* nextFrame = anim->GetFrame(anim->GetCurrentFrameIndex());
+					Holder<Sprite2D> nextFrame = anim->GetFrame(anim->GetCurrentFrameIndex());
 
 					ieDword flags = 0;
 					if (game) game->ApplyGlobalTint(clr, flags);

--- a/gemrb/core/Projectile.cpp
+++ b/gemrb/core/Projectile.cpp
@@ -118,7 +118,6 @@ Projectile::~Projectile()
 			if(shadow[i])
 				delete shadow[i];
 		}
-		Sprite2D::FreeSprite(light);
 	}
 
 	if(children) {
@@ -262,7 +261,7 @@ void Projectile::GetPaletteCopy(Animation *anim[], PaletteHolder &pal)
 		return;
 	for (unsigned int i=0;i<MAX_ORIENT;i++) {
 		if (anim[i]) {
-			Sprite2D* spr = anim[i]->GetFrame(0);
+			Holder<Sprite2D> spr = anim[i]->GetFrame(0);
 			if (spr) {
 				pal = spr->GetPalette()->Copy();
 				break;
@@ -1697,7 +1696,7 @@ void Projectile::DrawLine(const Region& vp, int face, ieDword flag)
 {
 	Game *game = core->GetGame();
 	PathNode *iter = path;
-	Sprite2D *frame;
+	Holder<Sprite2D> frame;
 	if (game && game->IsTimestopActive() && !(TFlags&PTF_TIMELESS)) {
 		frame = travel[face]->LastFrame();
 		flag |= BLIT_GREY;
@@ -1789,7 +1788,7 @@ void Projectile::DrawTravel(const Region& viewport)
 
 	if (ExtFlags&PEF_POP) {
 			//draw pop in/hold/pop out animation sequences
-			Sprite2D *frame;
+			Holder<Sprite2D> frame;
 			if (game && game->IsTimestopActive() && !(TFlags&PTF_TIMELESS)) {
 				frame = travel[face]->LastFrame();
 				flags |= BLIT_GREY;
@@ -1819,7 +1818,7 @@ void Projectile::DrawTravel(const Region& viewport)
 	}
 	
 	if (shadow[face]) {
-		Sprite2D *frame = shadow[face]->NextFrame();
+		Holder<Sprite2D> frame = shadow[face]->NextFrame();
 		Draw(frame, pos, flags, tint2);
 	}
 
@@ -1829,14 +1828,14 @@ void Projectile::DrawTravel(const Region& viewport)
 		//draw all frames simultaneously on top of each other
 		for(int i=0;i<Aim;i++) {
 			if (travel[i]) {
-				Sprite2D *frame = travel[i]->NextFrame();
+				Holder<Sprite2D> frame = travel[i]->NextFrame();
 				Draw(frame, pos, flags, tint2);
 				pos.y-=frame->Frame.y;
 			}
 		}
 	} else {
 		if (travel[face]) {
-			Sprite2D *frame;
+			Holder<Sprite2D> frame;
 			if (game && game->IsTimestopActive() && !(TFlags&PTF_TIMELESS)) {
 				frame = travel[face]->LastFrame();
 				flags |= BLIT_GREY; // move higher if it interferes with other tints badly
@@ -1909,7 +1908,7 @@ void Projectile::Cleanup()
 	phase=P_EXPIRED;
 }
 
-void Projectile::Draw(Sprite2D* spr, const Point& p,
+void Projectile::Draw(Holder<Sprite2D> spr, const Point& p,
 		  unsigned int flags, Color tint) const
 {
 	Video *video = core->GetVideoDriver();

--- a/gemrb/core/Projectile.h
+++ b/gemrb/core/Projectile.h
@@ -264,7 +264,7 @@ protected:
 	//special (not using char animations)
 	Animation* travel[MAX_ORIENT];
 	Animation* shadow[MAX_ORIENT];
-	Sprite2D* light;//this is just a round/halftrans sprite, has no animation
+	Holder<Sprite2D> light;//this is just a round/halftrans sprite, has no animation
 	EffectQueue* effects;
 	Projectile **children;
 	int child_size;
@@ -410,7 +410,7 @@ private:
 	void SetupPalette(Animation *anim[], PaletteHolder &pal, const ieByte *gradients);
 
 private:
-	void Draw(Sprite2D* spr, const Point& p,
+	void Draw(Holder<Sprite2D> spr, const Point& p,
 			  unsigned int flags, Color tint) const;
 };
 

--- a/gemrb/core/SaveGame.h
+++ b/gemrb/core/SaveGame.h
@@ -68,8 +68,8 @@ public:
 		return SlotName;
 	}
 
-	Sprite2D* GetPortrait(int index) const;
-	Sprite2D* GetPreview() const;
+	Holder<Sprite2D> GetPortrait(int index) const;
+	Holder<Sprite2D> GetPreview() const;
 	DataStream* GetGame() const;
 	DataStream* GetWmap(int idx) const;
 	DataStream* GetSave() const;

--- a/gemrb/core/SaveGameIterator.cpp
+++ b/gemrb/core/SaveGameIterator.cpp
@@ -135,7 +135,7 @@ SaveGame::~SaveGame()
 {
 }
 
-Sprite2D* SaveGame::GetPortrait(int index) const
+Holder<Sprite2D> SaveGame::GetPortrait(int index) const
 {
 	if (index > PortraitCount) {
 		return NULL;
@@ -148,7 +148,7 @@ Sprite2D* SaveGame::GetPortrait(int index) const
 	return im->GetSprite2D();
 }
 
-Sprite2D* SaveGame::GetPreview() const
+Holder<Sprite2D> SaveGame::GetPreview() const
 {
 	ResourceHolder<ImageMgr> im = GetResourceHolder<ImageMgr>(Prefix, manager, true);
 	if (!im)
@@ -456,18 +456,17 @@ static bool DoSaveGame(const char *Path)
 	//Create portraits
 	for (int i = 0; i < game->GetPartySize( false ); i++) {
 		Actor *actor = game->GetPC( i, false );
-		Sprite2D* portrait = actor->CopyPortrait(true);
+		Holder<Sprite2D> portrait = actor->CopyPortrait(true);
 
 		if (portrait) {
 			char FName[_MAX_PATH];
 			snprintf( FName, sizeof(FName), "PORTRT%d", i );
 			FileStream outfile;
-			outfile.Create( Path, FName, IE_BMP_CLASS_ID );
+			outfile.Create(Path, FName, IE_BMP_CLASS_ID);
 			// NOTE: we save the true portrait size, even tho the preview buttons arent (always) the same
 			// we do this because: 1. the GUI should be able to use whatever size it wants
 			// and 2. its more appropriate to have a flag on the buttons to do the scaling/cropping
-			im->PutImage( &outfile, portrait );
-			Sprite2D::FreeSprite(portrait);
+			im->PutImage(&outfile, portrait);
 		}
 	}
 
@@ -475,7 +474,7 @@ static bool DoSaveGame(const char *Path)
 	// FIXME: the preview shoudl be passed in by the caller!
 
 	WindowManager* wm = core->GetWindowManager();
-	Sprite2D* preview = wm->GetScreenshot(wm->GetGameWindow());
+	Holder<Sprite2D> preview = wm->GetScreenshot(wm->GetGameWindow());
 
 	// scale down to get more of the screen and reduce the size
 	preview = core->GetVideoDriver()->SpriteScaleDown(preview, 5);

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -630,8 +630,6 @@ void Actor::SetAnimationID(unsigned int AnimID)
 			CopyResRef(paletteResRef, anims->PaletteResRef[PAL_MAIN]);
 			if (recover->named) {
 				recover = gamedata->GetPalette(paletteResRef);
-			} else {
-				recover->acquire();
 			}
 		}
 		delete( anims );

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -6656,7 +6656,7 @@ void Actor::SetDialog(const ieResRef resref)
 	CopyResRef(Dialog, resref);
 }
 
-Sprite2D* Actor::CopyPortrait(int which) const
+Holder<Sprite2D> Actor::CopyPortrait(int which) const
 {
 	ResourceHolder<ImageMgr> im = GetResourceHolder<ImageMgr>(which ? SmallPortrait : LargePortrait, true);
 	return (im) ? im->GetSprite2D() : NULL;
@@ -8476,7 +8476,7 @@ void Actor::DrawActorSprite(int cx, int cy, uint32_t flags,
 		Animation* anim = part.first;
 		PaletteHolder palette = part.second;
 
-		Sprite2D* currentFrame = anim->CurrentFrame();
+		Holder<Sprite2D> currentFrame = anim->CurrentFrame();
 		if (currentFrame) {
 			if (palette->HasAlpha() && TranslucentShadows) {
 				ieByte tmpa = palette->col[1].a;
@@ -8710,7 +8710,7 @@ bool Actor::UpdateDrawingState()
 		Region newBBox(Pos, Size());
 		for (const auto& part : currentStance.anim) {
 			Animation* anim = part.first;
-			Sprite2D* animframe = anim->CurrentFrame();
+			Holder<Sprite2D> animframe = anim->CurrentFrame();
 			assert(animframe);
 			Region partBBox = animframe->Frame;
 			partBBox.x = Pos.x - partBBox.x;

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -3745,7 +3745,7 @@ bool Actor::GetSavingThrow(ieDword type, int modifier, const Effect *fx)
 		if (core->HasFeedback(FT_COMBAT) && prevType != type && prevActor != this && prevRoll != ret) {
 			// "Save Vs Death" in all games except pst: "Save Vs. Death:"
 			String *str = core->GetString(displaymsg->GetStringReference(STR_SAVE_SPELL + type));
-			wchar_t tmp[3];
+			wchar_t tmp[20];
 			swprintf(tmp, sizeof(tmp)/sizeof(tmp[0]), L" %d", ret);
 			String msg = *str + tmp;
 			delete str;

--- a/gemrb/core/Scriptable/Actor.h
+++ b/gemrb/core/Scriptable/Actor.h
@@ -553,7 +553,7 @@ public:
 	const char* GetDialog(int flags=GD_NORMAL) const;
 	void SetDialog(const ieResRef resref);
 	/** Gets the Portrait */
-	Sprite2D* CopyPortrait(int which) const;
+	Holder<Sprite2D> CopyPortrait(int which) const;
 
 	/** Gets the attack projectile */
 	Projectile* GetAttackProjectile()

--- a/gemrb/core/Scriptable/Container.cpp
+++ b/gemrb/core/Scriptable/Container.cpp
@@ -55,11 +55,8 @@ Container::Container(void)
 
 void Container::FreeGroundIcons()
 {
-	for (int i = 0;i<MAX_GROUND_ICON_DRAWN;i++) {
-		if (groundicons[i]) {
-			Sprite2D::FreeSprite( groundicons[i] );
-			groundicons[i]=NULL;
-		}
+	for (int i = 0; i < MAX_GROUND_ICON_DRAWN; i++) {
+		groundicons[i] = nullptr;
 	}
 }
 
@@ -73,7 +70,7 @@ Region Container::DrawingRegion() const
 	Region r;
 	
 	for (int i = 0; i < MAX_GROUND_ICON_DRAWN; ++i) {
-		const Sprite2D* icon = groundicons[i];
+		const Holder<Sprite2D> icon = groundicons[i];
 		if (icon) {
 			r.ExpandToRegion(icon->Frame);
 		}
@@ -94,7 +91,7 @@ void Container::DrawPile(bool highlight, const Region& vp, uint32_t flags, Color
 	game->ApplyGlobalTint(tint, flags);
 
 	for (int i = 0;i<MAX_GROUND_ICON_DRAWN;i++) {
-		const Sprite2D* icon = groundicons[i];
+		const Holder<Sprite2D> icon = groundicons[i];
 		if (icon) {
 			if (highlight) {
 				video->BlitGameSprite(icon, Pos.x - vp.x, Pos.y - vp.y, flags, tint);

--- a/gemrb/core/Scriptable/Container.h
+++ b/gemrb/core/Scriptable/Container.h
@@ -67,7 +67,7 @@ public:
 	Inventory inventory;
 	ieStrRef OpenFail;
 	//these are not saved
-	Sprite2D *groundicons[3];
+	Holder<Sprite2D> groundicons[3];
 	//keyresref is stored in Highlightable
 };
 

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -1743,7 +1743,7 @@ void Selectable::DrawCircle(const Point& p) const
 
 	Color mix;
 	const Color* col = &selectedColor;
-	Sprite2D* sprite = circleBitmap[0];
+	Holder<Sprite2D> sprite = circleBitmap[0];
 
 	if (Selected && !Over) {
 		sprite = circleBitmap[1];
@@ -1805,7 +1805,7 @@ void Selectable::Select(int Value)
 	}
 }
 
-void Selectable::SetCircle(int circlesize, float factor, const Color &color, Sprite2D* normal_circle, Sprite2D* selected_circle)
+void Selectable::SetCircle(int circlesize, float factor, const Color &color, Holder<Sprite2D> normal_circle, Holder<Sprite2D> selected_circle)
 {
 	size = circlesize;
 	sizeFactor = factor;

--- a/gemrb/core/Scriptable/Scriptable.h
+++ b/gemrb/core/Scriptable/Scriptable.h
@@ -393,7 +393,7 @@ public:
 	bool Over;
 	Color selectedColor;
 	Color overColor;
-	Sprite2D *circleBitmap[2];
+	Holder<Sprite2D> circleBitmap[2];
 	int size;
 	float sizeFactor;
 public:
@@ -403,7 +403,7 @@ public:
 	void SetOver(bool over);
 	bool IsSelected() const;
 	void Select(int Value);
-	void SetCircle(int size, float, const Color &color, Sprite2D* normal_circle, Sprite2D* selected_circle);
+	void SetCircle(int size, float, const Color &color, Holder<Sprite2D> normal_circle, Holder<Sprite2D> selected_circle);
 };
 
 class GEM_EXPORT Highlightable : public Scriptable {

--- a/gemrb/core/ScriptedAnimation.cpp
+++ b/gemrb/core/ScriptedAnimation.cpp
@@ -369,9 +369,6 @@ ScriptedAnimation::~ScriptedAnimation(void)
 		delete twin;
 	}
 	StopSound();
-	if (light) {
-		Sprite2D::FreeSprite(light);
-	}
 }
 
 void ScriptedAnimation::SetPhase(int arg)
@@ -502,7 +499,7 @@ void ScriptedAnimation::SetOrientation(int orientation)
 	}
 }
 
-bool ScriptedAnimation::HandlePhase(Sprite2D *&frame)
+bool ScriptedAnimation::HandlePhase(Holder<Sprite2D> &frame)
 {
 	Game *game = core->GetGame();
 
@@ -639,7 +636,7 @@ bool ScriptedAnimation::Draw(const Point &Pos, const Color &p_tint, Map *area, b
 	Video *video = core->GetVideoDriver();
 	Game *game = core->GetGame();
 
-	Sprite2D* frame;
+	Holder<Sprite2D> frame;
 
 	if (HandlePhase(frame)) {
 		//expired
@@ -749,7 +746,7 @@ void ScriptedAnimation::GetPaletteCopy()
 	//therefore the cycle
 	for (Animation *anim : anims) {
 		if (anim) {
-			Sprite2D* spr = anim->GetFrame(0);
+			Holder<Sprite2D> spr = anim->GetFrame(0);
 			if (spr) {
 				palette = spr->GetPalette()->Copy();
 				if ((Transparency&IE_VVC_BLENDED) && palette->HasAlpha() == false) {

--- a/gemrb/core/ScriptedAnimation.h
+++ b/gemrb/core/ScriptedAnimation.h
@@ -116,7 +116,7 @@ public:
 	//these are signed
 	int XPos, YPos, ZPos;
 	ieDword LightX, LightY, LightZ;
-	Sprite2D* light;//this is just a round/halftrans sprite, has no animation
+	Holder<Sprite2D> light;//this is just a round/halftrans sprite, has no animation
 	ieDword FrameRate;
 	ieDword NumOrientations;
 	ieDword Orientation;
@@ -168,7 +168,7 @@ public:
 	ScriptedAnimation *DetachTwin();
 private:
 	Animation *PrepareAnimation(AnimationFactory *af, unsigned int cycle, unsigned int i, bool loop = false);
-	bool HandlePhase(Sprite2D *&frame);
+	bool HandlePhase(Holder<Sprite2D> &frame);
 	void GetPaletteCopy();
 	void IncrementPhase();
 	/* stops any sound playing */

--- a/gemrb/core/Sprite2D.cpp
+++ b/gemrb/core/Sprite2D.cpp
@@ -31,14 +31,12 @@ Sprite2D::Sprite2D(const Region& rgn, int Bpp, void* pixels)
 {
 	freePixels = (pixels != NULL);
 	BAM = false;
-	RefCount = 1;
 	renderFlags = 0;
 }
 
 Sprite2D::Sprite2D(const Sprite2D &obj)
 {
 	BAM = false;
-	RefCount = 1;
 
 	Frame = obj.Frame;
 	Bpp = obj.Bpp;
@@ -77,13 +75,5 @@ void* Sprite2D::LockSprite()
 
 void Sprite2D::UnlockSprite() const
 {}
-
-void Sprite2D::release()
-{
-	assert(RefCount > 0);
-	if (--RefCount == 0) {
-		delete this;
-	}
-}
 
 }

--- a/gemrb/core/Sprite2D.h
+++ b/gemrb/core/Sprite2D.h
@@ -46,11 +46,10 @@ class AnimationFactory;
  * Objects of this class are usually created by Video driver.
  */
 
-class GEM_EXPORT Sprite2D {
+class Sprite2D;
+class GEM_EXPORT Sprite2D : public Held<Sprite2D> {
 public:
 	static const TypeID ID;
-private:
-	int RefCount;
 protected:
 	bool freePixels;
 	void* pixels;
@@ -64,7 +63,7 @@ public:
 
 	Sprite2D(const Region&, int Bpp, void* pixels);
 	Sprite2D(const Sprite2D &obj);
-	virtual Sprite2D* copy() const = 0;
+	virtual Holder<Sprite2D> copy() const = 0;
 	virtual ~Sprite2D();
 
 	bool IsPixelTransparent(const Point& p) const;
@@ -84,16 +83,6 @@ public:
 	virtual void SetColorKey(ieDword) = 0;
 	virtual bool ConvertFormatTo(int /*bpp*/, ieDword /*rmask*/, ieDword /*gmask*/,
 							   ieDword /*bmask*/, ieDword /*amask*/) { return false; }; // not pure virtual!
-	void acquire() { ++RefCount; }
-	void release();
-
-public:
-	static void FreeSprite(Sprite2D*& spr) {
-		if (spr) {
-			spr->release();
-			spr = NULL;
-		}
-	}
 };
 
 }

--- a/gemrb/core/SpriteSheet.h
+++ b/gemrb/core/SpriteSheet.h
@@ -35,20 +35,16 @@ protected:
 	Region SheetRegion; // FIXME: this is only needed because of a subclass
 	std::map<KeyType, Region> RegionMap;
 
-	SpriteSheet() {
-		Sheet = NULL;
-	}
+	SpriteSheet() = default;
 
 public:
-	Sprite2D* Sheet;
+	Holder<Sprite2D> Sheet;
 
 public:
-	SpriteSheet(Sprite2D* sheet) : Sheet(sheet) {
-		Sheet->acquire();
+	SpriteSheet(Holder<Sprite2D> sheet) : Sheet(sheet) {
 		SheetRegion = Sheet->Frame;
 	};
 	virtual ~SpriteSheet() {
-		if (Sheet) Sheet->release();
 	}
 
 	const Region& operator[](KeyType key) {

--- a/gemrb/core/Video.cpp
+++ b/gemrb/core/Video.cpp
@@ -181,12 +181,12 @@ void Video::SetEventMgr(EventMgr* evnt)
 // Flips given sprite according to the flags. If MirrorAnchor=true,
 // flips its anchor (i.e. origin/base point) as well
 // returns new sprite
-Sprite2D* Video::MirrorSprite(const Sprite2D* sprite, uint32_t flags, bool MirrorAnchor)
+Holder<Sprite2D> Video::MirrorSprite(const Holder<Sprite2D> sprite, uint32_t flags, bool MirrorAnchor)
 {
 	if (!sprite)
 		return NULL;
 
-	Sprite2D* dest = sprite->copy();
+	Holder<Sprite2D> dest = sprite->copy();
 
 	if (flags&BLIT_MIRRORX) {
 		dest->renderFlags ^= BLIT_MIRRORX;
@@ -209,7 +209,7 @@ bool Video::GetFullscreenMode() const
 	return fullscreen;
 }
 
-void Video::BlitSprite(const Sprite2D* spr, int x, int y,
+void Video::BlitSprite(const Holder<Sprite2D> spr, int x, int y,
 								const Region* clip)
 {
 	Region dst(x - spr->Frame.x, y - spr->Frame.y, spr->Frame.w, spr->Frame.h);
@@ -235,7 +235,7 @@ void Video::BlitSprite(const Sprite2D* spr, int x, int y,
 	BlitSprite(spr, src, fClip);
 }
 
-void Video::BlitTiled(Region rgn, const Sprite2D* img)
+void Video::BlitTiled(Region rgn, const Holder<Sprite2D> img)
 {
 	int xrep = ( rgn.w + img->Frame.w - 1 ) / img->Frame.w;
 	int yrep = ( rgn.h + img->Frame.h - 1 ) / img->Frame.h;
@@ -247,7 +247,7 @@ void Video::BlitTiled(Region rgn, const Sprite2D* img)
 	}
 }
 
-void Video::BlitGameSpriteWithPalette(Sprite2D* spr, PaletteHolder pal, int x, int y,
+void Video::BlitGameSpriteWithPalette(Holder<Sprite2D> spr, PaletteHolder pal, int x, int y,
 							   uint32_t flags, Color tint, const Region* clip)
 {
 	if (pal) {
@@ -261,7 +261,7 @@ void Video::BlitGameSpriteWithPalette(Sprite2D* spr, PaletteHolder pal, int x, i
 }
 
 //Sprite conversion, creation
-Sprite2D* Video::CreateAlpha( const Sprite2D *sprite)
+Holder<Sprite2D> Video::CreateAlpha( const Holder<Sprite2D> sprite)
 {
 	if (!sprite)
 		return 0;
@@ -292,7 +292,7 @@ Sprite2D* Video::CreateAlpha( const Sprite2D *sprite)
 		0x00FF0000, 0x0000FF00, 0x000000FF, pixels );
 }
 
-Sprite2D* Video::SpriteScaleDown( const Sprite2D* sprite, unsigned int ratio )
+Holder<Sprite2D> Video::SpriteScaleDown( const Holder<Sprite2D> sprite, unsigned int ratio )
 {
 	Region scaledFrame = sprite->Frame;
 	scaledFrame.w /= ratio;
@@ -309,7 +309,7 @@ Sprite2D* Video::SpriteScaleDown( const Sprite2D* sprite, unsigned int ratio )
 		}
 	}
 
-	Sprite2D* small = CreateSprite(scaledFrame, 32, 0x000000ff, 0x0000ff00, 0x00ff0000,
+	Holder<Sprite2D> small = CreateSprite(scaledFrame, 32, 0x000000ff, 0x0000ff00, 0x00ff0000,
 0xff000000, pixels, false, 0 );
 
 	small->Frame.x = sprite->Frame.x / ratio;
@@ -320,7 +320,7 @@ Sprite2D* Video::SpriteScaleDown( const Sprite2D* sprite, unsigned int ratio )
 
 //TODO light could be elliptical in the original engine
 //is it difficult?
-Sprite2D* Video::CreateLight(int radius, int intensity)
+Holder<Sprite2D> Video::CreateLight(int radius, int intensity)
 {
 	if(!radius) return NULL;
 	Point p, q;
@@ -339,7 +339,7 @@ Sprite2D* Video::CreateLight(int radius, int intensity)
 		}
 	}
 
-	Sprite2D* light = CreateSprite(Region(0,0, radius*2, radius*2), 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000, pixels);
+	Holder<Sprite2D> light = CreateSprite(Region(0,0, radius*2, radius*2), 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000, pixels);
 
 	light->Frame.x = radius;
 	light->Frame.y = radius;
@@ -347,7 +347,7 @@ Sprite2D* Video::CreateLight(int radius, int intensity)
 	return light;
 }
 
-Color Video::SpriteGetPixelSum(const Sprite2D* sprite, unsigned short xbase, unsigned short ybase, unsigned int ratio)
+Color Video::SpriteGetPixelSum(const Holder<Sprite2D> sprite, unsigned short xbase, unsigned short ybase, unsigned int ratio)
 {
 	// TODO: turn this into one of our software "shaders"
 	Color sum;

--- a/gemrb/core/Video.h
+++ b/gemrb/core/Video.h
@@ -186,28 +186,28 @@ public:
 
 	virtual bool TouchInputEnabled() = 0;
 
-	virtual Sprite2D* CreateSprite(const Region&, int bpp, ieDword rMask,
+	virtual Holder<Sprite2D> CreateSprite(const Region&, int bpp, ieDword rMask,
 		ieDword gMask, ieDword bMask, ieDword aMask, void* pixels,
 		bool cK = false, int index = 0) = 0;
-	virtual Sprite2D* CreateSprite8(const Region&, void* pixels,
+	virtual Holder<Sprite2D> CreateSprite8(const Region&, void* pixels,
 									PaletteHolder palette, bool cK = false, int index = 0) = 0;
-	virtual Sprite2D* CreatePalettedSprite(const Region&, int bpp, void* pixels,
+	virtual Holder<Sprite2D> CreatePalettedSprite(const Region&, int bpp, void* pixels,
 										   Color* palette, bool cK = false, int index = 0) = 0;
 	virtual bool SupportsBAMSprites() { return false; }
 
-	virtual void BlitTile(const Sprite2D* spr, int x, int y, const Region* clip,
+	virtual void BlitTile(const Holder<Sprite2D> spr, int x, int y, const Region* clip,
 						  uint32_t flags, const Color* tint = NULL) = 0;
-	void BlitSprite(const Sprite2D* spr, int x, int y,
+	void BlitSprite(const Holder<Sprite2D> spr, int x, int y,
 					const Region* clip = NULL);
-	virtual void BlitSprite(const Sprite2D* spr, const Region& src, Region dst) = 0;
+	virtual void BlitSprite(const Holder<Sprite2D> spr, const Region& src, Region dst) = 0;
 
 	// Note: Tint cannot be constified, because it is modified locally
 	// not a pretty interface :)
-	virtual void BlitGameSprite(const Sprite2D* spr, int x, int y,
+	virtual void BlitGameSprite(const Holder<Sprite2D> spr, int x, int y,
 								uint32_t flags, Color tint,
 								const Region* clip = NULL) = 0;
 
-	void BlitGameSpriteWithPalette(Sprite2D* spr, PaletteHolder pal, int x, int y,
+	void BlitGameSpriteWithPalette(Holder<Sprite2D> spr, PaletteHolder pal, int x, int y,
 				   uint32_t flags, Color tint, const Region* clip = NULL);
 
 	virtual void BlitVideoBuffer(const VideoBufferPtr& buf, const Point& p, uint32_t flags,
@@ -215,7 +215,7 @@ public:
 
 	/** Return GemRB window screenshot.
 	 * It's generated from the momentary back buffer */
-	virtual Sprite2D* GetScreenshot( Region r, const VideoBufferPtr& buf = nullptr) = 0;
+	virtual Holder<Sprite2D> GetScreenshot(Region r, const VideoBufferPtr& buf = nullptr) = 0;
 	/** This function Draws the Border of a Rectangle as described by the Region parameter. The Color used to draw the rectangle is passes via the Color parameter. */
 	void DrawRect(const Region& rgn, const Color& color, bool fill = true, uint32_t flags = 0);
 
@@ -235,13 +235,13 @@ public:
 	void DrawLine(const Point& p1, const Point& p2, const Color& color, uint32_t flags = 0);
 	void DrawLines(const std::vector<Point>& points, const Color& color, uint32_t flags = 0);
 	/** Blits a Sprite filling the Region */
-	void BlitTiled(Region rgn, const Sprite2D* img);
+	void BlitTiled(Region rgn, const Holder<Sprite2D> img);
 	/** Sets Event Manager */
 	void SetEventMgr(EventMgr* evnt);
 	/** Flips sprite, returns new sprite */
-	Sprite2D *MirrorSprite(const Sprite2D *sprite, uint32_t flags, bool MirrorAnchor);
+	Holder<Sprite2D> MirrorSprite(const Holder<Sprite2D> sprite, uint32_t flags, bool MirrorAnchor);
 	/** Duplicates and transforms sprite to have an alpha channel */
-	Sprite2D* CreateAlpha(const Sprite2D *sprite);
+	Holder<Sprite2D> CreateAlpha(const Holder<Sprite2D> sprite);
 
 	/** Sets Clip Rectangle */
 	void SetScreenClip(const Region* clip);
@@ -250,12 +250,12 @@ public:
 	virtual void SetGamma(int brightness, int contrast) = 0;
 
 	/** Scales down a sprite by a ratio */
-	Sprite2D* SpriteScaleDown( const Sprite2D* sprite, unsigned int ratio );
+	Holder<Sprite2D> SpriteScaleDown(const Holder<Sprite2D> sprite, unsigned int ratio);
 	/** Creates an ellipse or circle shaped sprite with various intensity
 	 *  for projectile light spots */
-	Sprite2D* CreateLight(int radius, int intensity);
+	Holder<Sprite2D> CreateLight(int radius, int intensity);
 
-	Color SpriteGetPixelSum (const Sprite2D* sprite, unsigned short xbase, unsigned short ybase, unsigned int ratio);
+	Color SpriteGetPixelSum(const Holder<Sprite2D> sprite, unsigned short xbase, unsigned short ybase, unsigned int ratio);
 };
 
 }

--- a/gemrb/core/WorldMap.cpp
+++ b/gemrb/core/WorldMap.cpp
@@ -52,13 +52,12 @@ WMPAreaEntry::~WMPAreaEntry()
 	if (StrTooltip) {
 		core->FreeString(StrTooltip);
 	}
-	Sprite2D::FreeSprite(MapIcon);
 }
 
 void WMPAreaEntry::SetAreaStatus(ieDword arg, int op)
 {
 	SetBits(AreaStatus, arg, op);
-	Sprite2D::FreeSprite(MapIcon);
+	MapIcon = nullptr;
 }
 
 const String* WMPAreaEntry::GetCaption()
@@ -79,14 +78,14 @@ const char* WMPAreaEntry::GetTooltip()
 
 static int gradients[5]={18,22,19,3,4};
 
-void WMPAreaEntry::SetPalette(int gradient, Sprite2D* MapIcon)
+void WMPAreaEntry::SetPalette(int gradient, Holder<Sprite2D> MapIcon)
 {
 	if (!MapIcon) return;
 	const auto& colors = core->GetPalette256(gradient);
 	MapIcon->SetPalette(new Palette(&colors[0], &colors[256]));
 }
 
-Sprite2D *WMPAreaEntry::GetMapIcon(AnimationFactory *bam, bool overridePalette)
+Holder<Sprite2D> WMPAreaEntry::GetMapIcon(AnimationFactory *bam, bool overridePalette)
 {
 	if (!bam || IconSeq == (ieDword) -1) {
 		return NULL;
@@ -123,7 +122,6 @@ Sprite2D *WMPAreaEntry::GetMapIcon(AnimationFactory *bam, bool overridePalette)
 			SetPalette(color, MapIcon);
 		}
 	}
-	MapIcon->acquire();
 	return MapIcon;
 }
 
@@ -242,9 +240,6 @@ WorldMap::~WorldMap(void)
 	for (i = 0; i < area_links.size(); i++) {
 		delete( area_links[i] );
 	}
-	if (MapMOS) {
-		Sprite2D::FreeSprite(MapMOS);
-	}
 	if (Distances) {
 		free(Distances);
 	}
@@ -259,11 +254,8 @@ void WorldMap::SetMapIcons(AnimationFactory *newicons)
 	bam = newicons;
 }
 
-void WorldMap::SetMapMOS(Sprite2D *newmos)
+void WorldMap::SetMapMOS(Holder<Sprite2D> newmos)
 {
-	if (MapMOS) {
-		Sprite2D::FreeSprite(MapMOS);
-	}
 	MapMOS = newmos;
 }
 

--- a/gemrb/core/WorldMap.h
+++ b/gemrb/core/WorldMap.h
@@ -72,19 +72,19 @@ public:
 	void SetAreaStatus(ieDword status, int op);
 
 	//! return the map icon of this location. Free the sprite afterwards.
-	Sprite2D *GetMapIcon(AnimationFactory *bam, bool overridePalette);
+	Holder<Sprite2D> GetMapIcon(AnimationFactory *bam, bool overridePalette);
 	// note that this is only valid after GetMapIcon has been called
 	bool HighlightSelected() const { return SingleFrame; }
 	const String* GetCaption();
 	const char* GetTooltip();
 private:
 	ieDword AreaStatus;
-	Sprite2D *MapIcon;
+	Holder<Sprite2D> MapIcon;
 	String* StrCaption;
 	char *StrTooltip;
 	bool SingleFrame;
 
-	void SetPalette(int gradient, Sprite2D *MapIcon);
+	void SetPalette(int gradient, Holder<Sprite2D> MapIcon);
 public:
 	ieResRef AreaName;
 	ieResRef AreaResRef;
@@ -136,7 +136,7 @@ public: //struct members
 
 	AnimationFactory *bam;
 private: //non-struct members
-	Sprite2D* MapMOS;
+	Holder<Sprite2D> MapMOS;
 	std::vector< WMPAreaEntry*> area_entries;
 	std::vector< WMPAreaLink*> area_links;
 	int *Distances;
@@ -144,8 +144,8 @@ private: //non-struct members
 	int encounterArea;
 public:
 	void SetMapIcons(AnimationFactory *bam);
-	Sprite2D* GetMapMOS() const { return MapMOS; }
-	void SetMapMOS(Sprite2D *newmos);
+	Holder<Sprite2D> GetMapMOS() const { return MapMOS; }
+	void SetMapMOS(Holder<Sprite2D> newmos);
 	int GetEntryCount() const { return (int) area_entries.size(); }
 	WMPAreaEntry *GetEntry(unsigned int index) { return area_entries[index]; }
 	int GetLinkCount() const { return (int) area_links.size(); }

--- a/gemrb/plugins/BAMImporter/BAMFontManager.cpp
+++ b/gemrb/plugins/BAMImporter/BAMFontManager.cpp
@@ -51,12 +51,9 @@ Font* BAMFontManager::GetFont(unsigned short /*ptSize*/,
 	AnimationFactory* af = bamImp->GetAnimationFactory(resRef, IE_NORMAL, false); // released by BAMFont
 	// FIXME: this test only exists to let the minimal test pass
 	// we should maybe instead use a *valid* font for such a "test"
-	Sprite2D* spr = af->GetFrame(0);
-	if (spr == NULL) {
-		return NULL;
+	if (af->GetFrame(0) == nullptr) {
+		return nullptr;
 	}
-	spr->release();
-	spr = NULL;
 
 	if (af->GetFrameCount() == 0) return NULL; // the minimal test will explode without this...
 	bool isNumeric = (af->GetCycleCount() <= 1);
@@ -68,10 +65,9 @@ Font* BAMFontManager::GetFont(unsigned short /*ptSize*/,
 		// since state icons should all be the same size/position we can just take the position of the first one
 		static const ieWord topIconCycles[] = {254 /* level up icon */, 153 /* dialog icon */, 154 /* store icon */, 37 /* separator glyph (like '-')*/};
 		for (size_t i = 0; i < 3; i++) {
-			spr = af->GetFrame(0, topIconCycles[i]);
+			Holder<Sprite2D> spr = af->GetFrame(0, topIconCycles[i]);
 			if (spr->Frame.x > 0) // not all datasets are messed up here
 				spr->Frame.y = spr->Frame.x;
-			spr->release();
 		}
 	}
 
@@ -84,31 +80,22 @@ Font* BAMFontManager::GetFont(unsigned short /*ptSize*/,
 	ieWord baseLine = 0;
 	ieWord lineHeight = 0;
 	if (isNumeric) {
-		spr = af->GetFrame(0);
 		baseLine = 0;
-		lineHeight = spr->Frame.h;
-		spr->release();
+		lineHeight = af->GetFrame(0)->Frame.h;
 	} else {
-		spr = af->GetFrame(0, 0);
-		baseLine = spr->Frame.h;
-		spr->release();
-		spr = af->GetFrame(0, 1);
-		lineHeight = spr->Frame.h;
-		spr->release();
+		baseLine = af->GetFrame(0, 0)->Frame.h;
+		lineHeight = af->GetFrame(0, 1)->Frame.h;
 	}
 
-	spr = af->GetFrameWithoutCycle(0);
 	if (!pal) {
-		pal = spr->GetPalette();
+		pal = af->GetFrameWithoutCycle(0)->GetPalette();
 	}
 	Font* fnt = new Font(pal, lineHeight, baseLine);
-	spr->release();
 
 	std::map<Sprite2D*, ieWord> tmp;
-	std::map<Sprite2D*, ieWord>::const_iterator i;
 	for (ieWord cycle = 0; cycle < af->GetCycleCount(); cycle++) {
 		for (ieWord frame = 0; frame < af->GetCycleSize(cycle); frame++) {
-			spr = af->GetFrame(frame, cycle);
+			Holder<Sprite2D> spr = af->GetFrame(frame, cycle);
 			assert(spr);
 
 			ieWord chr = '\0';
@@ -117,7 +104,8 @@ Font* BAMFontManager::GetFont(unsigned short /*ptSize*/,
 			} else {
 				chr = ((frame << 8) | (cycle&0x00ff)) + 1;
 			}
-			i = tmp.find(spr);
+			Sprite2D *key = spr.get();
+			auto i = tmp.find(key);
 			if (i != tmp.end()) {
 				// opimization for when glyphs are shared between cycles
 				// just alias the existing character
@@ -125,9 +113,8 @@ Font* BAMFontManager::GetFont(unsigned short /*ptSize*/,
 				fnt->CreateAliasForChar(i->second, chr);
 			} else {
 				fnt->CreateGlyphForCharSprite(chr, spr);
-				tmp[spr] = chr;
+				tmp[key] = chr;
 			}
-			spr->release();
 		}
 	}
 

--- a/gemrb/plugins/BAMImporter/BAMImporter.cpp
+++ b/gemrb/plugins/BAMImporter/BAMImporter.cpp
@@ -141,10 +141,10 @@ int BAMImporter::GetCycleSize(unsigned char Cycle)
 	return cycles[Cycle].FramesCount;
 }
 
-Sprite2D* BAMImporter::GetFrameInternal(unsigned short findex, unsigned char mode,
+Holder<Sprite2D> BAMImporter::GetFrameInternal(unsigned short findex, unsigned char mode,
 										bool RLESprite, unsigned char* data)
 {
-	Sprite2D* spr = 0;
+	Holder<Sprite2D> spr;
 
 	if (RLESprite) {
 		assert(data);
@@ -266,7 +266,7 @@ AnimationFactory* BAMImporter::GetAnimationFactory(const char* ResRef, unsigned 
 
 	for (i = 0; i < FramesCount; ++i) {
 		bool RLECompressed = allowCompression && (frames[i].FrameData & 0x80000000) == 0;
-		Sprite2D* frame = GetFrameInternal(i, mode, RLECompressed, data);
+		Holder<Sprite2D> frame = GetFrameInternal(i, mode, RLECompressed, data);
 		assert(!RLECompressed || frame->BAM);
 		af->AddFrame(frame);
 	}
@@ -280,7 +280,7 @@ AnimationFactory* BAMImporter::GetAnimationFactory(const char* ResRef, unsigned 
 
 /** Debug Function: Returns the Global Animation Palette as a Sprite2D Object.
 If the Global Animation Palette is NULL, returns NULL. */
-Sprite2D* BAMImporter::GetPalette()
+Holder<Sprite2D> BAMImporter::GetPalette()
 {
 	unsigned char * pixels = ( unsigned char * ) malloc( 256 );
 	unsigned char * p = pixels;

--- a/gemrb/plugins/BAMImporter/BAMImporter.h
+++ b/gemrb/plugins/BAMImporter/BAMImporter.h
@@ -52,7 +52,7 @@ private:
 	ieDword FramesOffset, PaletteOffset, FLTOffset;
 	unsigned long DataStart;
 private:
-	Sprite2D* GetFrameInternal(unsigned short findex, unsigned char mode,
+	Holder<Sprite2D> GetFrameInternal(unsigned short findex, unsigned char mode,
 							   bool RLESprite, unsigned char* data);
 	void* GetFramePixels(unsigned short findex);
 	ieWord * CacheFLT(unsigned int &count);
@@ -65,7 +65,7 @@ public:
 		unsigned char mode = IE_NORMAL, bool allowCompression = true);
 	/** Debug Function: Returns the Global Animation Palette as a Sprite2D Object.
 	If the Global Animation Palette is NULL, returns NULL. */
-	Sprite2D* GetPalette();
+	Holder<Sprite2D> GetPalette();
 
 	/** Gets a Pixel Index from the Image, unused */
 	unsigned int GetPixelIndex(unsigned int /*x*/, unsigned int /*y*/)

--- a/gemrb/plugins/BAMImporter/BAMSprite2D.cpp
+++ b/gemrb/plugins/BAMImporter/BAMSprite2D.cpp
@@ -49,7 +49,7 @@ BAMSprite2D::BAMSprite2D(const BAMSprite2D &obj)
 	freePixels = false; // managed by AnimationFactory
 }
 
-BAMSprite2D* BAMSprite2D::copy() const
+Holder<Sprite2D> BAMSprite2D::copy() const
 {
 	return new BAMSprite2D(*this);
 }

--- a/gemrb/plugins/BAMImporter/BAMSprite2D.h
+++ b/gemrb/plugins/BAMImporter/BAMSprite2D.h
@@ -38,7 +38,7 @@ public:
 	BAMSprite2D(const Region&, void* pixels,
 				PaletteHolder palette, ieDword colorkey);
 	BAMSprite2D(const BAMSprite2D &obj);
-	BAMSprite2D* copy() const override;
+	Holder<Sprite2D> copy() const override;
 
 	PaletteHolder GetPalette() const override;
 	void SetPalette(PaletteHolder pal) override;

--- a/gemrb/plugins/BAMImporter/BAMSprite2D.h
+++ b/gemrb/plugins/BAMImporter/BAMSprite2D.h
@@ -38,14 +38,14 @@ public:
 	BAMSprite2D(const Region&, void* pixels,
 				PaletteHolder palette, ieDword colorkey);
 	BAMSprite2D(const BAMSprite2D &obj);
-	BAMSprite2D* copy() const;
+	BAMSprite2D* copy() const override;
 
-	PaletteHolder GetPalette() const;
-	void SetPalette(PaletteHolder pal);
-	Color GetPixel(const Point&) const;
-	int32_t GetColorKey() const { return colorkey; };
-	void SetColorKey(ieDword ck) { colorkey = (ieByte)ck; };
-	bool HasTransparency() const;
+	PaletteHolder GetPalette() const override;
+	void SetPalette(PaletteHolder pal) override;
+	Color GetPixel(const Point&) const override;
+	int32_t GetColorKey() const override { return colorkey; };
+	void SetColorKey(ieDword ck) override { colorkey = (ieByte)ck; };
+	bool HasTransparency() const override;
 };
 
 }

--- a/gemrb/plugins/BMPImporter/BMPImporter.cpp
+++ b/gemrb/plugins/BMPImporter/BMPImporter.cpp
@@ -223,9 +223,9 @@ void BMPImporter::Read4To8(void *rpixels)
 	}
 }
 
-Sprite2D* BMPImporter::GetSprite2D()
+Holder<Sprite2D> BMPImporter::GetSprite2D()
 {
-	Sprite2D* spr = NULL;
+	Holder<Sprite2D> spr;
 	if (BitCount == 32) {
 		const ieDword red_mask = 0x000000ff;
 		const ieDword green_mask = 0x0000ff00;

--- a/gemrb/plugins/BMPImporter/BMPImporter.h
+++ b/gemrb/plugins/BMPImporter/BMPImporter.h
@@ -44,7 +44,7 @@ public:
 	BMPImporter(void);
 	~BMPImporter(void);
 	bool Open(DataStream* stream);
-	Sprite2D* GetSprite2D();
+	Holder<Sprite2D> GetSprite2D();
 	virtual Bitmap* GetBitmap();
 	virtual Image* GetImage();
 	void GetPalette(int colors, Color* pal);

--- a/gemrb/plugins/BMPWriter/BMPWriter.cpp
+++ b/gemrb/plugins/BMPWriter/BMPWriter.cpp
@@ -19,7 +19,7 @@ BMPWriter::~BMPWriter()
 {
 }
 
-void BMPWriter::PutImage(DataStream *output, Sprite2D *spr)
+void BMPWriter::PutImage(DataStream *output, Holder<Sprite2D> spr)
 {
 	ieDword tmpDword;
 	ieWord tmpWord;

--- a/gemrb/plugins/BMPWriter/BMPWriter.h
+++ b/gemrb/plugins/BMPWriter/BMPWriter.h
@@ -7,7 +7,7 @@ public:
 	BMPWriter(void);
 	~BMPWriter(void);
 
-	void PutImage(DataStream *output, Sprite2D *sprite);
+	void PutImage(DataStream *output, Holder<Sprite2D> sprite);
 };
 
 }

--- a/gemrb/plugins/CHUImporter/CHUImporter.cpp
+++ b/gemrb/plugins/CHUImporter/CHUImporter.cpp
@@ -136,7 +136,7 @@ Window* CHUImporter::GetWindow(ScriptingId wid) const
 	str->ReadWord( &FirstControl );
 
 	Window* win = CreateWindow(WindowID, Region(XPos, YPos, Width, Height));
-	Sprite2D* bg = NULL;
+	Holder<Sprite2D> bg;
 	if (BackGround == 1) {
 		ResourceHolder<ImageMgr> mos = GetResourceHolder<ImageMgr>(MosFile);
 		if (mos) {
@@ -226,7 +226,7 @@ Window* CHUImporter::GetWindow(ScriptingId wid) const
 					break;
 				}
 				/** Cycle is only a byte for buttons */
-				Sprite2D* tspr = bam->GetFrame( UnpressedIndex, (unsigned char) Cycle );
+				Holder<Sprite2D> tspr = bam->GetFrame( UnpressedIndex, (unsigned char) Cycle );
 				btn->SetImage( BUTTON_IMAGE_UNPRESSED, tspr );
 				tspr = bam->GetFrame( PressedIndex, Cycle );
 				btn->SetImage( BUTTON_IMAGE_PRESSED, tspr );
@@ -269,8 +269,8 @@ Window* CHUImporter::GetWindow(ScriptingId wid) const
 				Progressbar* pbar = new Progressbar(ctrlFrame, KnobStepsCount);
 				pbar->SetSliderPos( KnobXPos, KnobYPos, CapXPos, CapYPos );
 
-				Sprite2D* img = NULL;
-				Sprite2D* img2 = NULL;
+				Holder<Sprite2D> img;
+				Holder<Sprite2D> img2;
 				if ( MOSFile[0] ) {
 					ResourceHolder<ImageMgr> mos = GetResourceHolder<ImageMgr>(MOSFile);
 					img = mos->GetSprite2D();
@@ -294,7 +294,7 @@ Window* CHUImporter::GetWindow(ScriptingId wid) const
 				}
 				else {
 					ResourceHolder<ImageMgr> mos = GetResourceHolder<ImageMgr>(BAMFile);
-					Sprite2D* img3 = mos->GetSprite2D();
+					Holder<Sprite2D> img3 = mos->GetSprite2D();
 					pbar->SetBarCap( img3 );
 				}
 				ctrl = pbar;
@@ -317,7 +317,7 @@ Window* CHUImporter::GetWindow(ScriptingId wid) const
 				str->ReadWord( &KnobStepsCount );
 				Slider* sldr = new Slider(ctrlFrame, Point(KnobXPos, KnobYPos), KnobStep, KnobStepsCount);
 				ResourceHolder<ImageMgr> mos = GetResourceHolder<ImageMgr>(MOSFile);
-				Sprite2D* img = mos->GetSprite2D();
+				Holder<Sprite2D> img = mos->GetSprite2D();
 				sldr->SetImage( IE_GUI_SLIDER_BACKGROUND, img);
 
 				AnimationFactory* bam = ( AnimationFactory* )
@@ -373,13 +373,13 @@ Window* CHUImporter::GetWindow(ScriptingId wid) const
 					gamedata->GetFactoryResource( CursorResRef,
 							IE_BAM_CLASS_ID,
 							IE_NORMAL );
-				Sprite2D *cursor = NULL;
+				Holder<Sprite2D> cursor;
 				if (bam) {
 					cursor = bam->GetFrame( CurCycle, CurFrame );
 				}
 
 				ResourceHolder<ImageMgr> mos = GetResourceHolder<ImageMgr>(BGMos);
-				Sprite2D *img = NULL;
+				Holder<Sprite2D> img;
 				if(mos) {
 					img = mos->GetSprite2D();
 				}

--- a/gemrb/plugins/CHUImporter/CHUImporter.cpp
+++ b/gemrb/plugins/CHUImporter/CHUImporter.cpp
@@ -500,15 +500,15 @@ endalign:
 					Log(ERROR, "CHUImporter", "Unable to create scrollbar, no BAM: %s", BAMResRef);
 					break;
 				}
-				Sprite2D* images[ScrollBar::IMAGE_COUNT];
-				for (int i=0; i < ScrollBar::IMAGE_COUNT; i++) {
-					str->ReadWord( &imgIdx );
-					images[i] = bam->GetFrame( imgIdx, Cycle );
+				Holder<Sprite2D> images[ScrollBar::IMAGE_COUNT];
+				for (int i = 0; i < ScrollBar::IMAGE_COUNT; i++) {
+					str->ReadWord(&imgIdx);
+					images[i] = bam->GetFrame(imgIdx, Cycle);
 				}
 				str->ReadWord( &TAID );
-				
+
 				ScrollBar* sb = new ScrollBar(ctrlFrame, images);
-				
+
 				if (TAID == 0xffff) {
 					// text areas produce their own scrollbars in GemRB
 					ctrl = sb;

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -2086,8 +2086,8 @@ static PyObject* GemRB_CreateView(PyObject * /*self*/, PyObject* args)
 				return RuntimeError( tmpstr );
 			}
 
-			Sprite2D* images[ScrollBar::IMAGE_COUNT];
-			for(int i=0; i < ScrollBar::IMAGE_COUNT; i++) {
+			Holder<Sprite2D> images[ScrollBar::IMAGE_COUNT];
+			for (int i = 0; i < ScrollBar::IMAGE_COUNT; i++) {
 				long frame = PyInt_AsLong( PyList_GetItem(pyImgList, i));
 				if (PyErr_Occurred()) {
 					return AttributeError("Error retrieving image from list");

--- a/gemrb/plugins/GUIScript/PythonConversions.cpp
+++ b/gemrb/plugins/GUIScript/PythonConversions.cpp
@@ -115,12 +115,11 @@ Holder<SymbolMgr> GetSymbols(PyObject* obj)
 
 Holder<Sprite2D> SpriteFromPy(PyObject* pypic)
 {
-	Holder<Sprite2D> pic = NULL;
+	Holder<Sprite2D> pic;
 	if (PyObject_TypeCheck( pypic, &PyString_Type )) {
 		ResourceHolder<ImageMgr> im = GetResourceHolder<ImageMgr>(PyString_AsString(pypic));
 		if (im) {
 			pic = im->GetSprite2D();
-			pic->release(); // prevent leak
 		}
 	} else if (pypic != Py_None) {
 		pic = CObject<Sprite2D>(pypic);

--- a/gemrb/plugins/MOSImporter/MOSImporter.cpp
+++ b/gemrb/plugins/MOSImporter/MOSImporter.cpp
@@ -73,7 +73,7 @@ bool MOSImporter::Open(DataStream* stream)
 	return true;
 }
 
-Sprite2D* MOSImporter::GetSprite2D()
+Holder<Sprite2D> MOSImporter::GetSprite2D()
 {
 	Color Col[256];
 	unsigned char * pixels = ( unsigned char * ) malloc( Width * Height * 4 );
@@ -120,7 +120,7 @@ Sprite2D* MOSImporter::GetSprite2D()
 		}
 	}
 	free( blockpixels );
-	Sprite2D* ret = core->GetVideoDriver()->CreateSprite(Region(0,0, Width, Height), 32,
+	Holder<Sprite2D> ret = core->GetVideoDriver()->CreateSprite(Region(0,0, Width, Height), 32,
 		red_mask, green_mask, blue_mask, 0,
 		pixels, true, green_mask );
 	return ret;

--- a/gemrb/plugins/MOSImporter/MOSImporter.h
+++ b/gemrb/plugins/MOSImporter/MOSImporter.h
@@ -33,7 +33,7 @@ public:
 	MOSImporter(void);
 	~MOSImporter(void);
 	bool Open(DataStream* stream);
-	Sprite2D* GetSprite2D();
+	Holder<Sprite2D> GetSprite2D();
 	int GetWidth() { return (int) Width; }
 	int GetHeight() { return (int) Height; }
 };

--- a/gemrb/plugins/PLTImporter/PLTImporter.cpp
+++ b/gemrb/plugins/PLTImporter/PLTImporter.cpp
@@ -76,7 +76,7 @@ bool PLTImporter::Open(DataStream* str)
 	return true;
 }
 
-Sprite2D* PLTImporter::GetSprite2D(unsigned int type, ieDword paletteIndex[8])
+Holder<Sprite2D> PLTImporter::GetSprite2D(unsigned int type, ieDword paletteIndex[8])
 {
 	static int pperm[8]={3,6,0,5,4,1,2,7};
 	ColorPal<256> Palettes[8];
@@ -100,7 +100,7 @@ Sprite2D* PLTImporter::GetSprite2D(unsigned int type, ieDword paletteIndex[8])
 				*dest++ = 0xff;
 		}
 	}
-	Sprite2D* spr = core->GetVideoDriver()->CreateSprite( Region(0,0,Width,Height), 32,
+	Holder<Sprite2D> spr = core->GetVideoDriver()->CreateSprite( Region(0,0,Width,Height), 32,
 		red_mask, green_mask, blue_mask, 0, p,
 		true, green_mask );
 	spr->Frame.x = 0;

--- a/gemrb/plugins/PLTImporter/PLTImporter.h
+++ b/gemrb/plugins/PLTImporter/PLTImporter.h
@@ -33,7 +33,7 @@ public:
 	PLTImporter(void);
 	~PLTImporter(void);
 	bool Open(DataStream* stream);
-	Sprite2D* GetSprite2D(unsigned int type, ieDword col[8]);
+	Holder<Sprite2D> GetSprite2D(unsigned int type, ieDword col[8]);
 };
 
 }

--- a/gemrb/plugins/PNGImporter/PNGImporter.cpp
+++ b/gemrb/plugins/PNGImporter/PNGImporter.cpp
@@ -154,9 +154,9 @@ bool PNGImporter::Open(DataStream* stream)
 	return true;
 }
 
-Sprite2D* PNGImporter::GetSprite2D()
+Holder<Sprite2D> PNGImporter::GetSprite2D()
 {
-	Sprite2D* spr = 0;
+	Holder<Sprite2D> spr;
 	unsigned char* buffer = 0;
 	png_bytep* row_pointers = new png_bytep[Height];
 	buffer = (unsigned char *) malloc((hasPalette?1:4)*Width*Height);

--- a/gemrb/plugins/PNGImporter/PNGImporter.h
+++ b/gemrb/plugins/PNGImporter/PNGImporter.h
@@ -38,7 +38,7 @@ public:
 	~PNGImporter(void);
 	void Close();
 	bool Open(DataStream* stream);
-	Sprite2D* GetSprite2D();
+	Holder<Sprite2D> GetSprite2D();
 	void GetPalette(int colors, Color* pal);
 	int GetWidth() { return (int) Width; }
 	int GetHeight() { return (int) Height; }

--- a/gemrb/plugins/SDLVideo/GLPaletteManager.cpp
+++ b/gemrb/plugins/SDLVideo/GLPaletteManager.cpp
@@ -52,7 +52,6 @@ GLuint GLPaletteManager::CreatePaletteTexture(PaletteHolder palette, unsigned in
 #endif
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, (GLvoid*) colors);
 		delete[] colors;
-		palette->acquire();
 		currentTextures->insert(std::make_pair(key, texture));
 		currentIndexes->insert(std::make_pair(texture, key));
 	}

--- a/gemrb/plugins/SDLVideo/GLTextureSprite2D.cpp
+++ b/gemrb/plugins/SDLVideo/GLTextureSprite2D.cpp
@@ -51,7 +51,7 @@ GLTextureSprite2D::GLTextureSprite2D(const GLTextureSprite2D &obj) : Sprite2D(ob
 	SetPalette(obj.currentPalette);
 }
 
-GLTextureSprite2D* GLTextureSprite2D::copy() const
+GLTextureHolder<Sprite2D> GLTextureSprite2D::copy() const
 {
 	return new GLTextureSprite2D(*this);
 }

--- a/gemrb/plugins/SDLVideo/GLTextureSprite2D.h
+++ b/gemrb/plugins/SDLVideo/GLTextureSprite2D.h
@@ -36,7 +36,7 @@ namespace GemRB
 		GLTextureSprite2D (int Width, int Height, int Bpp, void* pixels, Uint32 rmask=0, Uint32 gmask=0, Uint32 bmask=0, Uint32 amask=0);
 		~GLTextureSprite2D();
 		GLTextureSprite2D(const GLTextureSprite2D &obj);
-		GLTextureSprite2D* copy() const;
+		GLTextureHolder<Sprite2D> copy() const;
 		void MakeUnused();
 	};
 }

--- a/gemrb/plugins/SDLVideo/SDL12Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL12Video.cpp
@@ -158,7 +158,7 @@ IAlphaIterator* SDL12VideoDriver::StencilIterator(uint32_t flags, SDL_Rect maskc
 	return maskit;
 }
 
-void SDL12VideoDriver::BlitSpriteBAMClipped(const Sprite2D* spr, const Region& src, const Region& dst,
+void SDL12VideoDriver::BlitSpriteBAMClipped(const Holder<Sprite2D> spr, const Region& src, const Region& dst,
 											uint32_t flags, const Color* t)
 {
 	Color tint(255,255,255,255);
@@ -248,7 +248,7 @@ void SDL12VideoDriver::BlitSpriteBAMClipped(const Sprite2D* spr, const Region& s
 
 void SDL12VideoDriver::BlitSpriteNativeClipped(const sprite_t* spr, const SDL_Rect& srect, const SDL_Rect& drect, uint32_t flags, const SDL_Color* tint)
 {
-	const SDLSurfaceSprite2D* sdlspr = static_cast<const SDLSurfaceSprite2D*>(spr);
+	const SDLSurfaceSprite2D *sdlspr = static_cast<const SDLSurfaceSprite2D*>(spr);
 	SDL_Surface* surf = sdlspr->GetSurface();
 
 	Color c;
@@ -522,12 +522,12 @@ SDLVideoDriver::vid_buf_t* SDL12VideoDriver::CurrentStencilBuffer() const
 	return std::static_pointer_cast<SDLSurfaceVideoBuffer>(stencilBuffer)->Surface();
 }
 
-Sprite2D* SDL12VideoDriver::GetScreenshot(Region r,  const VideoBufferPtr& buf)
+Holder<Sprite2D> SDL12VideoDriver::GetScreenshot(Region r,  const VideoBufferPtr& buf)
 {
 	unsigned int Width = r.w ? r.w : screenSize.w;
 	unsigned int Height = r.h ? r.h : screenSize.h;
 
-	SDLSurfaceSprite2D* screenshot = new SDLSurfaceSprite2D(Region(0,0, Width, Height), 24,
+	SDLSurfaceSprite2D *screenshot = new SDLSurfaceSprite2D(Region(0,0, Width, Height), 24,
 															0x00ff0000, 0x0000ff00, 0x000000ff, 0);
 	SDL_Rect src = RectFromRegion(r);
 	if (buf) {

--- a/gemrb/plugins/SDLVideo/SDL12Video.h
+++ b/gemrb/plugins/SDLVideo/SDL12Video.h
@@ -39,7 +39,7 @@ public:
 	int CreateDriverDisplay(const Size&, int bpp, const char* title) override;
 	void SetWindowTitle(const char *title) override { SDL_WM_SetCaption(title, 0); };
 
-	Sprite2D* GetScreenshot( Region r, const VideoBufferPtr& buf = nullptr ) override;
+	Holder<Sprite2D> GetScreenshot( Region r, const VideoBufferPtr& buf = nullptr ) override;
 
 	bool SetFullscreenMode(bool set) override;
 
@@ -69,7 +69,7 @@ private:
 
 	int ProcessEvent(const SDL_Event & event) override;
 
-	void BlitSpriteBAMClipped(const Sprite2D* spr, const Region& src, const Region& dst,
+	void BlitSpriteBAMClipped(const Holder<Sprite2D> spr, const Region& src, const Region& dst,
 							  uint32_t flags = 0, const Color* tint = NULL) override;
 	void BlitSpriteNativeClipped(const sprite_t* spr, const SDL_Rect& src, const SDL_Rect& dst,
 								 uint32_t flags = 0, const SDL_Color* tint = NULL) override;

--- a/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20GLVideo.cpp
@@ -215,18 +215,18 @@ bool GLVideoDriver::createPrograms()
 	return true;
 }
 
-Sprite2D* GLVideoDriver::CreateSprite(const Region& rgn, int bpp, ieDword rMask, ieDword gMask, ieDword bMask, ieDword aMask, void* pixels, bool cK, int index)
+Holder<Sprite2D> GLVideoDriver::CreateSprite(const Region& rgn, int bpp, ieDword rMask, ieDword gMask, ieDword bMask, ieDword aMask, void* pixels, bool cK, int index)
 {
-	GLTextureSprite2D* spr = new GLTextureSprite2D(rgn, bpp, pixels, rMask, gMask, bMask, aMask);
+	GLTextureHolder<Sprite2D> spr = new GLTextureSprite2D(rgn, bpp, pixels, rMask, gMask, bMask, aMask);
 	if (cK) spr->SetColorKey(index);
 	return spr;
 }
 
-Sprite2D* GLVideoDriver::CreatePalettedSprite(const Region& rgn, int bpp, void* pixels, Color* palette, bool cK, int index)
+Holder<Sprite2D> GLVideoDriver::CreatePalettedSprite(const Region& rgn, int bpp, void* pixels, Color* palette, bool cK, int index)
 {
 	if (palette == NULL) return NULL;
 
-	GLTextureSprite2D* spr = new GLTextureSprite2D(rgn, bpp, pixels);
+	GLTextureHolder<Sprite2D> spr = new GLTextureSprite2D(rgn, bpp, pixels);
 	spr->SetPaletteManager(paletteManager);
 	PaletteHolder pal = new Palette(palette);
 	spr->SetPalette(pal);
@@ -234,13 +234,13 @@ Sprite2D* GLVideoDriver::CreatePalettedSprite(const Region& rgn, int bpp, void* 
 	return spr;
 }
 
-Sprite2D* GLVideoDriver::CreateSprite8(const Region& rgn, void* pixels, PaletteHolder palette, bool cK, int index)
+Holder<Sprite2D> GLVideoDriver::CreateSprite8(const Region& rgn, void* pixels, PaletteHolder palette, bool cK, int index)
 {
 	return CreatePalettedSprite(rgn, 8, pixels, palette->col, cK, index);
 }
 
-void GLVideoDriver::GLBlitSprite(GLTextureSprite2D* spr, const Region& src, const Region& dst, PaletteHolder attachedPal,
-								 unsigned int flags, const Color* tint, GLTextureSprite2D* mask)
+void GLVideoDriver::GLBlitSprite(GLTextureHolder<Sprite2D> spr, const Region& src, const Region& dst, PaletteHolder attachedPal,
+								 unsigned int flags, const Color* tint, GLTextureHolder<Sprite2D> mask)
 {
 	// TODO: clip dst to the screen?
 	if (dst.w <= 0 || dst.h <= 0 || src.w <= 0 || src.h <= 0)
@@ -383,7 +383,7 @@ void GLVideoDriver::GLBlitSprite(GLTextureSprite2D* spr, const Region& src, cons
 	spritesPerFrame++;
 }
 
-void GLVideoDriver::BlitSprite(const Sprite2D* spr, const Region& src, const Region& dst, PaletteHolder palette)
+void GLVideoDriver::BlitSprite(const Holder<Sprite2D> spr, const Region& src, const Region& dst, PaletteHolder palette)
 {
 	GLBlitSprite((GLTextureSprite2D*)spr, src, dst, palette);
 }
@@ -523,7 +523,7 @@ static Region ClipSprite(const Sprite2D &sprite, const Region &clip, const int t
 	return r;
 }
 
-void GLVideoDriver::BlitTile(const Sprite2D* spr, int x, int y, const Region* clip, unsigned int flags, const Color* tint)
+void GLVideoDriver::BlitTile(const Holder<Sprite2D> spr, int x, int y, const Region* clip, unsigned int flags, const Color* tint)
 {
 	int tx = x - spr->Frame.x;
 	int ty = y - spr->Frame.y;
@@ -561,7 +561,7 @@ void GLVideoDriver::BlitTile(const Sprite2D* spr, int x, int y, const Region* cl
 						NULL, blitFlags, (totint ? &tileTint : NULL), (GLTextureSprite2D*)mask);
 }
 
-void GLVideoDriver::BlitGameSprite(const Sprite2D* spr, int x, int y, unsigned int flags, Color tint,
+void GLVideoDriver::BlitGameSprite(const Holder<Sprite2D> spr, int x, int y, unsigned int flags, Color tint,
 								   SpriteCover* cover, PaletteHolder palette, const Region* clip, bool anchor)
 {
 	int tx = x - spr->Frame.x;
@@ -571,7 +571,7 @@ void GLVideoDriver::BlitGameSprite(const Sprite2D* spr, int x, int y, unsigned i
 		tx -= Viewport.x;
 		ty -= Viewport.y;
 	}
-	GLTextureSprite2D* glSprite = (GLTextureSprite2D*)spr;
+	GLTextureHolder<Sprite2D> glSprite = (GLTextureSprite2D*)spr;
 	GLuint coverTexture = 0;
 
 	if(glSprite->IsPaletted())
@@ -772,7 +772,7 @@ int GLVideoDriver::SwapBuffers()
 	return val;
 }
 
-Sprite2D* GLVideoDriver::GetScreenshot(Region r)
+Holder<Sprite2D> GLVideoDriver::GetScreenshot(Region r)
 {
 	unsigned int w = r.w ? r.w : width - r.x;
 	unsigned int h = r.h ? r.h : height - r.y;
@@ -793,7 +793,7 @@ Sprite2D* GLVideoDriver::GetScreenshot(Region r)
 		pixelSrcPointer -= w;
 	}
 	free(glPixels);
-	Sprite2D* screenshot = new GLTextureSprite2D(w, h, 32, pixels, 0x000000FF, 0x0000FF00, 0x00FF0000, 0xFF000000);
+	Holder<Sprite2D> screenshot = new GLTextureSprite2D(w, h, 32, pixels, 0x000000FF, 0x0000FF00, 0x00FF0000, 0xFF000000);
 	return screenshot;
 }
 

--- a/gemrb/plugins/SDLVideo/SDL20GLVideo.h
+++ b/gemrb/plugins/SDLVideo/SDL20GLVideo.h
@@ -42,12 +42,12 @@ namespace GemRB
 
 		GLPaletteManager* paletteManager; // palette manager instance
 
-		GLTextureSprite2D *backgroundBuffer;
+		GLTextureHolder<Sprite2D> backgroundBuffer;
 		Region GLViewport;
 
 		void useProgram(GLSLProgram* program); // use this instead program->Use()
 		bool createPrograms();
-		void GLBlitSprite(GLTextureSprite2D* spr, const Region& src, const Region& dst, PaletteHolder attachedPal = NULL, unsigned int flags = 0, const Color* tint = NULL, GLTextureSprite2D* mask = NULL);
+		void GLBlitSprite(GLTextureHolder<Sprite2D> spr, const Region& src, const Region& dst, PaletteHolder attachedPal = NULL, unsigned int flags = 0, const Color* tint = NULL, GLTextureHolder<Sprite2D> mask = NULL);
 		void clearRect(const Region& rgn, const Color& color);
 		void drawEllipse(int cx, int cy, unsigned short xr, unsigned short yr, float thickness, const Color& color);
 		void drawPolygon(Point* points, unsigned int count, const Color& color, PointDrawingMode mode);
@@ -56,12 +56,12 @@ namespace GemRB
 		~GLVideoDriver();
 		int SwapBuffers();
 		int CreateDisplay(int w, int h, int b, bool fs, const char* title);
-		void BlitSprite(const Sprite2D* spr, const Region& src, const Region& dst, PaletteHolder palette);
-		void BlitGameSprite(const Sprite2D* spr, int x, int y, unsigned int flags, Color tint, SpriteCover* cover, PaletteHolder palette = NULL, const Region* clip = NULL, bool anchor = false);
-		void BlitTile(const Sprite2D* spr, int x, int y, const Region* clip, unsigned int flags, const Color* tint = NULL);
-		Sprite2D* CreateSprite(const Region&, int bpp, ieDword rMask, ieDword gMask, ieDword bMask, ieDword aMask, void* pixels,	bool cK = false, int index = 0);
-		Sprite2D* CreateSprite8(const Region&, void* pixels, PaletteHolder palette, bool cK, int index);
-		Sprite2D* CreatePalettedSprite(const Region&, int bpp, void* pixels, Color* palette, bool cK = false, int index = 0);
+		void BlitSprite(const Holder<Sprite2D> spr, const Region& src, const Region& dst, PaletteHolder palette);
+		void BlitGameSprite(const Holder<Sprite2D> spr, int x, int y, unsigned int flags, Color tint, SpriteCover* cover, PaletteHolder palette = NULL, const Region* clip = NULL, bool anchor = false);
+		void BlitTile(const Holder<Sprite2D> spr, int x, int y, const Region* clip, unsigned int flags, const Color* tint = NULL);
+		Holder<Sprite2D> CreateSprite(const Region&, int bpp, ieDword rMask, ieDword gMask, ieDword bMask, ieDword aMask, void* pixels,	bool cK = false, int index = 0);
+		Holder<Sprite2D> CreateSprite8(const Region&, void* pixels, PaletteHolder palette, bool cK, int index);
+		Holder<Sprite2D> CreatePalettedSprite(const Region&, int bpp, void* pixels, Color* palette, bool cK = false, int index = 0);
 		void DrawRect(const Region& rgn, const Color& color, bool fill = true, bool clipped = false);
 		void DrawHLine(short x1, short y, short x2, const Color& color, bool clipped = false);
 		void DrawVLine(short x, short y1, short y2, const Color& color, bool clipped = false);
@@ -71,7 +71,7 @@ namespace GemRB
 		void DrawCircle(short cx, short cy, unsigned short r, const Color& color, bool clipped = true);
 		void SetPixel(short x, short y, const Color& color, bool clipped = true);
 		/*void DrawEllipseSegment(short cx, short cy, unsigned short xr, unsigned short yr, const Color& color, double anglefrom, double angleto, bool drawlines = true, bool clipped = true);*/
-		Sprite2D* GetScreenshot(Region r);
+		Holder<Sprite2D> GetScreenshot(Region r);
 
 		void DrawBackgroundBuffer();
 		void FreeBackgroundBuffer();

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -509,7 +509,7 @@ void SDL20VideoDriver::DrawPolygonImp(const Gem_Polygon* poly, const Point& orig
 	}
 }
 
-Sprite2D* SDL20VideoDriver::GetScreenshot(Region r, const VideoBufferPtr& buf)
+Holder<Sprite2D> SDL20VideoDriver::GetScreenshot(Region r, const VideoBufferPtr& buf)
 {
 	SDL_Rect rect = RectFromRegion(r);
 

--- a/gemrb/plugins/SDLVideo/SDL20Video.h
+++ b/gemrb/plugins/SDLVideo/SDL20Video.h
@@ -224,7 +224,7 @@ public:
 
 	void SwapBuffers(VideoBuffers& buffers) override;
 
-	Sprite2D* GetScreenshot( Region r, const VideoBufferPtr& buf = nullptr ) override;
+	Holder<Sprite2D> GetScreenshot( Region r, const VideoBufferPtr& buf = nullptr ) override;
 	bool SetFullscreenMode(bool set) override;
 	void SetGamma(int brightness, int contrast) override;
 	bool ToggleGrabInput() override;
@@ -261,7 +261,7 @@ private:
 
 	void DrawPolygonImp(const Gem_Polygon* poly, const Point& origin, const Color& color, bool fill, uint32_t flags) override;
 
-	void BlitSpriteBAMClipped(const Sprite2D* /*spr*/, const Region& /*src*/, const Region& /*dst*/,
+	void BlitSpriteBAMClipped(const Holder<Sprite2D> /*spr*/, const Region& /*src*/, const Region& /*dst*/,
 					   unsigned int /*flags*/ = 0, const Color* /*tint*/ = NULL) override { assert(false); } // SDL2 does not support this
 	void BlitSpriteNativeClipped(const sprite_t* spr, const SDL_Rect& src, const SDL_Rect& dst,
 								 uint32_t flags = 0, const SDL_Color* tint = NULL) override;

--- a/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.cpp
+++ b/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.cpp
@@ -83,7 +83,7 @@ SDLSurfaceSprite2D::SDLSurfaceSprite2D(const SDLSurfaceSprite2D &obj)
 	original = surface;
 }
 
-SDLSurfaceSprite2D* SDLSurfaceSprite2D::copy() const
+Holder<Sprite2D> SDLSurfaceSprite2D::copy() const
 {
 	return new SDLSurfaceSprite2D(*this);
 }
@@ -335,7 +335,7 @@ SDLTextureSprite2D::SDLTextureSprite2D(const SDLTextureSprite2D& obj)
 	texture = obj.texture;
 }
 
-SDLTextureSprite2D* SDLTextureSprite2D::copy() const
+Holder<Sprite2D> SDLTextureSprite2D::copy() const
 {
 	return new SDLTextureSprite2D(*this);
 }

--- a/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.h
+++ b/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.h
@@ -56,21 +56,21 @@ public:
 	SDLSurfaceSprite2D(const Region&, int Bpp,
 					   ieDword rmask, ieDword gmask, ieDword bmask, ieDword amask);
 	SDLSurfaceSprite2D(const SDLSurfaceSprite2D &obj);
-	SDLSurfaceSprite2D* copy() const;
+	SDLSurfaceSprite2D* copy() const override;
 
-	const void* LockSprite() const;
-	void* LockSprite();
-	void UnlockSprite() const;
+	const void* LockSprite() const override;
+	void* LockSprite() override;
+	void UnlockSprite() const override;
 
-	PaletteHolder GetPalette() const;
+	PaletteHolder GetPalette() const override;
 	int SetPalette(const Color* pal) const;
-	void SetPalette(PaletteHolder pal);
-	int32_t GetColorKey() const;
-	void SetColorKey(ieDword pxvalue);
-	bool HasTransparency() const;
-	Color GetPixel(const Point&) const;
+	void SetPalette(PaletteHolder pal) override;
+	int32_t GetColorKey() const override;
+	void SetColorKey(ieDword pxvalue) override;
+	bool HasTransparency() const override;
+	Color GetPixel(const Point&) const override;
 	bool ConvertFormatTo(int bpp, ieDword rmask, ieDword gmask,
-						 ieDword bmask, ieDword amask);
+						 ieDword bmask, ieDword amask) override;
 
 	SDL_Surface* GetSurface() const { return *surface; };
 
@@ -108,15 +108,15 @@ public:
 	SDLTextureSprite2D(const Region&, int Bpp,
 					   ieDword rmask, ieDword gmask, ieDword bmask, ieDword amask);
 	SDLTextureSprite2D(const SDLTextureSprite2D& obj);
-	SDLTextureSprite2D* copy() const;
+	SDLTextureSprite2D* copy() const override;
 
 	using SDLSurfaceSprite2D::SetPalette;
-	void SetColorKey(ieDword pxvalue);
+	void SetColorKey(ieDword pxvalue) override;
 
 	SDL_Texture* GetTexture(SDL_Renderer* renderer) const;
 
-	void* NewVersion(version_t version) const;
-	void Restore() const;
+	void* NewVersion(version_t version) const override;
+	void Restore() const override;
 };
 #endif
 

--- a/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.h
+++ b/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.h
@@ -56,7 +56,7 @@ public:
 	SDLSurfaceSprite2D(const Region&, int Bpp,
 					   ieDword rmask, ieDword gmask, ieDword bmask, ieDword amask);
 	SDLSurfaceSprite2D(const SDLSurfaceSprite2D &obj);
-	SDLSurfaceSprite2D* copy() const override;
+	Holder<Sprite2D> copy() const override;
 
 	const void* LockSprite() const override;
 	void* LockSprite() override;
@@ -108,7 +108,7 @@ public:
 	SDLTextureSprite2D(const Region&, int Bpp,
 					   ieDword rmask, ieDword gmask, ieDword bmask, ieDword amask);
 	SDLTextureSprite2D(const SDLTextureSprite2D& obj);
-	SDLTextureSprite2D* copy() const override;
+	Holder<Sprite2D> copy() const override;
 
 	using SDLSurfaceSprite2D::SetPalette;
 	void SetColorKey(ieDword pxvalue) override;

--- a/gemrb/plugins/SDLVideo/SDLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDLVideo.cpp
@@ -238,7 +238,7 @@ int SDLVideoDriver::ProcessEvent(const SDL_Event & event)
 	return GEM_OK;
 }
 
-Sprite2D* SDLVideoDriver::CreateSprite(const Region& rgn, int bpp, ieDword rMask,
+Holder<Sprite2D> SDLVideoDriver::CreateSprite(const Region& rgn, int bpp, ieDword rMask,
 	ieDword gMask, ieDword bMask, ieDword aMask, void* pixels, bool cK, int index)
 {
 	sprite_t* spr = new sprite_t(rgn, bpp, pixels, rMask, gMask, bMask, aMask);
@@ -257,13 +257,13 @@ Sprite2D* SDLVideoDriver::CreateSprite(const Region& rgn, int bpp, ieDword rMask
 	return spr;
 }
 
-Sprite2D* SDLVideoDriver::CreateSprite8(const Region& rgn, void* pixels,
+Holder<Sprite2D> SDLVideoDriver::CreateSprite8(const Region& rgn, void* pixels,
 										PaletteHolder palette, bool cK, int index)
 {
 	return CreatePalettedSprite(rgn, 8, pixels, palette->col, cK, index);
 }
 
-Sprite2D* SDLVideoDriver::CreatePalettedSprite(const Region& rgn, int bpp, void* pixels,
+Holder<Sprite2D> SDLVideoDriver::CreatePalettedSprite(const Region& rgn, int bpp, void* pixels,
 											   Color* palette, bool cK, int index)
 {
 	sprite_t* spr = new sprite_t(rgn, bpp, pixels, 0, 0, 0, 0);
@@ -275,7 +275,7 @@ Sprite2D* SDLVideoDriver::CreatePalettedSprite(const Region& rgn, int bpp, void*
 	return spr;
 }
 
-void SDLVideoDriver::BlitTile(const Sprite2D* spr, int x, int y, const Region* clip, uint32_t flags, const Color* tint)
+void SDLVideoDriver::BlitTile(const Holder<Sprite2D> spr, int x, int y, const Region* clip, uint32_t flags, const Color* tint)
 {
 	assert(spr->BAM == false);
 
@@ -287,7 +287,7 @@ void SDLVideoDriver::BlitTile(const Sprite2D* spr, int x, int y, const Region* c
 	BlitSpriteClipped(spr, srect, fClip, flags, tint);
 }
 
-void SDLVideoDriver::BlitSprite(const Sprite2D* spr, const Region& src, Region dst)
+void SDLVideoDriver::BlitSprite(const Holder<Sprite2D> spr, const Region& src, Region dst)
 {
 	dst.x -= spr->Frame.x;
 	dst.y -= spr->Frame.y;
@@ -295,7 +295,7 @@ void SDLVideoDriver::BlitSprite(const Sprite2D* spr, const Region& src, Region d
 	BlitSpriteClipped(spr, src, dst, flags);
 }
 
-void SDLVideoDriver::BlitGameSprite(const Sprite2D* spr, int x, int y,
+void SDLVideoDriver::BlitGameSprite(const Holder<Sprite2D> spr, int x, int y,
 									uint32_t flags, Color tint, const Region* clip)
 {
 	Region srect(Point(0, 0), (clip) ? clip->Dimensions() : Size(spr->Frame.w, spr->Frame.h));
@@ -536,7 +536,7 @@ void SDLVideoDriver::DrawEllipseImp(const Point& c, unsigned short xr,
 
 #undef SetPixel
 
-void SDLVideoDriver::BlitSpriteClipped(const Sprite2D* spr, Region src, const Region& dst, uint32_t flags, const Color* tint)
+void SDLVideoDriver::BlitSpriteClipped(const Holder<Sprite2D> spr, Region src, const Region& dst, uint32_t flags, const Color* tint)
 {
 #if SDL_VERSION_ATLEAST(1,3,0)
 	// in SDL2 SDL_RenderCopyEx will flip the src rect internally if BLIT_MIRRORX or BLIT_MIRRORY is set
@@ -590,7 +590,7 @@ void SDLVideoDriver::BlitSpriteClipped(const Sprite2D* spr, Region src, const Re
 	} else {
 		SDL_Rect srect = RectFromRegion(src);
 		SDL_Rect drect = RectFromRegion(dclipped);
-		const sprite_t* native = static_cast<const sprite_t*>(spr);
+		const sprite_t* native = static_cast<const sprite_t*>(spr.get ());
 		BlitSpriteNativeClipped(native, srect, drect, flags, reinterpret_cast<const SDL_Color*>(tint));
 	}
 }

--- a/gemrb/plugins/SDLVideo/SDLVideo.h
+++ b/gemrb/plugins/SDLVideo/SDLVideo.h
@@ -65,22 +65,22 @@ public:
 	virtual ~SDLVideoDriver(void);
 	int Init(void) override;
 
-	Sprite2D* CreateSprite(const Region& rgn, int bpp, ieDword rMask,
+	Holder<Sprite2D> CreateSprite(const Region& rgn, int bpp, ieDword rMask,
 		ieDword gMask, ieDword bMask, ieDword aMask, void* pixels,
 		bool cK = false, int index = 0) override;
-	Sprite2D* CreateSprite8(const Region& rgn, void* pixels,
+	Holder<Sprite2D> CreateSprite8(const Region& rgn, void* pixels,
 							PaletteHolder palette, bool cK, int index) override;
-	Sprite2D* CreatePalettedSprite(const Region& rgn, int bpp, void* pixels,
+	Holder<Sprite2D> CreatePalettedSprite(const Region& rgn, int bpp, void* pixels,
 								   Color* palette, bool cK = false, int index = 0) override;
 
-	void BlitTile(const Sprite2D* spr, int x, int y, const Region* clip,
+	void BlitTile(const Holder<Sprite2D> spr, int x, int y, const Region* clip,
 						  uint32_t flags, const Color* tint = NULL) override;
-	void BlitSprite(const Sprite2D* spr, const Region& src, Region dst) override;
-	void BlitGameSprite(const Sprite2D* spr, int x, int y, uint32_t flags, Color tint,
+	void BlitSprite(const Holder<Sprite2D> spr, const Region& src, Region dst) override;
+	void BlitGameSprite(const Holder<Sprite2D> spr, int x, int y, uint32_t flags, Color tint,
 								const Region* clip = NULL) override;
 
 	/** Blits a Sprite filling the Region */
-	void BlitTiled(Region rgn, const Sprite2D* img);
+	void BlitTiled(Region rgn, const Holder<Sprite2D> img);
 
 protected:
 #if SDL_VERSION_ATLEAST(1,3,0)
@@ -98,9 +98,9 @@ protected:
 	
 	void RenderSpriteVersion(const SDLSurfaceSprite2D* spr, uint32_t renderflags, const Color* = NULL);
 
-	virtual void BlitSpriteBAMClipped(const Sprite2D* spr, const Region& src, const Region& dst, uint32_t flags = 0, const Color* tint = NULL)=0;
+	virtual void BlitSpriteBAMClipped(const Holder<Sprite2D> spr, const Region& src, const Region& dst, uint32_t flags = 0, const Color* tint = NULL)=0;
 	virtual void BlitSpriteNativeClipped(const sprite_t* spr, const SDL_Rect& src, const SDL_Rect& dst, uint32_t flags = 0, const SDL_Color* tint = NULL)=0;
-	void BlitSpriteClipped(const Sprite2D* spr, Region src, const Region& dst, uint32_t flags = 0, const Color* tint = NULL);
+	void BlitSpriteClipped(const Holder<Sprite2D> spr, Region src, const Region& dst, uint32_t flags = 0, const Color* tint = NULL);
 
 	int PollEvents() override;
 	/* used to process the SDL events dequeued by PollEvents or an arbitraty event from another source.*/

--- a/gemrb/plugins/SDLVideo/SpriteRenderer.inl
+++ b/gemrb/plugins/SDLVideo/SpriteRenderer.inl
@@ -358,7 +358,7 @@ static void BlitSpriteRLE_Partial(const Uint8* rledata, const int pitch, const R
 }
 
 template<typename Blender, typename Tinter>
-static void BlitSpriteRLE(const Sprite2D* spr, const Region& srect,
+static void BlitSpriteRLE(Holder<Sprite2D> spr, const Region& srect,
 						  SDL_Surface* dst, const Region& drect,
 						  IAlphaIterator* cover,
 						  uint32_t flags, const Tinter& tint)

--- a/gemrb/plugins/TISImporter/TISImporter.cpp
+++ b/gemrb/plugins/TISImporter/TISImporter.cpp
@@ -86,7 +86,7 @@ Tile* TISImporter::GetTile(unsigned short* indexes, int count,
 	return new Tile( ani );
 }
 
-Sprite2D* TISImporter::GetTile(int index)
+Holder<Sprite2D> TISImporter::GetTile(int index)
 {
 	Color Col[256];
 	Color Palette[256]{};

--- a/gemrb/plugins/TISImporter/TISImporter.h
+++ b/gemrb/plugins/TISImporter/TISImporter.h
@@ -36,7 +36,7 @@ public:
 	bool Open(DataStream* stream);
 	Tile* GetTile(unsigned short* indexes, int count,
 		unsigned short* secondary = NULL);
-	Sprite2D* GetTile(int index);
+	Holder<Sprite2D> GetTile(int index);
 public:
 };
 

--- a/gemrb/plugins/TTFImporter/TTFFont.cpp
+++ b/gemrb/plugins/TTFImporter/TTFFont.cpp
@@ -174,10 +174,9 @@ const Glyph& TTFFont::GetGlyph(ieWord chr) const
 	// TODO: do an underline if requested
 
 	Region r(0, FT_FLOOR(metrics->horiBearingY), sprSize.w, sprSize.h);
-	Sprite2D* spr = core->GetVideoDriver()->CreateSprite8(r, pixels, palette, true, 0);
+	Holder<Sprite2D> spr = core->GetVideoDriver()->CreateSprite8(r, pixels, palette, true, 0);
 	// FIXME: casting away const
 	const Glyph& ret = ((TTFFont*)this)->CreateGlyphForCharSprite(chr, spr);
-	spr->release();
 	return ret;
 }
 
@@ -204,7 +203,7 @@ TTFFont::TTFFont(PaletteHolder pal, FT_Face face, int lineheight, int baseline)
 	FT_Reference_Face(face); // retain the face or the font manager will destroy it
 #endif
 	// ttf fonts dont produce glyphs for whitespace
-	Sprite2D* blank = core->GetVideoDriver()->CreateSprite8(Region(), NULL, palette);
+	Holder<Sprite2D> blank = core->GetVideoDriver()->CreateSprite8(Region(), NULL, palette);
 	// blank for returning when there is an error
 	// TODO: ttf fonts have a "box" glyph they use for this
 	CreateGlyphForCharSprite(0, blank);
@@ -212,7 +211,6 @@ TTFFont::TTFFont(PaletteHolder pal, FT_Face face, int lineheight, int baseline)
 	CreateGlyphForCharSprite(' ', blank);
 	blank->Frame.w *= 4;
 	CreateGlyphForCharSprite('\t', blank);
-	blank->release();
 }
 
 TTFFont::~TTFFont()


### PR DESCRIPTION
## Description

This does the same for Sprite2D as the previous patch did for Palette: remove manual refcounting, use Holder.

Some of the followup patches fix a few other leaks: unwanted acquire calls left for Palette, and an Image that never got deleted. There's also a fix for one crash where the sanitizer detected a stack overrun.

Grepping for "release" calls shows the following are left in the code base (excluding Holder). As far as I can tell, none of them are related to Palette or Sprite2D, so at least on that point these changes should be safe.

gemrb/core/SaveGameIterator.cpp:667:		save.release();
gemrb/core/Interface.cpp:399:	AudioDriver.release();
gemrb/core/Interface.cpp:400:	video.release();
gemrb/core/Interface.cpp:565:		LoadGameIndex.release();
gemrb/core/Interface.cpp:2801:	symbols[index].sm.release();
gemrb/core/Interface.cpp:2935:		sound_override.release();
gemrb/core/GameData.cpp:230:			tables[index].tm.release();
gemrb/core/Scriptable/Actor.cpp:429:	extspeed.release();
gemrb/core/Scriptable/Scriptable.cpp:2049:			caster->casting_sound.release();
gemrb/core/ScriptedAnimation.cpp:590:		sound_handle.release();
gemrb/core/GUI/WindowManager.cpp:87:	video.release();
gemrb/core/GUI/WindowManager.cpp:480:				tooltip_sound.release();
gemrb/core/GameScript/GameScript.cpp:1399:	triggersTable.release();
gemrb/core/GameScript/GameScript.cpp:1400:	actionsTable.release();
gemrb/core/GameScript/GameScript.cpp:1401:	objectsTable.release();
gemrb/core/GameScript/GameScript.cpp:1402:	overrideActionsTable.release();
gemrb/core/GameScript/GameScript.cpp:1403:	overrideTriggersTable.release();
gemrb/core/Projectile.cpp:659:		travel_handle.release();
gemrb/core/TableMgr.cpp:58:		table.release();
gemrb/core/TableMgr.cpp:65:	release();
gemrb/core/TableMgr.cpp:78:	release();
gemrb/core/TableMgr.cpp:85:		table.release();
gemrb/plugins/GUIScript/PythonConversions.h:84:		static_cast<T*>(obj)->release();
gemrb/plugins/AREImporter/AREImporter.cpp:85:	INInote.release();
gemrb/plugins/OpenALAudio/OpenALAudio.cpp:154:		if (handle) { handle->Invalidate(); handle.release(); }
