### PR TITLE
[subviews] Improve whitespace handling

### DIFF
--- a/gemrb/core/GUI/TextSystem/Font.cpp
+++ b/gemrb/core/GUI/TextSystem/Font.cpp
@@ -446,7 +446,13 @@ size_t Font::RenderLine(const String& line, const Region& lineRgn,
 			dp.x += curGlyph.size.w;
 		}
 		linePos += i;
+
 		if (done) break;
+
+		// There are some bad strings with two spaces that appear as one in the original.
+		if (linePos < line.length() - 1 && line[linePos] == L' ' && line[linePos+1] == L' ') {
+			linePos += 1;
+		}
 	} while (linePos < line.length());
 	assert(linePos <= line.length());
 	return linePos;
@@ -661,7 +667,8 @@ Size Font::StringSize(const String& string, StringSizeMetrics* metrics) const
 					// always append *everything* if there is \n
 					lineW += spaceW; // everything else appended later
 					newline = true;
-				} else if (ws && string[i] != L'\r') {
+				// Don't take 2nd space into account, we will ignore it.
+				} else if (ws && string[i] != L'\r' && i > 0 && string[i-1] != L' ') {
 					spaceW += curGlyph.size.w;
 				}
 				APPEND_TO_LINE(wordW);


### PR DESCRIPTION
The original has some bad strings with two whitespaces (German PST) that are ignored by its rendering. We need to do this as some texts otherwise hit their containment borders.

about #293

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
