### PR TITLE
Use a deadzone when going into rectangle select mode

### DIFF
--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -51,8 +51,9 @@
 namespace GemRB {
 
 // A deadzone when rotating the formation, to prevent erratic movement near
-// the initial click.
-constexpr int rotate_deadzone = 5;
+// the initial click.  Also used when deciding whether to go into
+// rectangle select mode.
+constexpr int movement_deadzone = 10;
 
 #define FORMATIONSIZE 10
 typedef Point formation_type[FORMATIONSIZE];
@@ -612,7 +613,7 @@ void GameControl::DrawSelf(Region screen, const Region& /*clip*/)
 	// draw reticles
 	if (isFormationRotation) {
 		double angle = formationBaseAngle;
-		if (Distance(gameMousePos, gameClickPoint) > rotate_deadzone) {
+		if (Distance(gameMousePos, gameClickPoint) > movement_deadzone) {
 			angle = AngleFromPoints(gameMousePos, gameClickPoint);
 		}
 		DrawFormation(game->selected, gameClickPoint, angle);
@@ -1486,7 +1487,9 @@ bool GameControl::OnMouseDrag(const MouseEvent& me)
 		return true;
 	}
 
-	if (me.ButtonState(GEM_MB_ACTION) && !isFormationRotation) {
+	Point gameMousePos = GameMousePos();
+	if (me.ButtonState(GEM_MB_ACTION) && !isFormationRotation
+		&& Distance(gameMousePos, gameClickPoint) > movement_deadzone) {
 		isSelectionRect = true;
 	}
 
@@ -2278,7 +2281,7 @@ void GameControl::CommandSelectedMovement(const Point& p, unsigned short Mod)
 	if (isFormationRotation) {
 		angle = formationBaseAngle;
 		Point mp = GameMousePos();
-		if (Distance(mp, p) > rotate_deadzone) {
+		if (Distance(mp, p) > movement_deadzone) {
 			angle = AngleFromPoints(mp, p);
 		}
 	}


### PR DESCRIPTION
Currently, it can be difficult to initiate movement or combat, since a
slight movement of the mouse before releasing triggers rectangle select
mode.  I checked with the IE, and it also applies a deadzone so that
you can move the mouse a little between click and release.  This change
implements that.

The deadzone in IE is pretty large, around half of a reticle, so I bumped
ours as well.

One issue remains: IE shows feedback immediately on mouse press, rather
than waiting for mouse release, which makes for a better user experience.
