### PR TITLE
Pst level up subviews

### DIFF
--- a/gemrb/GUIScripts/GUICommon.py
+++ b/gemrb/GUIScripts/GUICommon.py
@@ -558,6 +558,20 @@ def IsMultiClassed (actor, verbose):
 	# return the tuple
 	return (NumClasses, Classes[0], Classes[1], Classes[2])
 
+def NamelessOneClass (actor):
+	# simple check to identify if the actor is TNO
+	# and return his active class (by name)
+
+	if not GameCheck.IsPST():
+		return None
+
+	Specific = GemRB.GetPlayerStat (actor, IE_SPECIFIC)
+	if Specific == 2:
+		Class = GetClassRowName(actor)
+		return Class
+
+	return None
+
 def CanDualClass(actor):
 	# race restriction (human)
 	RaceName = CommonTables.Races.FindValue ("ID", GemRB.GetPlayerStat (actor, IE_RACE, 1))

--- a/gemrb/GUIScripts/LUCommon.py
+++ b/gemrb/GUIScripts/LUCommon.py
@@ -59,6 +59,21 @@ def CanLevelUp(actor):
 		next = GUIREC.GetNextLevelExp(levelsum, GUIREC.GetECL(actor))
 		return next <= xp
 
+	# hardcoded special case to handle TNO, who is usually a single class 
+	# but with three separate Levels/XP values and the ability to switch between them
+	# it returns the active class if true
+	SwitcherClass = GUICommon.NamelessOneClass(actor) 
+	if SwitcherClass:
+		xp = { "FIGHTER" : GemRB.GetPlayerStat (actor, IE_XP), "MAGE" : GemRB.GetPlayerStat (actor, IE_XP_MAGE), "THIEF" : GemRB.GetPlayerStat (actor, IE_XP_THIEF) }
+		lvls = { "FIGHTER" : Levels[0] , "MAGE": Levels[1], "THIEF": Levels [2] }
+
+		tmpNext = GetNextLevelExp (lvls[SwitcherClass], SwitcherClass)
+		if (tmpNext != 0 or lvls[SwitcherClass] == 0) and tmpNext <= xp[SwitcherClass]:
+			return 1
+		#ignore the rest of this function, to avoid false positives
+		#other classes can only be achieved by hacking the game somehow
+		return 0
+
 	if Multi[0] > 1: # multiclassed
 		xp = xp/Multi[0] # divide the xp evenly between the classes
 		for i in range (Multi[0]):

