### PR TITLE
InventoryCommon.DialogItemWindow: Update the inventory window closing method

### DIFF
--- a/gemrb/GUIScripts/InventoryCommon.py
+++ b/gemrb/GUIScripts/InventoryCommon.py
@@ -873,9 +873,7 @@ def DialogItemWindow ():
 	dialog=item["Dialog"]
 	if ItemInfoWindow:
 		ItemInfoWindow.Unload ()
-		
-	import GUIINV
-	GUIINV.OpenInventoryWindow ()
+
 	GemRB.ExecuteString ("StartDialogOverride(\""+dialog+"\",Myself,0,0,1)", pc)
 	return
 


### PR DESCRIPTION
This should hopefully fix the rest of #998

The last inventory PR fixed the ability to enter the dialog mode, but I missed the fact that the inventory window does not close like it should in subviews branch, so it was overall still not functional.

This changes the close function to what I think is the newer method (please correct me if I'm wrong, but it does work in game)

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
