### PR TITLE
Clear trackingWin on mouse up

### DIFF
--- a/gemrb/core/GUI/WindowManager.cpp
+++ b/gemrb/core/GUI/WindowManager.cpp
@@ -350,13 +350,11 @@ bool WindowManager::DispatchEvent(const Event& event)
 					trackingWin->DispatchEvent(event);
 				}
 
-				if (event.type == Event::TouchUp) {
-					trackingWin = NULL;
-				}
+				trackingWin = NULL;
 			}
 
 			// we don't deliver mouse up events if there isn't a corresponding mouse down (trackingWin == NULL).
-			return bool(trackingWin);
+			return false;
 		}
 
 		if (event.type != Event::TouchGesture) {


### PR DESCRIPTION
Observed behaviour: Click on the rest button, wait for the movie to start,
then click on the same screen position again.  The game aborts with

Window.cpp:464: bool GemRB::Window::DispatchEvent(const GemRB::Event&): Assertion `target == NULL || target->IsVisible()' failed.

This seems to be caused by leaving trackingWin set after a MouseUp event,
an inconsistency with TouchUp.

Please note that the return value of this DispatchEvent is unused.  While
changing this code, I also removed a return value that looked meaningful
but wasn't, and changed it plain false.
