### PR TITLE
Pst level up subviews continued

### DIFF
--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -819,12 +819,13 @@ def AcceptLevelUp():
 	#increase weapon proficiency if needed
 	if WeapProfType!=-1:
 		GemRB.SetPlayerStat (pc, WeapProfType, CurrWeapProf + WeapProfGained )
-	Specific = GemRB.GetPlayerStat (pc, IE_SPECIFIC)
-	if Specific == 1:
-		#TODO:
-		#the nameless one is dual classed
-		#so we have to determine which level to increase
-		GemRB.SetPlayerStat (pc, IE_LEVEL, GemRB.GetPlayerStat (pc, IE_LEVEL)+NumOfPrimLevUp)
+
+	SwitcherClass = GUICommon.NamelessOneClass(pc) 
+	if SwitcherClass:
+		# Handle saving of TNO class level in the correct CRE stat
+		Levels = { "FIGHTER" : GemRB.GetPlayerStat (pc, IE_LEVEL) , "MAGE": GemRB.GetPlayerStat (pc, IE_LEVEL2), "THIEF": GemRB.GetPlayerStat (pc, IE_LEVEL3) }
+		LevelStats = { "FIGHTER" : IE_LEVEL , "MAGE": IE_LEVEL2, "THIEF": IE_LEVEL3 }
+		GemRB.SetPlayerStat (pc, LevelStats[SwitcherClass], Levels[SwitcherClass]+NumOfPrimLevUp)
 	else:
 		GemRB.SetPlayerStat (pc, IE_LEVEL, GemRB.GetPlayerStat (pc, IE_LEVEL)+NumOfPrimLevUp)
 		if avatar_header['SecoLevel'] != 0:

--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -899,7 +899,14 @@ def OpenLevelUpWindow ():
 				break
 
 	if WeapProfType!=-1:
+		# NPC: Just count the points in the favoured weapon proficiency
 		CurrWeapProf = GemRB.GetPlayerStat (pc, IE_PROFICIENCYBASTARDSWORD + WeapProfType)
+	else:
+		# TNO: Count the total amount of assigned and unassigned proficiencies
+		CurrWeapProf = GemRB.GetPlayerStat(pc, IE_FREESLOTS)
+		for i in range (6):
+			CurrWeapProf += GemRB.GetPlayerStat (pc, IE_PROFICIENCYBASTARDSWORD + i)
+		CurrWeapProf -= 4 #adjust for the 4 slots already given at level 1
 
 	# Recording this avatar's current proficiency level
 	# Since Nameless one is not covered, hammer and club can't occur
@@ -947,6 +954,11 @@ def OpenLevelUpWindow ():
 		while avatar_header['XP'] >= GetNextLevelExp (NextLevel, Class):
 			NextLevel = NextLevel + 1
 		NumOfPrimLevUp = NextLevel - avatar_header['PrimLevel'] # How many levels did we go up?
+
+		#How many weapon procifiencies we get
+		for i in range (NumOfPrimLevUp):
+			if HasGainedWeapProf (pc, CurrWeapProf + WeapProfGained, avatar_header['PrimLevel'] + i):
+				WeapProfGained += 1
 
 		# Is avatar Nameless One?
 		if Specific == 2:
@@ -998,10 +1010,6 @@ def OpenLevelUpWindow ():
 						SavThrUpdated = True
 			# Cleaning up
 		else:
-			#How many weapon procifiencies we get
-			for i in range (NumOfPrimLevUp):
-				if HasGainedWeapProf (pc, CurrWeapProf + WeapProfGained, avatar_header['PrimLevel'] + i):
-					WeapProfGained += 1
 
 			# Saving Throws
 			# Loading the right saving throw table

--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -396,13 +396,13 @@ def GetCharacterHeader (pc):
 
 	Class = GemRB.GetPlayerStat (pc, IE_CLASS) - 1
 	Multi = GUICommon.HasMultiClassBits (pc)
