### PR TITLE
pst/GUIREC: Handle saving of TNO level in the correct Stat

### DIFF
--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -819,12 +819,13 @@ def AcceptLevelUp():
 	#increase weapon proficiency if needed
 	if WeapProfType!=-1:
 		GemRB.SetPlayerStat (pc, WeapProfType, CurrWeapProf + WeapProfGained )
-	Specific = GemRB.GetPlayerStat (pc, IE_SPECIFIC)
-	if Specific == 1:
-		#TODO:
-		#the nameless one is dual classed
-		#so we have to determine which level to increase
-		GemRB.SetPlayerStat (pc, IE_LEVEL, GemRB.GetPlayerStat (pc, IE_LEVEL)+NumOfPrimLevUp)
+
+	SwitcherClass = GUICommon.NamelessOneClass(pc)
+	if SwitcherClass:
+		# Handle saving of TNO class level in the correct CRE stat
+		Levels = { "FIGHTER" : GemRB.GetPlayerStat (pc, IE_LEVEL) , "MAGE": GemRB.GetPlayerStat (pc, IE_LEVEL2), "THIEF": GemRB.GetPlayerStat (pc, IE_LEVEL3) }
+		LevelStats = { "FIGHTER" : IE_LEVEL , "MAGE": IE_LEVEL2, "THIEF": IE_LEVEL3 }
+		GemRB.SetPlayerStat (pc, LevelStats[SwitcherClass], Levels[SwitcherClass]+NumOfPrimLevUp)
 	else:
 		GemRB.SetPlayerStat (pc, IE_LEVEL, GemRB.GetPlayerStat (pc, IE_LEVEL)+NumOfPrimLevUp)
 		if avatar_header['SecoLevel'] != 0:


### PR DESCRIPTION
This commit was actually meant to be the last part of #1021 and the handling of each different class level for TNO, but got left out before that was merged.

I was just going bundle it with #1023 at first, but since I'll be rethinking the weapon proficiency handling and that part of GUIREC in general, I've split it out from there so that it doesn't end up getting lost.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
