### PR TITLE
RespawnNameless():  Reselect TNO after death

### DIFF
--- a/gemrb/core/IniSpawn.cpp
+++ b/gemrb/core/IniSpawn.cpp
@@ -636,6 +636,11 @@ void IniSpawn::RespawnNameless()
 	// resurrect leaves you at 1hp for raise dead, so manually bump it back to max
 	nameless->RefreshEffects(NULL);
 	nameless->SetBase(IE_HITPOINTS, 9999);
+
+	// reselect nameless, since he didn't really 'die'
+	// this matches the unconditional reselect behavior of the original
+	core->GetGame()->SelectActor(nameless, true, SELECT_NORMAL);
+
 	//hardcoded!!!
 	if (NamelessState==36) {
 		nameless->SetStance(IE_ANI_PST_START);


### PR DESCRIPTION
There is a small ease of life feature in the original game, when Nameless dies, he stays selected, since you come back to life moments later (well, from TNO's point of view, I guess)

I made this tweak a while ago, after noticing a convenient place here https://github.com/gemrb/gemrb/commit/b7cbeb87df04b55b25585c1c97fec5f0ae799661, but I was wondering if it could potentially cause any problems

It seems to work alright, however, there is a worrying comment in Scriptable.cpp at Selectable::Select https://github.com/gemrb/gemrb/blob/e14fe1ac692a999d6acb0203bf1b632152141a5e/gemrb/core/Scriptable/Scriptable.cpp#L1816-L1817

This is only really a fix for a minor annoyance, but I was hoping to get some feedback so I can scratch it off the list. Can the condition that the comment warns about actually occur? Or is there a better place to add this line or a better way to achieve the same result?

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