-	Specific = "%d"%GemRB.GetPlayerStat (pc, IE_SPECIFIC)
+	Specific = GemRB.GetPlayerStat (pc, IE_SPECIFIC)
 
-	#Nameless is Specific == 1
+	#Nameless is Specific == 2
 	avatar_header['Specific'] = Specific
 
 	# Nameless is a special case (dual class)
-	if Specific == 1:
+	if Specific == 2:
 		avatar_header['PrimClass'] = CommonTables.Classes.GetRowName (Class)
 		avatar_header['SecoClass'] = "*"
 
@@ -864,7 +864,7 @@ def OpenLevelUpWindow ():
 	# These are used to identify Nameless One
 	BioTable = GemRB.LoadTable ("bios")
 	Specific = GemRB.GetPlayerStat (pc, IE_SPECIFIC)
-	AvatarName = BioTable.GetRowName (Specific+1)
+	AvatarName = BioTable.GetRowName (Specific)
 
 	# These will be used for saving throws
 	SavThrUpdated = False
@@ -885,8 +885,8 @@ def OpenLevelUpWindow ():
 	WeapProfType = -1
 	CurrWeapProf = -1
 	#This does not apply to Nameless since he uses unused slots system
-	#Nameless is Specific == 1
-	if Specific != "1":
+	#Nameless is Specific == 2
+	if Specific != 2:
 		# Searching for the column name where value is 1
 		for i in range (5):
 			WeapProfName = ClasWeapTable.GetRowName (i)
@@ -946,7 +946,7 @@ def OpenLevelUpWindow ():
 		NumOfPrimLevUp = NextLevel - avatar_header['PrimLevel'] # How many levels did we go up?
 
 		# Is avatar Nameless One?
-		if Specific == "1":
+		if Specific == 2:
 			# Saving Throws
 			# Nameless One gets the best possible throws from all the classes except Priest
 			FigSavThrTable = GemRB.LoadTable ("SAVEWAR")

--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -818,7 +818,10 @@ def AcceptLevelUp():
 	GemRB.SetPlayerStat (pc, IE_HITPOINTS, HPGained+oldhp)
 	#increase weapon proficiency if needed
 	if WeapProfType!=-1:
-		GemRB.SetPlayerStat (pc, WeapProfType, CurrWeapProf + WeapProfGained )
+		GemRB.SetPlayerStat (pc, IE_PROFICIENCYBASTARDSWORD+WeapProfType, CurrWeapProf + WeapProfGained )
+	else:
+		freeSlots = GemRB.GetPlayerStat(pc, IE_FREESLOTS)
+		GemRB.SetPlayerStat (pc, IE_FREESLOTS, freeSlots + WeapProfGained )
 
 	SwitcherClass = GUICommon.NamelessOneClass(pc) 
 	if SwitcherClass:

--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -864,6 +864,8 @@ def OpenLevelUpWindow ():
 
 	pc = GemRB.GameGetSelectedPCSingle ()
 
+	Class = GUICommon.GetClassRowName(pc)
+
 	# These are used to identify Nameless One
 	BioTable = GemRB.LoadTable ("bios")
 	Specific = GemRB.GetPlayerStat (pc, IE_SPECIFIC)
@@ -960,9 +962,24 @@ def OpenLevelUpWindow ():
 			if HasGainedWeapProf (pc, CurrWeapProf + WeapProfGained, avatar_header['PrimLevel'] + i):
 				WeapProfGained += 1
 
-		# Is avatar Nameless One?
+		# Hit Points Gained and Hit Points from Constitution Bonus
+		for i in range (NumOfPrimLevUp):
+			HPGained = HPGained + GetSingleClassHP (Class, avatar_header['PrimLevel'])
+
+		if not "FIGHTER" in Class:
+			CONType = 0
+		else:
+			CONType = 1
+		ConHPBon = GetConHPBonus (pc, NumOfPrimLevUp, 0, CONType)
+
+		# Thac0
+		Thac0 = GetThac0 (Class, NextLevel)
+		# Is the new thac0 better than old? (The smaller, the better)
+		if Thac0 < GemRB.GetPlayerStat (pc, IE_TOHIT, 1):
+			Thac0Updated = True
+
+		# Saving Throws
 		if Specific == 2:
