### PR TITLE
Fix autopause on enemy sighted

### DIFF
--- a/gemrb/core/Map.h
+++ b/gemrb/core/Map.h
@@ -403,6 +403,7 @@ private:
 	Actor** queue[QUEUE_COUNT];
 	int Qcount[QUEUE_COUNT];
 	unsigned int lastActorCount[QUEUE_COUNT];
+	bool hostiles_visible = false;
 
 	VideoBufferPtr wallStencil;
 	Region stencilViewport;
@@ -436,7 +437,7 @@ public:
 	void CopyGroundPiles(Map *othermap, const Point &Pos);
 	/* transfers all ever visible piles (loose items) to the specified position */
 	void MoveVisibleGroundPiles(const Point &Pos);
-	
+
 	void DrawMap(const Region& viewport, uint32_t debugFlags);
 	void PlayAreaSong(int SongType, bool restart = true, bool hard = false);
 	void AddAnimation(AreaAnimation* anim);
@@ -458,6 +459,7 @@ public:
 	bool BehindWall(const Point&, const Region&) const;
 	void Shout(Actor* actor, int shoutID, bool global);
 	void ActorSpottedByPlayer(Actor *actor);
+	bool HandleAutopauseForVisible(Actor *actor, bool);
 	void InitActors();
 	void InitActor(Actor *actor);
 	void AddActor(Actor* actor, bool init);

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -7994,15 +7994,6 @@ void Actor::UpdateActorState()
 		DisplayHeadHPRatio();
 	}
 
-	// trigger on-enemy-sighted autopause
-	if (!(InternalFlags & IF_TRIGGER_AP)) {
-		// always recheck in case of EA changes (npc going hostile)
-		if (Modified[IE_EA] > EA_EVILCUTOFF && !(InternalFlags & IF_STOPATTACK)) {
-			InternalFlags |= IF_TRIGGER_AP;
-			core->Autopause(AP_ENEMY, this);
-		}
-	}
-
 	const auto& anim = currentStance.anim;
 	if (attackProjectile) {
 		// default so that the projectile fires if we dont have an animation for some reason
@@ -8723,9 +8714,10 @@ bool Actor::UpdateDrawingState()
 	}
 
 	int explored = Modified[IE_DONOTJUMP]&DNJ_UNHINDERED;
+	bool visible = area->IsVisible(Pos, explored);
 	//check the deactivation condition only if needed
 	//this fixes dead actors disappearing from fog of war (they should be permanently visible)
-	if ((!area->IsVisible( Pos, explored) || (InternalFlags&IF_REALLYDIED) ) && (InternalFlags&IF_ACTIVE) ) {
+	if ((!visible || (InternalFlags & IF_REALLYDIED)) && (InternalFlags & IF_ACTIVE) ) {
 		//turning actor inactive if there is no action next turn
 		if (ShouldHibernate()) {
 			InternalFlags|=IF_IDLE;


### PR DESCRIPTION
There were a number of problems here.  The first one is that directly
after creating a character, BG2 goes into pause mode, which looks like
a lockup to the user, since the GUI isn't shown at that point.  The
issue is that Actor::UpdateActorState doesn't check for visibility
and triggers autopause for the Cambion, which is somewhere else
entirely.  I believe this code isn't needed at all, and deleted it.

The next problem is the check in Map::InitActor.  This has an
isVisible check using actor->Pos, but the position isn't set at that
point, it's 0,0.  Most callers of AddActor appear to follow up with
SetPosition (and you can't swap the two).  I removed the
ActorSpottedByPlayer call in this function, and added a log message
to show an error in case the condition ever triggers, which really
ought not to be possible.

The only semi-reasonable autopause code was in GenerateQueues, and now
we generate all enemy-sighted pauses from there.  It was necessary to
separate the autopause code from ActorSpottedByPlayer, so that we can
also call it for already IF_ACTIVE actors.

The final issue was the use of AnyPCInCombat.  That seems to just be
a countdown, which was observable in Chateau Irenicus.  After
defeating the Ogre Mage spawned in by the genie, and then walking to
the first group of kobolds.  If you do it quickly, AnyPCInCombat
returns true, and no autopause is generated, which is incorrect.
Instead of this, we now keep track of whether hostile actors are
visible on the map, and suppress new autopause events when we already
saw some.  That is bug #630.
