### PR TITLE
Fix MakeHolder to get the reference count right

### DIFF
--- a/gemrb/core/Holder.h
+++ b/gemrb/core/Holder.h
@@ -137,7 +137,6 @@ template<class T, typename... ARGS>
 inline Holder<T> MakeHolder(ARGS&&... args)
 {
 	Holder<T> holder(new T(std::forward<ARGS>(args)...));
-	holder.release();
 	return holder;
 }
 


### PR DESCRIPTION
It was incorrectly calling release, presumably because the only
instances of MakeHolder are with Palette as a template arg, and
before Palette used Holder, it started with a refcount of 1 instead
of the normal 0 for other Holders.