-			# Saving Throws
 			# Nameless One gets the best possible throws from all the classes except Priest
 			FigSavThrTable = GemRB.LoadTable ("SAVEWAR")
 			MagSavThrTable = GemRB.LoadTable ("SAVEWIZ")
@@ -973,18 +990,13 @@ def OpenLevelUpWindow ():
 			FighterLevel = GemRB.GetPlayerStat (pc, IE_LEVEL) - 1
 			MageLevel = GemRB.GetPlayerStat (pc, IE_LEVEL2) - 1
 			ThiefLevel = GemRB.GetPlayerStat (pc, IE_LEVEL3) - 1
-			# this is the constitution bonus type for this level
-			CONType = 1
 			# We are leveling up one of those levels. Therefore, one of them has to be updated.
-			if avatar_header['PrimClass'] == "FIGHTER":
+			if Class == "FIGHTER":
 				FighterLevel = NextLevel - 1
-				CONType = 0
-			elif avatar_header['PrimClass'] == "MAGE":
+			elif Class == "MAGE":
 				MageLevel = NextLevel - 1
 			else:
 				ThiefLevel = NextLevel - 1
-
-			ConHPBon = GetConHPBonus (pc, NumOfPrimLevUp, 0, CONType)
 			# Now we need to update the saving throws with the best values from those tables.
 			# The smaller the number, the better saving throw it is.
 			# We also need to check if any of the levels are larger than 21, since
@@ -1008,11 +1020,7 @@ def OpenLevelUpWindow ():
 					if Throw < SavThrows[i]:
 						SavThrows[i] = Throw
 						SavThrUpdated = True
-			# Cleaning up
 		else:
-
-			# Saving Throws
-			# Loading the right saving throw table
 			SavThrTable = GemRB.LoadTable (CommonTables.Classes.GetValue (Class, "SAVE"))
 			# Updating the current saving throws. They are changed only if the
 			# new ones are better than current. The smaller the number, the better.
@@ -1025,23 +1033,6 @@ def OpenLevelUpWindow ():
 					if Throw < SavThrows[i]:
 						SavThrows[i] = Throw
 						SavThrUpdated = True
-			# Cleaning Up
-
-			# Hit Points Gained and Hit Points from Constitution Bonus
-			for i in range (NumOfPrimLevUp):
-				HPGained = HPGained + GetSingleClassHP (Class, avatar_header['PrimLevel'])
-
-			if avatar_header['PrimClass'] == "FIGHTER":
-				CONType = 0
-			else:
-				CONType = 1
-			ConHPBon = GetConHPBonus (pc, NumOfPrimLevUp, 0, CONType)
-
-			# Thac0
-			Thac0 = GetThac0 (Class, NextLevel)
-			# Is the new thac0 better than old? (The smaller, the better)
-			if Thac0 < GemRB.GetPlayerStat (pc, IE_TOHIT, 1):
-				Thac0Updated = True
 
 	else:
 		# avatar is multi class

--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -884,16 +884,16 @@ def OpenLevelUpWindow ():
 	Thac0 = 0
 	WeapProfGained = 0
 
-	ClasWeapTable = GemRB.LoadTable ("weapprof")
+	WeapProfTable = GemRB.LoadTable ("weapprof")
 	WeapProfType = -1
 	CurrWeapProf = -1
 	#This does not apply to Nameless since he uses unused slots system
 	#Nameless is Specific == 2
 	if Specific != 2:
 		# Searching for the column name where value is 1
-		for i in range (5):
-			WeapProfName = ClasWeapTable.GetRowName (i)
-			value = ClasWeapTable.GetValue (WeapProfName, AvatarName)
+		for i in range (6):
+			WeapProfName = WeapProfTable.GetRowName (i)
+			value = WeapProfTable.GetValue (WeapProfName,AvatarName)
 			if value == 1:
 				WeapProfType = i
 				break