--- a/gemrb/GUIScripts/LUSkillsSelection.py
+++ b/gemrb/GUIScripts/LUSkillsSelection.py
@@ -107,7 +107,7 @@ def SetupSkillsWindow (pc, type, window, callback, level1=[0,0,0], level2=[1,1,1
 		SkillLeftPress = SkillDecreasePress
 		SkillRightPress = SkillIncreasePress
 		#There is actually no hint text to describe the skills, so this is a dummy
-		SkillsWindow.CreateTextArea (45, 1, 1, 1, 1, "FONTDLG", IE_FONT_ALIGN_LEFT)
+		SkillsWindow.CreateTextArea (45, 1, 1, 1, 1, "FONTDLG")
 		SkillsTextArea =  SkillsWindow.GetControl (45)
 	elif type == LUSKILLS_TYPE_LEVELUP:
 		SkillsOffsetPress = -1

--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -805,7 +805,6 @@ def OpenBiographyWindow ():
 
 
 def AcceptLevelUp():
-	LevelUpWindow.Close()
 	#do level up
 	pc = GemRB.GameGetSelectedPCSingle ()
 	GemRB.SetPlayerStat (pc, IE_SAVEVSDEATH, SavThrows[0])
@@ -833,7 +832,7 @@ def AcceptLevelUp():
 	
 	LUSkillsSelection.SkillsSave (pc)
 
-	UpdateRecordsWindow(RecordsWindow)
+	LevelUpWindow.Close()
 	NewLife.OpenLUStatsWindow()
 
 def RedrawSkills():

--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -67,6 +67,7 @@
 import GemRB
 import GUICommon
 import CommonTables
+import LUCommon
 import GUICommonWindows
 import NewLife
 from GUIDefines import *
@@ -148,17 +149,10 @@ def UpdateRecordsWindow (Window):
 
 	# Checking whether character has leveled up.
 	Button = Window.GetControl (9)
-	if avatar_header['SecoLevel'] == 0:
-		if avatar_header['XP'] >= avatar_header['PrimNextLevXP']:
-			Button.SetState (IE_GUI_BUTTON_ENABLED)
-		else:
-			Button.SetState (IE_GUI_BUTTON_DISABLED)
+	if LUCommon.CanLevelUp (pc):
+		Button.SetState (IE_GUI_BUTTON_ENABLED)
 	else:
-		# Character is Multi-Class
-		if avatar_header['XP'] >= avatar_header['PrimNextLevXP'] or avatar_header['XP'] >= avatar_header['SecoNextLevXP']:
-			Button.SetState (IE_GUI_BUTTON_ENABLED)
-		else:
-			Button.SetState (IE_GUI_BUTTON_DISABLED)
+		Button.SetState (IE_GUI_BUTTON_DISABLED)
 
 	# name
 	Label = Window.GetControl (0x1000000a)

--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -805,7 +805,7 @@ def OpenBiographyWindow ():
 
 
 def AcceptLevelUp():
-	OpenLevelUpWindow()
+	LevelUpWindow.Close()
 	#do level up
 	pc = GemRB.GameGetSelectedPCSingle ()
 	GemRB.SetPlayerStat (pc, IE_SAVEVSDEATH, SavThrows[0])
@@ -851,13 +851,6 @@ def OpenLevelUpWindow ():
 	global HPGained
 	global WeapProfType, CurrWeapProf, WeapProfGained
 	global NumOfPrimLevUp, NumOfSecoLevUp
-
-	if LevelUpWindow != None:
-		if LevelUpWindow:
-			LevelUpWindow.Unload ()
-		LevelUpWindow = None
-
-		return
 
 	LevelUpWindow = Window = GemRB.LoadWindow (4, "GUIREC") # since we get called from NewLife
 

--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -102,7 +102,7 @@ def InitRecordsWindow (Window):
 	# Level Up
 	Button = Window.GetControl (9)
 	Button.SetText (4246)
-	Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, NewLife.OpenLUStatsWindow)
+	Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, OpenLevelUpWindow)
 
 	statevents = (OnRecordsHelpStrength, OnRecordsHelpIntelligence, OnRecordsHelpWisdom, OnRecordsHelpDexterity, OnRecordsHelpConstitution, OnRecordsHelpCharisma)
 	# stat buttons
@@ -832,7 +832,9 @@ def AcceptLevelUp():
 			GemRB.SetPlayerStat (pc, IE_LEVEL2, GemRB.GetPlayerStat (pc, IE_LEVEL2)+NumOfSecoLevUp)
 	
 	LUSkillsSelection.SkillsSave (pc)
-	UpdateRecordsWindow ()
+
+	UpdateRecordsWindow(RecordsWindow)
+	NewLife.OpenLUStatsWindow()
 
 def RedrawSkills():
 	DoneButton = LevelUpWindow.GetControl(0)

--- a/gemrb/GUIScripts/pst/NewLife.py
+++ b/gemrb/GUIScripts/pst/NewLife.py
@@ -142,7 +142,10 @@ def OpenLUStatsWindow(Type = 1):
 		Button.SetActionInterval (200)
 
 	NewLifeLabel = NewLifeWindow.GetControl(0x10000023)
-	NewLifeLabel.SetText(1899)
+	if LevelUp:
+		NewLifeLabel.SetText(19356)
+	else:
+		NewLifeLabel.SetText(1899)
 
 	TextArea = NewLifeWindow.GetControl(23)
 	TextArea.SetText(18495)

--- a/gemrb/GUIScripts/pst/NewLife.py
+++ b/gemrb/GUIScripts/pst/NewLife.py
@@ -63,17 +63,11 @@ def OpenLUStatsWindow(Type = 1):
 
 	LevelUp = Type
 	if LevelUp:
-		import GUICommonWindows
 		import GUIREC
-		GUICommonWindows.OptionsWindow.SetVisible (False)
-		GUICommonWindows.PortraitWindow.SetVisible (False)
-		GUICommonWindows.ActionsWindow.SetVisible (False)
-		GUIREC.RecordsWindow.SetVisible (False)
 		# only TNO gets the main stat boosts
 		pc = GemRB.GameGetSelectedPCSingle ()
 		Specific = GemRB.GetPlayerStat (pc, IE_SPECIFIC)
 		if Specific != 2:
