### PR TITLE
Subviews MSVC build issues

### DIFF
--- a/gemrb/core/GameData.h
+++ b/gemrb/core/GameData.h
@@ -136,7 +136,7 @@ private:
 	Cache ItemCache;
 	Cache SpellCache;
 	Cache EffectCache;
-	std::unordered_map<const ResRef, PaletteHolder, ResRef::Hash> PaletteCache;
+	std::unordered_map<ResRef, PaletteHolder, ResRef::Hash> PaletteCache;
 	Factory* factory;
 	std::vector<Table> tables;
 	typedef std::map<const char*, Store*, iless> StoreMap;

--- a/gemrb/includes/win32def.h
+++ b/gemrb/includes/win32def.h
@@ -61,6 +61,9 @@
 #ifndef M_PI_2
 #define M_PI_2  1.57079632679489661923 // pi/2
 #endif
+#ifndef M_PI_4
+#define 	M_PI_4   0.78539816339744830962
+#endif
 
  /* WinAPI collision. GetObject from wingdi.h conflicts with a type used in the GUIScript source (core\ScriptEngine.h) */
 #ifdef GetObject

--- a/gemrb/plugins/WEDImporter/WEDImporter.cpp
+++ b/gemrb/plugins/WEDImporter/WEDImporter.cpp
@@ -28,6 +28,7 @@
 #include "TileSetMgr.h"
 
 #include <cmath>
+#include <iterator>
 
 #if HAVE_UNISTD_H
 #include <unistd.h>


### PR DESCRIPTION
I was just checking to see if I could still build Subviews with visual studio and found some new issues.

1: Apparently, using #define _USE_MATH_DEFINES before cmath is useless under MSVC, people report they can only get it to work if it is set as a command line directive, which is why there have to be M_PI defines in win32def.h

I worked around it by adding it to the core CMakeLists.txt, since it seems that is where the defines are needed, but I don't know if it will cause any issues, I don't really know why it is optional

2: The WEDimporter refused to build because back_inserter was not declared, I found you have to include iterator

3: The window.rc moved, so I cherry picked the commit from master that updates the location of the icon

This gets me as far as  40ce03e , but after that I am lost because I don't understand what is actually happening to be able to investigate the errors I am getting from b8224c3

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
