### PR TITLE
pst/GUIREC: Fix annoyance of missing species display on record sheet

### DIFF
--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -250,10 +250,18 @@ def UpdateRecordsWindow ():
 		Label.SetText (str (stats[i]))
 
 	# race
-	# HACK: for some strange reason, Morte's race is 1 (Human), instead of 45 (Morte)
-	print "species: %d  race: %d" %(GemRB.GetPlayerStat (pc, IE_SPECIES), GemRB.GetPlayerStat (pc, IE_RACE))
-	#be careful, some saves got this field corrupted
+
+	# this is -1 to lookup the value in the table
 	race = GemRB.GetPlayerStat (pc, IE_SPECIES) - 1
+
+	# workaround for original saves that don't have the characters species stat set properly
+	if race == -1:
+		if GemRB.GetPlayerStat (pc, IE_SPECIFIC) == 3: # Vhailor
+			race = 50 # Changes from GHOST to RESTLESS_SPIRIT
+		elif  GemRB.GetPlayerStat (pc, IE_SPECIFIC) == 9: # Morte
+			race = 44 # Changes from HUMAN to MORTE. Morte is Morte :)
+		else:
+			race = GemRB.GetPlayerStat (pc, IE_RACE) - 1
 
 	text = CommonTables.Races.GetValue (race, 0)
 	


### PR DESCRIPTION
This only applies to original save games, which don't seem to respect the IE_SPECIES stat of player characters

Should close #1025

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