-			GUIREC.OpenLevelUpWindow ()
 			return
 	else:
 		GemRB.LoadGame(None)  #loading the base game
@@ -174,6 +168,8 @@ def OpenLUStatsWindow(Type = 1):
 	CancelButton = NewLifeWindow.GetControl(1)
 	CancelButton.SetText(4196)
 	CancelButton.SetEvent(IE_GUI_BUTTON_ON_PRESS, CancelPress)
+	if LevelUp:
+		CancelButton.SetState(IE_GUI_BUTTON_DISABLED)
 
 	UpdateLabels()
 
@@ -250,9 +246,8 @@ def AcceptPress():
 	GemRB.SetPlayerStat(1, IE_CHR, Stats[5])
 
 	if LevelUp:
-		# hp is handled in GUIREC
-		import GUIREC
-		GUIREC.OpenLevelUpWindow ()
+		# Return to the RecordsWindow
+		NewLifeWindow.Close()
 		return
 
 	#don't add con bonus, it will be calculated by the game

--- a/gemrb/GUIScripts/pst/NewLife.py
+++ b/gemrb/GUIScripts/pst/NewLife.py
@@ -63,7 +63,6 @@ def OpenLUStatsWindow(Type = 1):
 
 	LevelUp = Type
 	if LevelUp:
-		import GUIREC
 		# only TNO gets the main stat boosts
 		pc = GemRB.GameGetSelectedPCSingle ()
 		Specific = GemRB.GetPlayerStat (pc, IE_SPECIFIC)

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -8184,14 +8184,33 @@ void Actor::AddExperience(int exp, int combat)
 		bonus += adjustmentPercent;
 	}
 	bonus += GetFavoredPenalties();
-	exp = ((exp * (100 + bonus)) / 100) + BaseStats[IE_XP];
+
+	int xpStat = IE_XP;
+
+	// decide which particular XP stat to add to (only for TNO's switchable classes)
+	Game* game = core->GetGame();
+	if (pstflags && this == game->GetPC(0, false)) { // rule only applies to the protagonist
+		switch (BaseStats[IE_CLASS]) {
+			case 4:
+				xpStat = IE_XP_THIEF;
+				break;
+			case 1:
+				xpStat = IE_XP_MAGE;
+				break;
+			case 2:
+			default: //just in case the character was modified
+				break;
+		}
+	}
+
+	exp = ((exp * (100 + bonus)) / 100) + BaseStats[xpStat];
 	if (xpcap != NULL) {
 		int classid = GetActiveClass() - 1;
 		if (xpcap[classid] > 0 && exp > xpcap[classid]) {
 			exp = xpcap[classid];
 		}
 	}
-	SetBase(IE_XP, exp);
+	SetBase(xpStat, exp);
 }
 
 static bool is_zero(const int& value) {


### PR DESCRIPTION
I recently started rebasing the changes to PST level up I have been working on top of the subviews branch - it gives me a chance to look at everything twice, it avoids having to worry about merge conflicts with master, and also it means I can test for new bugs and regressions in the game along the way (of course not just in the level up code, but anything else I encounter)

I already found and fixed two new problems. One was an unintended consequence of my last skills patch which broke in subviews because the CreateTextArea function seems to be different. Another is that NewLife.py was hiding the various in game windows, but not setting them visible again after level up.

I also included here one small change for discussion, patching the common level up code to work with TNO's separate XP values, so that the code can be used generally to detect ability to level up. 

Before I can really continue though, I need some advice about how to best deal with TNO's three different XP/LEVEL stats

Unlike a multi class character, who gets evenly distributed XP divided by number of classes, each class XP value is individually tracked in the original game. You only gain XP in the class you are currently playing as. Currently the main problem in GemRB, there is nothing handling the adding XP gained to the correct IE_XP_[_____] stat depending on the active class. So although you can change your class in game, the XP you gain always goes into the first XP stat, which is only meant to save his fighter XP value. 

On my game just for testing, I wrote a workaround in python to shift any gained XP to the correct stat based on the active class of TNO . It worked very well in practice, I could switch classes and level them up individually, but it is also just a little bit hacky.

Another option is to handle it in Actor.cpp, right here in AddExperience: https://github.com/gemrb/gemrb/blob/d5da8d109a65d6b55e1ae4f660c9e6a7d213492f/gemrb/core/Scriptable/Actor.cpp#L8115

This is the only real major blocker I think, everything else should fall into place easily after deciding what to do here.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
