### PR TITLE
FreePalette followup

### DIFF
--- a/gemrb/core/CharAnimations.cpp
+++ b/gemrb/core/CharAnimations.cpp
@@ -395,7 +395,7 @@ void CharAnimations::SetupColors(PaletteType type)
 		*/
 		for (int i = 0; i < colorcount; i++) {
 			const auto& pal32 = core->GetPalette32(Colors[i]);
-			palette[PAL_MAIN]->CopyColorRange(&pal32[0], &pal32[32], dest);			
+			palette[PAL_MAIN]->CopyColorRange(&pal32[0], &pal32[32], dest);
 			dest +=size;
 		}
 
@@ -1501,7 +1501,7 @@ void CharAnimations::GetAnimResRef(unsigned char StanceID,
 			break;
 
 		case IE_ANI_PST_STAND:
-			sprintf(NewResRef,"%cSTD%4s",ResRef[0], ResRef+1);
+			sprintf(NewResRef, "%cSTD%4s", ResRef[0], ResRef+1);
 			Cycle = (ieByte) SixteenToFive[Orient];
 			break;
 		case IE_ANI_PST_GHOST: // pst static animations
@@ -1515,18 +1515,18 @@ void CharAnimations::GetAnimResRef(unsigned char StanceID,
 }
 
 void CharAnimations::GetEquipmentResRef(const char* equipRef, bool offhand,
-	char* ResRef, unsigned char& Cycle, EquipResRefData* equip)
+	char *dest, unsigned char& Cycle, EquipResRefData* equip)
 {
 	switch (GetAnimType()) {
 		case IE_ANI_FOUR_FILES:
 		case IE_ANI_FOUR_FILES_2:
-			GetLREquipmentRef( ResRef, Cycle, equipRef, offhand, equip );
+			GetLREquipmentRef(dest, Cycle, equipRef, offhand, equip);
 			break;
 		case IE_ANI_CODE_MIRROR:
-			GetVHREquipmentRef( ResRef, Cycle, equipRef, offhand, equip );
+			GetVHREquipmentRef(dest, Cycle, equipRef, offhand, equip);
 			break;
 		case IE_ANI_TWENTYTWO:
-			GetMHREquipmentRef( ResRef, Cycle, equipRef, offhand, equip );
+			GetMHREquipmentRef(dest, Cycle, equipRef, offhand, equip);
 			break;
 		default:
 			error("CharAnimations", "Unsupported animation type for equipment animation.\n");
@@ -1550,7 +1550,7 @@ const int* CharAnimations::GetZOrder(unsigned char Orient)
 }
 
 
-void CharAnimations::AddPSTSuffix(char* ResRef, unsigned char StanceID,
+void CharAnimations::AddPSTSuffix(char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient)
 {
 	const char *Prefix;
@@ -1590,14 +1590,14 @@ void CharAnimations::AddPSTSuffix(char* ResRef, unsigned char StanceID,
 			Cycle=SixteenToFive[Orient];
 			if (RAND(0,1)) {
 				Prefix="sf2";
-				sprintf(ResRef,"%c%3s%4s",this->ResRef[0], Prefix, this->ResRef+1);
-				if (gamedata->Exists(ResRef, IE_BAM_CLASS_ID) ) {
+				sprintf(dest,"%c%3s%4s", ResRef[0], Prefix, ResRef+1);
+				if (gamedata->Exists(dest, IE_BAM_CLASS_ID) ) {
 					return;
 				}
 			}
 			Prefix="sf1";
-			sprintf(ResRef,"%c%3s%4s",this->ResRef[0], Prefix, this->ResRef+1);
-			if (gamedata->Exists(ResRef, IE_BAM_CLASS_ID) ) {
+			sprintf(dest,"%c%3s%4s", ResRef[0], Prefix, ResRef+1);
+			if (gamedata->Exists(dest, IE_BAM_CLASS_ID) ) {
 				return;
 			}
 			Prefix = "stc";
@@ -1609,10 +1609,10 @@ void CharAnimations::AddPSTSuffix(char* ResRef, unsigned char StanceID,
 			Cycle=SixteenToFive[Orient];
 			Prefix="stc"; break;
 	}
-	sprintf(ResRef,"%c%3s%4s",this->ResRef[0], Prefix, this->ResRef+1);
+	sprintf(dest,"%c%3s%4s", ResRef[0], Prefix, ResRef+1);
 }
 
-void CharAnimations::AddVHR2Suffix(char* ResRef, unsigned char StanceID,
+void CharAnimations::AddVHR2Suffix(char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient)
 {
 	Cycle=SixteenToNine[Orient];
@@ -1620,43 +1620,43 @@ void CharAnimations::AddVHR2Suffix(char* ResRef, unsigned char StanceID,
 	switch (StanceID) {
 		case IE_ANI_ATTACK: //temporarily
 		case IE_ANI_ATTACK_BACKSLASH:
-			strcat( ResRef, "g21" );
+			strcat(dest, "g21");
 			Cycle+=9;
 			break;
 
 		case IE_ANI_ATTACK_SLASH:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			break;
 
 		case IE_ANI_ATTACK_JAB:
-			strcat( ResRef, "g22" );
+			strcat(dest, "g22");
 			Cycle+=18;
 			break;
 
 		case IE_ANI_CAST: //looping
-			strcat( ResRef, "g25" );
+			strcat(dest, "g25");
 			Cycle+=45;
 			break;
 
 		case IE_ANI_CONJURE://ending
-			strcat( ResRef, "g26" );
+			strcat(dest, "g26");
 			Cycle+=54;
 			break;
 
 		case IE_ANI_SHOOT:
-			strcat( ResRef, "g24" );
+			strcat(dest, "g24");
 			Cycle+=27;
 			break;
 
 		case IE_ANI_HEAD_TURN:
 		case IE_ANI_AWAKE:
-			strcat( ResRef, "g12" );
+			strcat(dest, "g12");
 			Cycle+=18;
 			break;
 
 		case IE_ANI_SLEEP:
 		case IE_ANI_TWITCH:
-			strcat( ResRef, "g15" );
+			strcat(dest, "g15");
 			Cycle+=45;
 			break;
 
@@ -1664,33 +1664,33 @@ void CharAnimations::AddVHR2Suffix(char* ResRef, unsigned char StanceID,
 		case IE_ANI_EMERGE:
 		case IE_ANI_GET_UP:
 		case IE_ANI_PST_START:
-			strcat( ResRef, "g14" );
+			strcat(dest, "g14");
 			Cycle+=36;
 			break;
 
 		case IE_ANI_DAMAGE:
-			strcat( ResRef, "g13" );
+			strcat(dest, "g13");
 			Cycle+=27;
 			break;
 
 		case IE_ANI_READY:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			Cycle+=9;
 			break;
 
 		case IE_ANI_WALK:
-			strcat( ResRef, "g11" );
+			strcat(dest, "g11");
 			break;
 
 		case IE_ANI_HIDE:
-			strcat( ResRef, "g22" );
+			strcat(dest, "g22");
 			break;
 		default:
-			error("CharAnimation", "VHR2 Animation: unhandled stance: %s %d\n", ResRef, StanceID);
+			error("CharAnimation", "VHR2 Animation: unhandled stance: %s %d\n", dest, StanceID);
 	}
 }
 
-void CharAnimations::AddVHR3Suffix(char* ResRef, unsigned char StanceID,
+void CharAnimations::AddVHR3Suffix(char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient)
 {
 	Cycle=SixteenToNine[Orient];
@@ -1698,40 +1698,40 @@ void CharAnimations::AddVHR3Suffix(char* ResRef, unsigned char StanceID,
 	switch (StanceID) {
 		case IE_ANI_ATTACK: //temporarily
 		case IE_ANI_ATTACK_BACKSLASH:
-			strcat( ResRef, "g21" );
+			strcat(dest, "g21");
 			Cycle+=9;
 			break;
 
 		case IE_ANI_ATTACK_SLASH:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			break;
 
 		case IE_ANI_ATTACK_JAB:
 		case IE_ANI_CONJURE://ending
-			strcat( ResRef, "g22" );
+			strcat(dest, "g22");
 			Cycle+=18;
 			break;
 
 		case IE_ANI_CAST: //looping
-			strcat( ResRef, "g22" );
+			strcat(dest, "g22");
 			Cycle+=27;
 			break;
 
 		case IE_ANI_SHOOT:
-			strcat( ResRef, "g23" );
+			strcat(dest, "g23");
 			Cycle+=27;
 			break;
 
 		case IE_ANI_HEAD_TURN:
 		case IE_ANI_AWAKE:
 		case IE_ANI_HIDE:
-			strcat( ResRef, "g12" );
+			strcat(dest, "g12");
 			Cycle+=18;
 			break;
 
 		case IE_ANI_SLEEP:
 		case IE_ANI_TWITCH:
-			strcat( ResRef, "g15" );
+			strcat(dest, "g15");
 			Cycle+=45;
 			break;
 
@@ -1739,68 +1739,68 @@ void CharAnimations::AddVHR3Suffix(char* ResRef, unsigned char StanceID,
 		case IE_ANI_EMERGE:
 		case IE_ANI_GET_UP:
 		case IE_ANI_PST_START:
-			strcat( ResRef, "g14" );
+			strcat(dest, "g14");
 			Cycle+=36;
 			break;
 
 		case IE_ANI_DAMAGE:
-			strcat( ResRef, "g13" );
+			strcat(dest, "g13");
 			Cycle+=27;
 			break;
 
 		case IE_ANI_READY:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			Cycle+=9;
 			break;
 
 		case IE_ANI_WALK:
-			strcat( ResRef, "g11" );
+			strcat(dest, "g11");
 			break;
 		default:
-			error("CharAnimation", "VHR3 Animation: unhandled stance: %s %d\n", ResRef, StanceID);
+			error("CharAnimation", "VHR3 Animation: unhandled stance: %s %d\n", dest, StanceID);
 	}
 }
 
 // Note: almost like SixSuffix
-void CharAnimations::AddFFSuffix(char* ResRef, unsigned char StanceID,
+void CharAnimations::AddFFSuffix(char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient, int Part)
 {
 	Cycle=SixteenToNine[Orient];
 	switch (StanceID) {
 		case IE_ANI_WALK:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			break;
 
 		case IE_ANI_ATTACK:
 		case IE_ANI_ATTACK_SLASH:
-			strcat( ResRef, "g3" );
+			strcat(dest, "g3");
 			break;
 
 		case IE_ANI_ATTACK_BACKSLASH:
-			strcat( ResRef, "g3" );
+			strcat(dest, "g3");
 			Cycle += 16;
 			break;
 
 		case IE_ANI_ATTACK_JAB:
 		case IE_ANI_CAST:
 		case IE_ANI_CONJURE:
-			strcat( ResRef, "g3" );
+			strcat(dest, "g3");
 			Cycle += 32;
 			break;
 
 		case IE_ANI_HEAD_TURN: //could be wrong
 		case IE_ANI_HIDE: //could be wrong
 		case IE_ANI_AWAKE:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			break;
 
 		case IE_ANI_READY:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			Cycle += 16;
 			break;
 
 		case IE_ANI_DAMAGE:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			Cycle += 32;
 			break;
 
@@ -1808,97 +1808,97 @@ void CharAnimations::AddFFSuffix(char* ResRef, unsigned char StanceID,
 		case IE_ANI_GET_UP:
 		case IE_ANI_EMERGE:
 		case IE_ANI_PST_START:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			Cycle += 48;
 			break;
 
 		case IE_ANI_SLEEP:
 		case IE_ANI_TWITCH:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			Cycle += 64;
 			break;
 
 		default:
-			error("CharAnimation", "Four frames Animation: unhandled stance: %s %d\n", ResRef, StanceID);
+			error("CharAnimation", "Four frames Animation: unhandled stance: %s %d\n", dest, StanceID);
 
 	}
-	size_t last = strnlen(ResRef, 6);
-	ResRef[last] = (char) (Part+'1');
-	ResRef[last+1] = 0;
+	size_t last = strnlen(dest, 6);
+	dest[last] = (char) (Part+'1');
+	dest[last+1] = 0;
 }
 
-void CharAnimations::AddFF2Suffix(char* ResRef, unsigned char StanceID,
+void CharAnimations::AddFF2Suffix(char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient, int Part) const
 {
 	Cycle = SixteenToNine[Orient];
 	switch (StanceID) {
 		case IE_ANI_HEAD_TURN:
-			strcat( ResRef, "g101" );
+			strcat(dest, "g101");
 			break;
 
 		case IE_ANI_READY:
 		case IE_ANI_AWAKE:
-			strcat( ResRef, "g102" );
+			strcat(dest, "g102");
 			Cycle += 9;
 			break;
 
 		case IE_ANI_WALK:
-			strcat( ResRef, "g101" );
+			strcat(dest, "g101");
 			break;
 
 		case IE_ANI_CAST:
 		case IE_ANI_CONJURE:
-			strcat( ResRef, "g205" );
+			strcat(dest, "g205");
 			Cycle += 45;
 			break;
 
 		case IE_ANI_ATTACK:
 		case IE_ANI_ATTACK_SLASH:
-			strcat( ResRef, "g206" );
+			strcat(dest, "g206");
 			Cycle += 54;
 			break;
 
 		case IE_ANI_ATTACK_BACKSLASH:
-			strcat( ResRef, "g202" );
+			strcat(dest, "g202");
 			break;
 
 		case IE_ANI_ATTACK_JAB:
-			strcat( ResRef, "g203" );
+			strcat(dest, "g203");
 			Cycle += 18;
 			break;
 
 		case IE_ANI_DIE:
 		case IE_ANI_GET_UP:
 		case IE_ANI_EMERGE:
-			strcat( ResRef, "g104" );
+			strcat(dest, "g104");
 			Cycle += 36;
 			break;
 
 		case IE_ANI_SLEEP:
 		case IE_ANI_TWITCH:
 		case IE_ANI_DAMAGE:
-			strcat( ResRef, "g103" );
+			strcat(dest, "g103");
 			Cycle += 27;
 			break;
 
 		default:
-			error("CharAnimation", "Four frames 2 Animation: unhandled stance: %s %d\n", ResRef, StanceID);
+			error("CharAnimation", "Four frames 2 Animation: unhandled stance: %s %d\n", dest, StanceID);
 
 	}
-	size_t last = strnlen(ResRef, 6);
-	ResRef[last] = (char) (Part+'1');
-	ResRef[last+1] = 0;
+	size_t last = strnlen(dest, 6);
+	dest[last] = (char) (Part+'1');
+	dest[last+1] = 0;
 }
 
-void CharAnimations::AddNFSuffix(char* ResRef, unsigned char StanceID,
+void CharAnimations::AddNFSuffix(char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient, int Part)
 {
 	char prefix[10];
 
 	Cycle = SixteenToNine[Orient];
-	snprintf(prefix, 9, "%s%c%d%c%d", ResRef, StancePrefix[StanceID], (Part+1)%100,
+	snprintf(prefix, 9, "%s%c%d%c%d", dest, StancePrefix[StanceID], (Part+1)%100,
 			 CyclePrefix[StanceID], Cycle);
-	strnlwrcpy(ResRef,prefix,8);
+	strnlwrcpy(dest,prefix,8);
 	Cycle=(ieByte) (Cycle+CycleOffset[StanceID]);
 }
 
@@ -1913,7 +1913,7 @@ static const char *JabPrefix[]={"a5","a6","a9"};
 static const char *RangedPrefix[]={"sa","sx","ss"};
 static const char *RangedPrefixOld[]={"sa","sx","a1"};
 
-void CharAnimations::AddVHRSuffix(char* ResRef, unsigned char StanceID,
+void CharAnimations::AddVHRSuffix(char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient, EquipResRefData*& EquipData)
 {
 	Cycle = SixteenToNine[Orient];
@@ -1922,45 +1922,45 @@ void CharAnimations::AddVHRSuffix(char* ResRef, unsigned char StanceID,
 	switch (StanceID) {
 		case IE_ANI_ATTACK:
 		case IE_ANI_ATTACK_SLASH:
-			strcat( ResRef, SlashPrefix[WeaponType] );
+			strcat(dest, SlashPrefix[WeaponType]);
 			strlcpy(EquipData->Suffix, SlashPrefix[WeaponType], sizeof(EquipData->Suffix));
 			break;
 
 		case IE_ANI_ATTACK_BACKSLASH:
-			strcat( ResRef, BackPrefix[WeaponType] );
+			strcat(dest, BackPrefix[WeaponType]);
 			strlcpy(EquipData->Suffix, BackPrefix[WeaponType], sizeof(EquipData->Suffix));
 			break;
 
 		case IE_ANI_ATTACK_JAB:
-			strcat( ResRef, JabPrefix[WeaponType] );
+			strcat(dest, JabPrefix[WeaponType]);
 			strlcpy(EquipData->Suffix, JabPrefix[WeaponType], sizeof(EquipData->Suffix));
 			break;
 
 		case IE_ANI_AWAKE:
-			strcat( ResRef, "g17" );
+			strcat(dest, "g17");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle += 63;
 			break;
 
 		case IE_ANI_CAST: //looping
-			strcat( ResRef, "ca" );
+			strcat(dest, "ca");
 			strcpy( EquipData->Suffix, "ca" );
 			break;
 
 		case IE_ANI_CONJURE: //ending
-			strcat( ResRef, "ca" );
+			strcat(dest, "ca");
 			strcpy( EquipData->Suffix, "ca" );
 			Cycle += 9;
 			break;
 
 		case IE_ANI_DAMAGE:
-			strcat( ResRef, "g14" );
+			strcat(dest, "g14");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle += 36;
 			break;
 
 		case IE_ANI_DIE:
-			strcat( ResRef, "g15" );
+			strcat(dest, "g15");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle += 45;
 			break;
@@ -1969,17 +1969,17 @@ void CharAnimations::AddVHRSuffix(char* ResRef, unsigned char StanceID,
 		case IE_ANI_GET_UP:
 		case IE_ANI_EMERGE:
 		case IE_ANI_PST_START:
-			strcat( ResRef, "g19" );
+			strcat(dest, "g19");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle += 81;
 			break;
 
 		case IE_ANI_HEAD_TURN:
 			if (RAND(0,1)) {
-				strcat( ResRef, "g12" );
+				strcat(dest, "g12");
 				Cycle += 18;
 			} else {
-				strcat( ResRef, "g18" );
+				strcat(dest, "g18");
 				Cycle += 72;
 			}
 			strcpy( EquipData->Suffix, "g1" );
@@ -1991,77 +1991,77 @@ void CharAnimations::AddVHRSuffix(char* ResRef, unsigned char StanceID,
 
 		case IE_ANI_READY:
 			if ( WeaponType == IE_ANI_WEAPON_2H ) {
-				strcat( ResRef, "g13" );
+				strcat(dest, "g13");
 				Cycle += 27;
 			} else {
-				strcat( ResRef, "g1" );
+				strcat(dest, "g1");
 				Cycle += 9;
 			}
 			strcpy( EquipData->Suffix, "g1" );
 			break;
 			//This depends on the ranged weapon equipped
 		case IE_ANI_SHOOT:
-			strcat( ResRef, RangedPrefix[RangedType] );
+			strcat(dest, RangedPrefix[RangedType]);
 			strlcpy(EquipData->Suffix, RangedPrefix[RangedType], sizeof(EquipData->Suffix));
 			break;
 
 		case IE_ANI_SLEEP:
-			strcat( ResRef, "g16" );
+			strcat(dest, "g16");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle += 54;
 			break;
 
 		case IE_ANI_TWITCH:
-			strcat( ResRef, "g16" );
+			strcat(dest, "g16");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle += 54;
 			break;
 
 		case IE_ANI_WALK:
-			strcat( ResRef, "g11" );
+			strcat(dest, "g11");
 			strcpy( EquipData->Suffix, "g1" );
 			break;
 
 		default:
-			error("CharAnimation", "VHR Animation: unhandled stance: %s %d\n", ResRef, StanceID);
+			error("CharAnimation", "VHR Animation: unhandled stance: %s %d\n", dest, StanceID);
 	}
 	EquipData->Cycle = Cycle;
 }
 
-void CharAnimations::GetVHREquipmentRef(char* ResRef, unsigned char& Cycle,
+void CharAnimations::GetVHREquipmentRef(char *dest, unsigned char& Cycle,
 			const char* equipRef, bool offhand,
 			EquipResRefData* equip)
 {
 	Cycle = equip->Cycle;
 	if (offhand) {
-		sprintf( ResRef, "wq%c%c%co%s", GetSize(), equipRef[0], equipRef[1], equip->Suffix );
+		sprintf(dest, "wq%c%c%co%s", GetSize(), equipRef[0], equipRef[1], equip->Suffix);
 	} else {
-		sprintf( ResRef, "wq%c%c%c%s", GetSize(), equipRef[0], equipRef[1], equip->Suffix );
+		sprintf(dest, "wq%c%c%c%s", GetSize(), equipRef[0], equipRef[1], equip->Suffix);
 	}
 }
 
-void CharAnimations::AddSixSuffix(char* ResRef, unsigned char StanceID,
+void CharAnimations::AddSixSuffix(char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient)
 {
 	switch (StanceID) {
 		case IE_ANI_WALK:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			Cycle = Orient;
 			break;
 
 		case IE_ANI_ATTACK:
 		case IE_ANI_ATTACK_SLASH:
-			strcat( ResRef, "g3" );
+			strcat(dest, "g3");
 			Cycle = Orient;
 			break;
 
 		case IE_ANI_ATTACK_BACKSLASH:
-			strcat( ResRef, "g3" );
+			strcat(dest, "g3");
 			Cycle = 16 + Orient;
 			break;
 
 		case IE_ANI_ATTACK_JAB:
-			strcat( ResRef, "g3" );
+			strcat(dest, "g3");
 			Cycle = 32 + Orient;
 			break;
 
@@ -2069,18 +2069,18 @@ void CharAnimations::AddSixSuffix(char* ResRef, unsigned char StanceID,
 		case IE_ANI_AWAKE:
 		case IE_ANI_CAST: //could be wrong
 		case IE_ANI_CONJURE:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			Cycle = 0 + Orient;
 			break;
 
 		case IE_ANI_READY:
 		case IE_ANI_HIDE: //could be wrong
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			Cycle = 16 + Orient;
 			break;
 
 		case IE_ANI_DAMAGE:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			Cycle = 32 + Orient;
 			break;
 
@@ -2088,26 +2088,26 @@ void CharAnimations::AddSixSuffix(char* ResRef, unsigned char StanceID,
 		case IE_ANI_GET_UP:
 		case IE_ANI_EMERGE:
 		case IE_ANI_PST_START:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			Cycle = 48 + Orient;
 			break;
 
 		case IE_ANI_TWITCH:
 		case IE_ANI_SLEEP:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			Cycle = 64 + Orient;
 			break;
 
 		default:
-			error("CharAnimation", "Six Animation: unhandled stance: %s %d\n", ResRef, StanceID);
+			error("CharAnimation", "Six Animation: unhandled stance: %s %d\n", dest, StanceID);
 
 	}
 	if (Orient>9) {
-		strcat( ResRef, "e" );
+		strcat(dest, "e");
 	}
 }
 
-void CharAnimations::AddLR2Suffix(char* ResRef, unsigned char StanceID,
+void CharAnimations::AddLR2Suffix(char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient)
 {
 	Orient /= 2;
@@ -2147,16 +2147,16 @@ void CharAnimations::AddLR2Suffix(char* ResRef, unsigned char StanceID,
 			Cycle = 32 + Orient;
 			break;
 		default:
-			error("CharAnimation", "LR2 Animation: unhandled stance: %s %d\n", ResRef, StanceID);
+			error("CharAnimation", "LR2 Animation: unhandled stance: %s %d\n", dest, StanceID);
 	}
 	if (Orient>=4) {
-		strcat( ResRef, "g1e" );
+		strcat(dest, "g1e");
 	} else {
-		strcat( ResRef, "g1" );
+		strcat(dest, "g1");
 	}
 }
 
-void CharAnimations::AddMHRSuffix(char* ResRef, unsigned char StanceID,
+void CharAnimations::AddMHRSuffix(char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient, EquipResRefData*& EquipData)
 {
 	Orient /= 2;
@@ -2166,25 +2166,25 @@ void CharAnimations::AddMHRSuffix(char* ResRef, unsigned char StanceID,
 	switch (StanceID) {
 		case IE_ANI_ATTACK:
 		case IE_ANI_ATTACK_SLASH:
-			strcat (ResRef, SlashPrefix[WeaponType]);
+			strcat (dest, SlashPrefix[WeaponType]);
 			strlcpy(EquipData->Suffix, SlashPrefix[WeaponType], sizeof(EquipData->Suffix));
 			Cycle = Orient;
 			break;
 
 		case IE_ANI_ATTACK_BACKSLASH:
-			strcat (ResRef, BackPrefix[WeaponType]);
+			strcat (dest, BackPrefix[WeaponType]);
 			strlcpy(EquipData->Suffix, BackPrefix[WeaponType], sizeof(EquipData->Suffix));
 			Cycle = Orient;
 			break;
 
 		case IE_ANI_ATTACK_JAB:
-			strcat (ResRef, JabPrefix[WeaponType]);
+			strcat (dest, JabPrefix[WeaponType]);
 			strlcpy(EquipData->Suffix, JabPrefix[WeaponType], sizeof(EquipData->Suffix));
 			Cycle = Orient;
 			break;
 
 		case IE_ANI_READY:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			if ( WeaponType == IE_ANI_WEAPON_2W ) {
 				Cycle = 24 + Orient;
@@ -2194,19 +2194,19 @@ void CharAnimations::AddMHRSuffix(char* ResRef, unsigned char StanceID,
 			break;
 
 		case IE_ANI_CAST://looping
-			strcat( ResRef, "ca" );
+			strcat(dest, "ca");
 			strcpy( EquipData->Suffix, "ca" );
 			Cycle = 8 + Orient;
 			break;
 
 		case IE_ANI_CONJURE://ending
-			strcat( ResRef, "ca" );
+			strcat(dest, "ca");
 			strcpy( EquipData->Suffix, "ca" );
 			Cycle = Orient;
 			break;
 
 		case IE_ANI_DAMAGE:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 40 + Orient;
 			break;
@@ -2214,7 +2214,7 @@ void CharAnimations::AddMHRSuffix(char* ResRef, unsigned char StanceID,
 		case IE_ANI_DIE:
 		case IE_ANI_GET_UP:
 		case IE_ANI_PST_START:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 48 + Orient;
 			break;
@@ -2222,13 +2222,13 @@ void CharAnimations::AddMHRSuffix(char* ResRef, unsigned char StanceID,
 			//I cannot find an emerge animation...
 			//Maybe is Die reversed
 		case IE_ANI_EMERGE:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 48 + Orient;
 			break;
 
 		case IE_ANI_HEAD_TURN:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 32 + Orient;
 			break;
@@ -2238,59 +2238,59 @@ void CharAnimations::AddMHRSuffix(char* ResRef, unsigned char StanceID,
 			break;
 
 		case IE_ANI_AWAKE:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 16 + Orient;
 			break;
 
 			//This depends on the ranged weapon equipped
 		case IE_ANI_SHOOT:
-			strcat (ResRef, RangedPrefixOld[RangedType]);
+			strcat (dest, RangedPrefixOld[RangedType]);
 			strlcpy(EquipData->Suffix, RangedPrefixOld[RangedType], sizeof(EquipData->Suffix));
 			Cycle = Orient;
 			break;
 
 		case IE_ANI_SLEEP:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 64 + Orient;
 			break;
 
 		case IE_ANI_TWITCH:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 56 + Orient;
 			break;
 
 		case IE_ANI_WALK:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = Orient;
 			break;
 		default:
-			error("CharAnimation", "MHR Animation: unhandled stance: %s %d\n", ResRef, StanceID);
+			error("CharAnimation", "MHR Animation: unhandled stance: %s %d\n", dest, StanceID);
 	}
 	if (Orient>=5) {
-		strcat( ResRef, "e" );
+		strcat(dest, "e");
 		strcat( EquipData->Suffix, "e" );
 	}
 	EquipData->Cycle = Cycle;
 }
 
-void CharAnimations::GetMHREquipmentRef(char* ResRef, unsigned char& Cycle,
+void CharAnimations::GetMHREquipmentRef(char *dest, unsigned char& Cycle,
 			const char* equipRef, bool offhand,
 			EquipResRefData* equip)
 {
 	Cycle = equip->Cycle;
 	if (offhand) {
 		//i think there is no offhand stuff for bg1, lets use the bg2 equivalent here?
-		sprintf( ResRef, "wq%c%c%co%s", GetSize(), equipRef[0], equipRef[1], equip->Suffix );
+		sprintf(dest, "wq%c%c%co%s", GetSize(), equipRef[0], equipRef[1], equip->Suffix);
 	} else {
-		sprintf( ResRef, "wp%c%c%c%s", GetSize(), equipRef[0], equipRef[1], equip->Suffix );
+		sprintf(dest, "wp%c%c%c%s", GetSize(), equipRef[0], equipRef[1], equip->Suffix);
 	}
 }
 
-void CharAnimations::AddTwoFileSuffix( char* ResRef, unsigned char StanceID,
+void CharAnimations::AddTwoFileSuffix( char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient)
 {
 	switch(StanceID) {
@@ -2317,13 +2317,13 @@ void CharAnimations::AddTwoFileSuffix( char* ResRef, unsigned char StanceID,
 			Cycle = 8 + Orient / 2;
 			break;
 	}
-	strcat( ResRef, "g1" );
+	strcat(dest, "g1");
 	if (Orient > 9) {
-		strcat( ResRef, "e" );
+		strcat(dest, "e");
 	}
 }
 
-void CharAnimations::AddTwoFiles5Suffix( char* ResRef, unsigned char StanceID,
+void CharAnimations::AddTwoFiles5Suffix( char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient)
 {
 	const char *suffix;
@@ -2395,10 +2395,10 @@ void CharAnimations::AddTwoFiles5Suffix( char* ResRef, unsigned char StanceID,
 			Cycle += 18;
 			suffix = "g1";
 	}
-	strcat( ResRef, suffix );
+	strcat(dest, suffix);
 }
 
-void CharAnimations::AddLRSuffix2( char* ResRef, unsigned char StanceID,
+void CharAnimations::AddLRSuffix2( char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient, EquipResRefData *&EquipData)
 {
 	EquipData = new EquipResRefData;
@@ -2408,35 +2408,35 @@ void CharAnimations::AddLRSuffix2( char* ResRef, unsigned char StanceID,
 		case IE_ANI_ATTACK_BACKSLASH:
 		case IE_ANI_ATTACK_SLASH:
 		case IE_ANI_ATTACK_JAB:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			strcpy( EquipData->Suffix, "g2" );
 			Cycle = Orient / 2;
 			break;
 		case IE_ANI_CAST:
 		case IE_ANI_CONJURE:
 		case IE_ANI_SHOOT:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			strcpy( EquipData->Suffix, "g2" );
 			Cycle = 8 + Orient / 2;
 			break;
 		case IE_ANI_WALK:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = Orient / 2;
 			break;
 		case IE_ANI_READY:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 8 + Orient / 2;
 			break;
 		case IE_ANI_HEAD_TURN: //could be wrong
 		case IE_ANI_AWAKE:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 16 + Orient / 2;
 			break;
 		case IE_ANI_DAMAGE:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 24 + Orient / 2;
 			break;
@@ -2444,67 +2444,67 @@ void CharAnimations::AddLRSuffix2( char* ResRef, unsigned char StanceID,
 		case IE_ANI_EMERGE:
 		case IE_ANI_PST_START:
 		case IE_ANI_DIE:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 32 + Orient / 2;
 			break;
 		case IE_ANI_SLEEP:
 		case IE_ANI_HIDE:
 		case IE_ANI_TWITCH:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 40 + Orient / 2;
 			break;
 		default:
-			error("CharAnimation", "LRSuffix2 Animation: unhandled stance: %s %d\n", ResRef, StanceID);
+			error("CharAnimation", "LRSuffix2 Animation: unhandled stance: %s %d\n", dest, StanceID);
 	}
 	if (Orient > 9) {
-		strcat( ResRef, "e" );
+		strcat(dest, "e");
 		strcat( EquipData->Suffix, "e");
 	}
 	EquipData->Cycle = Cycle;
 }
 
-void CharAnimations::AddTwoPieceSuffix(char* ResRef, unsigned char StanceID,
+void CharAnimations::AddTwoPieceSuffix(char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient, int Part)
 {
 	if (Part == 1) {
-		strcat( ResRef, "d" );
+		strcat(dest, "d");
 	}
 
 	switch (StanceID) {
 		case IE_ANI_DIE:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			Cycle = 8 + Orient / 2;
 			break;
 		case IE_ANI_TWITCH:
 		case IE_ANI_SLEEP:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			Cycle = 16 + Orient / 2;
 			break;
 		case IE_ANI_READY:
 		case IE_ANI_HEAD_TURN:
 		case IE_ANI_AWAKE:
 		case IE_ANI_DAMAGE:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			Cycle = 24 + Orient / 2;
 			break;
 		case IE_ANI_WALK:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			Cycle = Orient / 2;
 			break;
 		case IE_ANI_GET_UP:
 		case IE_ANI_EMERGE:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			Cycle = 8 + Orient / 2;
 			break;
 		case IE_ANI_HIDE:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			Cycle = 16 + Orient / 2;
 			break;
 		case IE_ANI_ATTACK:
 		case IE_ANI_ATTACK_BACKSLASH:
-			strcat( ResRef, "g3" );
+			strcat(dest, "g3");
 			Cycle = Orient / 2;
 			break;
 		case IE_ANI_ATTACK_SLASH:
@@ -2512,18 +2512,18 @@ void CharAnimations::AddTwoPieceSuffix(char* ResRef, unsigned char StanceID,
 		case IE_ANI_CAST:
 		case IE_ANI_CONJURE:
 		case IE_ANI_SHOOT:
-			strcat( ResRef, "g3" );
+			strcat(dest, "g3");
 			Cycle = 8 + Orient / 2;
 			break;
 		default:
-			error("CharAnimation", "Two-piece Animation: unhandled stance: %s %d", ResRef, StanceID);
+			error("CharAnimation", "Two-piece Animation: unhandled stance: %s %d", dest, StanceID);
 	}
 	if (Orient > 9) {
-		strcat( ResRef, "e" );
+		strcat(dest, "e");
 	}
 }
 
-void CharAnimations::AddLRSuffix( char* ResRef, unsigned char StanceID,
+void CharAnimations::AddLRSuffix( char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient, EquipResRefData *&EquipData)
 {
 	EquipData = new EquipResRefData;
@@ -2531,42 +2531,42 @@ void CharAnimations::AddLRSuffix( char* ResRef, unsigned char StanceID,
 	switch (StanceID) {
 		case IE_ANI_ATTACK:
 		case IE_ANI_ATTACK_BACKSLASH:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			strcpy( EquipData->Suffix, "g2" );
 			Cycle = Orient / 2;
 			break;
 		case IE_ANI_ATTACK_SLASH:
 		case IE_ANI_CAST:
 		case IE_ANI_CONJURE:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			strcpy( EquipData->Suffix, "g2" );
 			Cycle = 8 + Orient / 2;
 			break;
 		case IE_ANI_ATTACK_JAB:
 		case IE_ANI_SHOOT:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			strcpy( EquipData->Suffix, "g2" );
 			Cycle = 16 + Orient / 2;
 			break;
 		case IE_ANI_WALK:
 		case IE_ANI_HIDE: // unknown, just a guess
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = Orient / 2;
 			break;
 		case IE_ANI_READY:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 8 + Orient / 2;
 			break;
 		case IE_ANI_HEAD_TURN: //could be wrong
 		case IE_ANI_AWAKE:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 16 + Orient / 2;
 			break;
 		case IE_ANI_DAMAGE:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 24 + Orient / 2;
 			break;
@@ -2574,75 +2574,75 @@ void CharAnimations::AddLRSuffix( char* ResRef, unsigned char StanceID,
 		case IE_ANI_EMERGE:
 		case IE_ANI_PST_START:
 		case IE_ANI_DIE:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 32 + Orient / 2;
 			break;
 		case IE_ANI_TWITCH:
 		case IE_ANI_SLEEP:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			strcpy( EquipData->Suffix, "g1" );
 			Cycle = 40 + Orient / 2;
 			break;
 		default:
-			error("CharAnimation", "LR Animation: unhandled stance: %s %d\n", ResRef, StanceID);
+			error("CharAnimation", "LR Animation: unhandled stance: %s %d\n", dest, StanceID);
 	}
 	if (Orient > 9) {
-		strcat( ResRef, "e" );
+		strcat(dest, "e");
 		strcat( EquipData->Suffix, "e");
 	}
 	EquipData->Cycle = Cycle;
 }
 
-void CharAnimations::GetLREquipmentRef(char* ResRef, unsigned char& Cycle,
+void CharAnimations::GetLREquipmentRef(char *dest, unsigned char& Cycle,
 			const char* equipRef, bool /*offhand*/,
 			EquipResRefData* equip)
 {
 	Cycle = equip->Cycle;
 	//hackhackhack
-	sprintf( ResRef, "%4s%c%s", this->ResRef, equipRef[0], equip->Suffix );
+	sprintf(dest, "%4s%c%s", ResRef, equipRef[0], equip->Suffix);
 }
 
 //Only for the ogre animation (MOGR)
-void CharAnimations::AddLR3Suffix( char* ResRef, unsigned char StanceID,
+void CharAnimations::AddLR3Suffix( char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient)
 {
 	switch (StanceID) {
 		case IE_ANI_ATTACK:
 		case IE_ANI_ATTACK_BACKSLASH:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			Cycle = Orient / 2;
 			break;
 		case IE_ANI_ATTACK_SLASH:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			Cycle = 8 + Orient / 2;
 			break;
 		case IE_ANI_ATTACK_JAB:
-			strcat( ResRef, "g2" );
+			strcat(dest, "g2");
 			Cycle = 8 + Orient / 2;  //there is no third attack animation
 			break;
 		case IE_ANI_CAST:
 		case IE_ANI_CONJURE:
 		case IE_ANI_SHOOT:
-			strcat( ResRef, "g3" );
+			strcat(dest, "g3");
 			Cycle = Orient / 2;
 			break;
 		case IE_ANI_WALK:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			Cycle = 16 + Orient / 2;
 			break;
 		case IE_ANI_READY:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			Cycle = 8 + Orient / 2;
 			break;
 		case IE_ANI_HEAD_TURN: //could be wrong
 		case IE_ANI_AWAKE:
 		case IE_ANI_HIDE:
-			strcat( ResRef, "g1" );
+			strcat(dest, "g1");
 			Cycle = Orient / 2;
 			break;
 		case IE_ANI_DAMAGE:
-			strcat( ResRef, "g3" );
+			strcat(dest, "g3");
 			Cycle = 8 + Orient / 2;
 			break;
 		case IE_ANI_DIE:
@@ -2650,22 +2650,22 @@ void CharAnimations::AddLR3Suffix( char* ResRef, unsigned char StanceID,
 		case IE_ANI_EMERGE:
 		case IE_ANI_PST_START:
 		case IE_ANI_SLEEP:
-			strcat( ResRef, "g3" );
+			strcat(dest, "g3");
 			Cycle = 16 + Orient / 2;
 			break;
 		case IE_ANI_TWITCH:
-			strcat( ResRef, "g3" );
+			strcat(dest, "g3");
 			Cycle = 24 + Orient / 2;
 			break;
 		default:
-			error("CharAnimation", "LR3 Animation: unhandled stance: %s %d\n", ResRef, StanceID);
+			error("CharAnimation", "LR3 Animation: unhandled stance: %s %d\n", dest, StanceID);
 	}
 	if (Orient > 9) {
-		strcat( ResRef, "e" );
+		strcat(dest, "e");
 	}
 }
 
-void CharAnimations::AddMMR2Suffix(char* ResRef, unsigned char StanceID,
+void CharAnimations::AddMMR2Suffix(char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient)
 {
 	switch (StanceID) {
@@ -2675,40 +2675,40 @@ void CharAnimations::AddMMR2Suffix(char* ResRef, unsigned char StanceID,
 		case IE_ANI_ATTACK_JAB:
 		case IE_ANI_CONJURE:
 		case IE_ANI_CAST:
-			strcat( ResRef, "a1" );
+			strcat(dest, "a1");
 			Cycle = ( Orient / 2 );
 			break;
 
 		case IE_ANI_SHOOT:
-			strcat( ResRef, "a4" );
+			strcat(dest, "a4");
 			Cycle = ( Orient / 2 );
 			break;
 
 		case IE_ANI_AWAKE:
 		case IE_ANI_READY:
-			strcat( ResRef, "sd" );
+			strcat(dest, "sd");
 			Cycle = ( Orient / 2 );
 			break;
 
 		case IE_ANI_HEAD_TURN:
-			strcat( ResRef, "sc" );
+			strcat(dest, "sc");
 			Cycle = ( Orient / 2 );
 			break;
 
 		case IE_ANI_DAMAGE:
-			strcat( ResRef, "gh" );
+			strcat(dest, "gh");
 			Cycle = ( Orient / 2 );
 			break;
 
 		case IE_ANI_DIE:
-			strcat( ResRef, "de" );
+			strcat(dest, "de");
 			Cycle = ( Orient / 2 );
 			break;
 
 		case IE_ANI_GET_UP:
 		case IE_ANI_EMERGE:
 		case IE_ANI_PST_START:
-			strcat( ResRef, "gu" );
+			strcat(dest, "gu");
 			Cycle = ( Orient / 2 );
 			break;
 
@@ -2717,28 +2717,28 @@ void CharAnimations::AddMMR2Suffix(char* ResRef, unsigned char StanceID,
 			break;
 
 		case IE_ANI_SLEEP:
-			strcat( ResRef, "sl" );
+			strcat(dest, "sl");
 			Cycle = ( Orient / 2 );
 			break;
 
 		case IE_ANI_TWITCH:
-			strcat( ResRef, "tw" );
+			strcat(dest, "tw");
 			Cycle = ( Orient / 2 );
 			break;
 
 		case IE_ANI_WALK:
-			strcat( ResRef, "wk" );
+			strcat(dest, "wk");
 			Cycle = ( Orient / 2 );
 			break;
 		default:
-			error("CharAnimation", "MMR Animation: unhandled stance: %s %d\n", ResRef, StanceID);
+			error("CharAnimation", "MMR Animation: unhandled stance: %s %d\n", dest, StanceID);
 	}
 	if (Orient > 9) {
-		strcat( ResRef, "e" );
+		strcat(dest, "e");
 	}
 }
 
-void CharAnimations::AddMMRSuffix(char* ResRef, unsigned char StanceID,
+void CharAnimations::AddMMRSuffix(char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient, bool mirror)
 {
 	if (mirror) {
@@ -2750,46 +2750,46 @@ void CharAnimations::AddMMRSuffix(char* ResRef, unsigned char StanceID,
 		case IE_ANI_ATTACK:
 		case IE_ANI_ATTACK_SLASH:
 		case IE_ANI_ATTACK_BACKSLASH:
-			strcat( ResRef, "a1" );
+			strcat(dest, "a1");
 			break;
 
 		case IE_ANI_SHOOT:
-			strcat( ResRef, "a4" );
+			strcat(dest, "a4");
 			break;
 
 		case IE_ANI_ATTACK_JAB:
-			strcat( ResRef, "a2" );
+			strcat(dest, "a2");
 			break;
 
 		case IE_ANI_AWAKE:
 		case IE_ANI_READY:
-			strcat( ResRef, "sd" );
+			strcat(dest, "sd");
 			break;
 
 		case IE_ANI_CONJURE:
-			strcat( ResRef, "ca" );
+			strcat(dest, "ca");
 			break;
 
 		case IE_ANI_CAST:
-			strcat( ResRef, "sp" );
+			strcat(dest, "sp");
 			break;
 
 		case IE_ANI_HEAD_TURN:
-			strcat( ResRef, "sc" );
+			strcat(dest, "sc");
 			break;
 
 		case IE_ANI_DAMAGE:
-			strcat( ResRef, "gh" );
+			strcat(dest, "gh");
 			break;
 
 		case IE_ANI_DIE:
-			strcat( ResRef, "de" );
+			strcat(dest, "de");
 			break;
 
 		case IE_ANI_GET_UP:
 		case IE_ANI_EMERGE:
 		case IE_ANI_PST_START:
-			strcat( ResRef, "gu" );
+			strcat(dest, "gu");
 			break;
 
 			//Unknown... maybe only a transparency effect apply
@@ -2797,25 +2797,25 @@ void CharAnimations::AddMMRSuffix(char* ResRef, unsigned char StanceID,
 			break;
 
 		case IE_ANI_SLEEP:
-			strcat( ResRef, "sl" );
+			strcat(dest, "sl");
 			break;
 
 		case IE_ANI_TWITCH:
-			strcat( ResRef, "tw" );
+			strcat(dest, "tw");
 			break;
 
 		case IE_ANI_WALK:
-			strcat( ResRef, "wk" );
+			strcat(dest, "wk");
 			break;
 		default:
-			error("CharAnimation", "MMR Animation: unhandled stance: %s %d\n", ResRef, StanceID);
+			error("CharAnimation", "MMR Animation: unhandled stance: %s %d\n", dest, StanceID);
 	}
 	if (!mirror && Orient > 9) {
-		strcat( ResRef, "e" );
+		strcat(dest, "e");
 	}
 }
 
-void CharAnimations::AddHLSuffix(char* ResRef, unsigned char StanceID,
+void CharAnimations::AddHLSuffix(char *dest, unsigned char StanceID,
 	unsigned char& Cycle, unsigned char Orient)
 {
 	//even orientations in 'h', odd in 'l', and since the WALK animation
@@ -2865,11 +2865,11 @@ void CharAnimations::AddHLSuffix(char* ResRef, unsigned char StanceID,
 			break;
 
 		default:
-			error("CharAnimation", "HL Animation: unhandled stance: %s %d", ResRef, StanceID);
+			error("CharAnimation", "HL Animation: unhandled stance: %s %d", dest, StanceID);
 	}
-	strcat(ResRef, offset ? "hg1" : "lg1");
+	strcat(dest, offset ? "hg1" : "lg1");
 	if (Orient > 9) {
-		strcat(ResRef, "e");
+		strcat(dest, "e");
 	}
 }
 

--- a/gemrb/core/CharAnimations.cpp
+++ b/gemrb/core/CharAnimations.cpp
@@ -670,10 +670,7 @@ CharAnimations::CharAnimations(unsigned int AnimID, ieDword ArmourLevel)
 	Colors = NULL;
 	for (size_t i = 0; i < PAL_MAX; ++i) {
 		change[i] = true;
-		modifiedPalette[i] = NULL;
-		palette[i] = NULL;
 	}
-	shadowPalette = NULL;
 	previousStanceID = nextStanceID = 0;
 	StanceID = 0;
 	autoSwitchOnEnd = false;

--- a/gemrb/core/CharAnimations.h
+++ b/gemrb/core/CharAnimations.h
@@ -224,54 +224,54 @@ private:
 	void DropAnims();
 	void InitAvatarsTable();
 	int GetActorPartCount() const;
-	void AddPSTSuffix(char* ResRef, unsigned char AnimID,
+	void AddPSTSuffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient);
-	void AddFFSuffix(char* ResRef, unsigned char AnimID,
+	void AddFFSuffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient, int Part);
-	void AddFF2Suffix(char* ResRef, unsigned char AnimID,
+	void AddFF2Suffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient, int Part) const;
-	void AddHLSuffix(char* ResRef, unsigned char AnimID,
+	void AddHLSuffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient);
-	void AddNFSuffix(char* ResRef, unsigned char AnimID,
+	void AddNFSuffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient, int Part);
-	void AddVHR2Suffix(char* ResRef, unsigned char AnimID,
+	void AddVHR2Suffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient);
-	void AddVHRSuffix(char* ResRef, unsigned char AnimID,
+	void AddVHRSuffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient, EquipResRefData*& equip);
-	void AddVHR3Suffix(char* ResRef, unsigned char AnimID,
+	void AddVHR3Suffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient);
-	void GetVHREquipmentRef(char* ResRef, unsigned char& Cycle,
+	void GetVHREquipmentRef(char *dest, unsigned char& Cycle,
 		const char* equipRef, bool offhand, EquipResRefData* equip);
-	void AddSixSuffix(char* ResRef, unsigned char AnimID,
+	void AddSixSuffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient);
-	void AddTwoPieceSuffix(char* ResRef, unsigned char AnimID,
+	void AddTwoPieceSuffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient, int Part);
-	void AddMHRSuffix(char* ResRef, unsigned char AnimID,
+	void AddMHRSuffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient, EquipResRefData*& equip);
-	void GetMHREquipmentRef(char* ResRef, unsigned char& Cycle,
+	void GetMHREquipmentRef(char *dest, unsigned char& Cycle,
 		const char* equipRef, bool offhand, EquipResRefData* equip);
-	void AddMMRSuffix(char* ResRef, unsigned char AnimID,
+	void AddMMRSuffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient, bool mirror);
-	void AddMMR2Suffix(char* ResRef, unsigned char AnimID,
+	void AddMMR2Suffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient);
-	void AddTwoFileSuffix(char* ResRef, unsigned char AnimID,
+	void AddTwoFileSuffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient);
-	void AddTwoFiles5Suffix(char* ResRef, unsigned char AnimID,
+	void AddTwoFiles5Suffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient);
-	void AddLRSuffix(char* ResRef, unsigned char AnimID,
+	void AddLRSuffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient, EquipResRefData*& equip);
-	void AddLRSuffix2( char* ResRef, unsigned char StanceID,
+	void AddLRSuffix2( char *dest, unsigned char StanceID,
 		unsigned char& Cycle, unsigned char Orient, EquipResRefData *&EquipData);
-	void GetLREquipmentRef(char* ResRef, unsigned char& Cycle,
+	void GetLREquipmentRef(char *dest, unsigned char& Cycle,
 		const char* equipRef, bool offhand, EquipResRefData* equip);
-	void AddLR2Suffix(char* ResRef, unsigned char AnimID,
+	void AddLR2Suffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient);
-	void AddLR3Suffix(char* ResRef, unsigned char AnimID,
+	void AddLR3Suffix(char *dest, unsigned char AnimID,
 		unsigned char& Cycle, unsigned char Orient);
 	void GetAnimResRef(unsigned char AnimID, unsigned char Orient,
-		char* ResRef, unsigned char& Cycle, int Part, EquipResRefData*& equip);
+		char *dest, unsigned char& Cycle, int Part, EquipResRefData*& equip);
 	void GetEquipmentResRef(const char* equipRef, bool offhand,
-		char* ResRef, unsigned char& Cycle, EquipResRefData* equip);
+		char *dest, unsigned char& Cycle, EquipResRefData* equip);
 	unsigned char MaybeOverrideStance(unsigned char stance) const;
 	void MaybeUpdateMainPalette(Animation**);
 };

--- a/gemrb/core/GUI/Button.cpp
+++ b/gemrb/core/GUI/Button.cpp
@@ -48,8 +48,6 @@ Button::Button(Region& frame)
 	HotKeyCallback = METHOD_CALLBACK(&Button::HandleHotKey, this);
 
 	hasText = false;
-	normal_palette = NULL;
-	disabled_palette = NULL;
 	SetFont(core->GetButtonFont());
 	SetFlags(IE_GUI_BUTTON_NORMAL, OP_OR);
 	ToggleState = false;
@@ -64,9 +62,6 @@ Button::~Button()
 {
 	SetImage(BUTTON_IMAGE_NONE, NULL);
 	ClearPictureList();
-
-	gamedata->FreePalette( normal_palette);
-	gamedata->FreePalette( disabled_palette);
 
 	if (hotKey.global) {
 		UnregisterHotKey();
@@ -368,7 +363,6 @@ void Button::EnableBorder(int index, bool enabled)
 void Button::SetFont(Font* newfont)
 {
 	font = newfont;
-	gamedata->FreePalette(disabled_palette);
 	disabled_palette = font->GetPalette()->Copy();
 	disabled_palette->Darken();
 }
@@ -700,10 +694,7 @@ bool Button::HitTest(const Point& p) const
 // Set palette used for drawing button label in normal state
 void Button::SetTextColor(const Color &fore, const Color &back)
 {
-	gamedata->FreePalette( normal_palette );
-	gamedata->FreePalette(disabled_palette);
-
-	normal_palette = new Palette( fore, back );
+	normal_palette = new Palette(fore, back);
 	disabled_palette = new Palette(fore, back);
 	disabled_palette->Darken();
 	MarkDirty();

--- a/gemrb/core/GUI/Label.cpp
+++ b/gemrb/core/GUI/Label.cpp
@@ -35,7 +35,6 @@ Label::Label(const Region& frame, Font* font, const String& string)
 {
 	ControlType = IE_GUI_LABEL;
 	this->font = font;
-	palette = NULL;
 
 	SetAlignment(IE_FONT_ALIGN_CENTER|IE_FONT_ALIGN_MIDDLE);
 	SetFlags(IgnoreEvents, OP_OR);
@@ -44,8 +43,8 @@ Label::Label(const Region& frame, Font* font, const String& string)
 
 Label::~Label()
 {
-	gamedata->FreePalette( palette );
 }
+
 /** Draws the Control on the Output Display */
 void Label::DrawSelf(Region rgn, const Region& /*clip*/)
 {
@@ -74,8 +73,7 @@ void Label::SetText(const String& string)
 /** Sets the Foreground Font Color */
 void Label::SetColor(Color col, Color bac)
 {
-	gamedata->FreePalette( palette );
-	palette = new Palette( col, bac );
+	palette = new Palette(col, bac);
 	MarkDirty();
 }
 

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -144,7 +144,6 @@ Interface::Interface()
 	CurrentStore = NULL;
 	CurrentContainer = NULL;
 	UseContainer = false;
-	InfoTextPalette = NULL;
 	timer = NULL;
 	displaymsg = NULL;
 	slottypes = NULL;
@@ -367,12 +366,6 @@ Interface::~Interface(void)
 	delete timer;
 	delete displaymsg;
 	delete TooltipBG;
-
-	if (video) {
-		if (InfoTextPalette) {
-			gamedata->FreePalette(InfoTextPalette);
-		}
-	}
 
 	delete vars;
 	delete tokens;
@@ -980,8 +973,6 @@ void Interface::Main()
 					   IE_FONT_ALIGN_MIDDLE | IE_FONT_SINGLE_LINE );
 		}
 	} while (video->SwapBuffers() == GEM_OK && !(QuitFlag&QF_KILL));
-
-	gamedata->FreePalette( palette );
 }
 
 int Interface::ReadResRefTable(const ieResRef tablename, ieResRef *&data)
@@ -1184,7 +1175,6 @@ int Interface::LoadFonts()
 		Font* fnt = NULL;
 		ResourceHolder<FontManager> fntMgr = GetResourceHolder<FontManager>(font_name);
 		if (fntMgr) fnt = fntMgr->GetFont(font_size, font_style, pal);
-		gamedata->FreePalette(pal);
 
 		if (!fnt) {
 			error("Core", "Unable to load font resource: %s for ResRef %s (check fonts.2da)", font_name, resref.CString());
@@ -4763,9 +4753,6 @@ void Interface::RegisterOpcodes(int count, const EffectDesc *opcodes)
 
 void Interface::SetInfoTextColor(const Color &color)
 {
-	if (InfoTextPalette) {
-		gamedata->FreePalette(InfoTextPalette);
-	}
 	InfoTextPalette = new Palette(color, ColorBlack);
 }
 

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -3571,7 +3571,6 @@ AreaAnimation::AreaAnimation()
 {
 	animation=NULL;
 	animcount=0;
-	palette=NULL;
 	appearance = sequence = frame = transparency = height = 0;
 	Flags = originalFlags = startFrameRange = skipcycle = startchance = 0;
 	unknown48 = 0;
@@ -3616,7 +3615,6 @@ AreaAnimation::~AreaAnimation()
 		}
 	}
 	free(animation);
-	gamedata->FreePalette(palette, PaletteRef);
 }
 
 Animation *AreaAnimation::GetAnimationPiece(AnimationFactory *af, int animCycle)

--- a/gemrb/core/Projectile.cpp
+++ b/gemrb/core/Projectile.cpp
@@ -97,13 +97,6 @@ Projectile::~Projectile()
 	}
 	delete effects;
 
-	if (TFlags&PTF_COLOUR) {
-		// unnamed palette, but PaletteRes may be set (eg. pshammb.pro of the Hammers mod)
-		gamedata->FreePalette(palette, NULL);
-	} else {
-		gamedata->FreePalette(palette, PaletteRes);
-	}
-
 	ClearPath();
 
 	if (travel_handle) {
@@ -428,8 +421,7 @@ void Projectile::Setup()
 	if (TFlags&PTF_COLOUR) {
 		SetupPalette(travel, palette, Gradients);
 	} else {
-		gamedata->FreePalette(palette, PaletteRes);
-		palette=gamedata->GetPalette(PaletteRes);
+		palette = gamedata->GetPalette(PaletteRes);
 	}
 
 	if (TFlags&PTF_LIGHT) {

--- a/gemrb/core/ScriptedAnimation.cpp
+++ b/gemrb/core/ScriptedAnimation.cpp
@@ -363,8 +363,6 @@ ScriptedAnimation::~ScriptedAnimation(void)
 		delete anim;
 	}
 
-	palette = nullptr;
-
 	if (twin) {
 		delete twin;
 	}
@@ -719,9 +717,7 @@ void ScriptedAnimation::SetBlend()
 {
 	if ((Transparency&IE_VVC_BLENDED) == 0) {
 		Transparency |= IE_VVC_BLENDED;
-		if (palette) {
-			palette = nullptr;
-		}
+		palette = nullptr;
 		GetPaletteCopy();
 		if (twin)
 			twin->SetBlend();

--- a/gemrb/plugins/BAMImporter/BAMImporter.cpp
+++ b/gemrb/plugins/BAMImporter/BAMImporter.cpp
@@ -45,7 +45,6 @@ BAMImporter::BAMImporter(void)
 	str = NULL;
 	frames = NULL;
 	cycles = NULL;
-	palette = NULL;
 	FramesCount = 0;
 	CyclesCount = 0;
 	CompressedColorIndex = DataStart = 0;
@@ -57,7 +56,6 @@ BAMImporter::~BAMImporter(void)
 	delete str;
 	delete[] frames;
 	delete[] cycles;
-	gamedata->FreePalette(palette);
 }
 
 bool BAMImporter::Open(DataStream* stream)
@@ -70,7 +68,9 @@ bool BAMImporter::Open(DataStream* stream)
 	delete str;
 	delete[] frames;
 	delete[] cycles;
-	gamedata->FreePalette(palette);
+	frames = nullptr;
+	cycles = nullptr;
+	palette = nullptr;
 
 	str = stream;
 	char Signature[8];


### PR DESCRIPTION
## Description
As promised in the other PR, here is a followup patch to clean up a bit more after the PaletteHolder changes. These changes are optional, they are not expected to have a user-visible impact.

FreePalette still remains, since the CharAnimations is hard to follow and I wanted to get the simple cases out of the way first. The second patch in this set contains an initial cleanup for CharAnimations to fix name shadowing.