### PR TITLE
GUILOAD: Start savegame Topindex at 1 instead of 0

### DIFF
--- a/gemrb/GUIScripts/GUILOAD.py
+++ b/gemrb/GUIScripts/GUILOAD.py
@@ -76,7 +76,7 @@ def OnLoad ():
 	ScrollBar=LoadWindow.GetControl (25)
 	ScrollBar.SetEvent (IE_GUI_SCROLLBAR_ON_CHANGE, ScrollBarUpdated)
 	Games=GemRB.GetSaveGames ()
-	TopIndex = max (0, len(Games) - 4)
+	TopIndex = max (1, len(Games) - 4)
 	ScrollBar.SetVarAssoc ("TopIndex", TopIndex, 0, TopIndex)
 	LoadWindow.SetEventProxy(ScrollBar)
 	LoadWindow.Focus()


### PR DESCRIPTION
This appears to fix the listing of games when there are less than 5 saved

Fixes #1005 

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
