### PR TITLE
Correct proficiencies scrollbar

### DIFF
--- a/gemrb/GUIScripts/LUProfsSelection.py
+++ b/gemrb/GUIScripts/LUProfsSelection.py
@@ -255,7 +255,7 @@ def SetupProfsWindow (pc, type, window, callback, level1=[0,0,0], level2=[1,1,1]
 			ProfsColumn = ProfsTable.GetColumnIndex (ClassName)
 
 	#setup some basic counts
-	RowCount = ProfsTable.GetRowCount () - ProfsTableOffset + 1
+	RowCount = ProfsTable.GetRowCount () - ProfsTableOffset
 	ProfCount = RowCount-ProfsNumButtons #decrease it with the number of controls
 
 	ProfsAssignable = 0
@@ -263,7 +263,7 @@ def SetupProfsWindow (pc, type, window, callback, level1=[0,0,0], level2=[1,1,1]
 	for i in range(RowCount):
 		ProfName = ProfsTable.GetValue (i+ProfsTableOffset, 1)
 		#decrease it with the number of invalid proficiencies
-		if ProfName > 0x1000000 or ProfName < 0:
+		if ProfName > 0x1000000 or ProfName <= 0:
 			ProfCount -= 1
 
 		#we only need the low 3 bits for proficiencies on levelup; otherwise


### PR DESCRIPTION
This one seems like an odd issue to remain for so long, but it really looks to me like the +1 is just wrong. Maybe someone wants to double check they are seeing the same problem before merging? Below is the commit message.

When creating a character in BG2, the weapon proficiencies can be scrolled
down beyond the end of the list, with an empty entry at the bottom.

Adding a few Log calls, the first entries of the table are all the
actual proficiencies, ending in Two Weapon Style. Then follow a number of
entries that are recognized as invalid, and ProfCount is reduced for
these.  Finally, there is one entry that is not recognized as invalid,
but calling GetString on it only produces an empty string - and when
scrolling past the end, there is indeed an empty row.

The RowCount calculation has a "+ 1" that just looks incorrect, and
removing it fixes BG2.  BG1 is unaffected either way, it does not
show a scrollbar (and in fact calls into this code with scroll=False).