@@ -1000,7 +1000,7 @@ def OpenLevelUpWindow ():
 		else:
 			#How many weapon procifiencies we get
 			for i in range (NumOfPrimLevUp):
-				if HasGainedWeapProf (pc, CurrWeapProf + WeapProfGained, avatar_header['PrimLevel'] + i, avatar_header['PrimClass']):
+				if HasGainedWeapProf (pc, CurrWeapProf + WeapProfGained, avatar_header['PrimLevel'] + i):
 					WeapProfGained += 1
 
 			# Saving Throws
@@ -1052,7 +1052,7 @@ def OpenLevelUpWindow ():
 		NumOfPrimLevUp = PrimNextLevel - avatar_header['PrimLevel']
 
 		for i in range (NumOfPrimLevUp):
-			if HasGainedWeapProf (pc, CurrWeapProf + WeapProfGained, avatar_header['PrimLevel'] + i, avatar_header['PrimClass']):
+			if HasGainedWeapProf (pc, CurrWeapProf + WeapProfGained, avatar_header['PrimLevel'] + i):
 				WeapProfGained += 1
 
 		# Saving Throws
@@ -1188,15 +1188,29 @@ def GetThac0 (Class, Level):
 	return Thac0Table.GetValue (Class, str (Level))
 
 #apparently the original code doesn't follow profsmax/profs tables
-def HasGainedWeapProf (pc, currProf, currLevel, Class):
-	#only fighters gain weapon proficiencies
-	if Class!="FIGHTER":
+def HasGainedWeapProf (pc, currProf, currLevel):
+
+ 	Class = GUICommon.GetClassRowName(pc)
+
+	# Limits obtained from testing original game
+	limit = 1000
+	if Class == "FIGHTER":
+		# Morte, Nordom amd Vhailor are limited to 5, but not TNO
+		if not GUICommon.NamelessOneClass(pc):
+			limit = 5
+	elif Class == "FIGHTER_MAGE" or Class == "FIGHTER_THIEF":
+		# Dakkon and Annah are limited to 4
+		limit = 4
+	else:
+		# Non fighters ie Grace get nothing
+		return
+	if  currProf >= limit:
 		return False
-	#hardcoded limit is 4
-	if currProf>3:
+
+	# Calculate the total limit (1 point for every 3 fighter levels)
+	if currProf >= (currLevel) / 3:
 		return False
-	if currProf > (currLevel - 1) / 3:
-		return False
+
 	return True
 
 ###################################################

--- a/gemrb/unhardcoded/pst/weapprof.2da
+++ b/gemrb/unhardcoded/pst/weapprof.2da
@@ -1,4 +1,5 @@
 2DA V1.0
+0
            ID      NAME_REF    DESC_REF    NAMELESS  ANNAH MORTE NORDOM  DAKKON  GRACE  IGNUS  VHAILOR
 FIST        0      64190       *           1         1     1     0       0       1      1      0
 DAGGER      1      64187       *           1         0     0     0       1       0      0      0


### PR DESCRIPTION
A continuation of bugfixes to PST level up:

1: Level up was not considering which TNO class level to upgrade, it would only upgrade the fighter level stat

2: In many cases, the assumption TNO's specific stat was wrong. It is actually 2, not 1, when you inspect a save game character or look at CHARBASE

3: The weapon proficiency table was not properly returning a value because it had no 'default' at the top. All calls to it were simply returning "ID", the name of the first column, so character proficiencies were not being detected

4: HasGainedWeapProf was given the wrong class name type as a parameter - the code was passing it the display name, which comes from a string and changes by language, and then comparing it to the internal name in all caps, so that was never functional

5: AcceptLevelUp was not accounting for the fact that WeapProfType is just an offset from the first weapon proficiency stat. Although this code would never have been run because of the above issues, it would have just done ```SetPlayerStat(pc, 0, etc``` , which would be bad.

6: There was also no accounting for adding TNO's unused slots for the dialog based combat training

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
