### PR TITLE
Make sure races are loaded in IWD2

### DIFF
--- a/gemrb/GUIScripts/iwd2/Race.py
+++ b/gemrb/GUIScripts/iwd2/Race.py
@@ -21,6 +21,7 @@ import GemRB
 from GUIDefines import *
 import CharOverview
 import CommonTables
+import GUICommon
 
 RaceWindow = 0
 TextAreaControl = 0


### PR DESCRIPTION
Without this, character generation shows an empty list when trying to
select race, and produces this python error:

Traceback (most recent call last):
  File "./GUIScripts/iwd2/Race.py", line 37, in OnLoad
    RaceCount = CommonTables.Races.GetRowCount ()
AttributeError: 'NoneType' object has no attribute 'GetRowCount'
