### PR TITLE
Demo: fixed the clown colors

### DIFF
--- a/demo/data/avatars.2da
+++ b/demo/data/avatars.2da
@@ -4,5 +4,5 @@
 0x0300     SPSMPUFF   SPSMPUFF   SPSMPUFF   SPSMPUFF   13         0          0          *
 0x0400     SKLH       SKLH       SKLH       SKLH       13         0          1          *
 0x1000     MWYV       MWYV       MWYV       MWYV       11         3          1          *
-0xc800     ZHMW1      ZHMW1      ZHMW1      ZHMW1      22         2          1          *
+0x8000     ZHMW1      ZHMW1      ZHMW1      ZHMW1      22         2          0          *
 


### PR DESCRIPTION
I fixed the clown colors for the demo, there was a bad line in avatars.2da
But there's another problem now, the avatar looks completely yellow. Is this normal?