### PR TITLE
PST Level up Proficiencies w/table & fixes

### DIFF
--- a/gemrb/GUIScripts/CommonTables.py
+++ b/gemrb/GUIScripts/CommonTables.py
@@ -24,12 +24,13 @@ from ie_restype import RES_2DA
 # these two are only used in SetEncumbranceLabels, but that is called very often
 StrMod = StrModEx = None
 Classes = KitList = ClassSkills = Races = NextLevel = None
-Pdolls = SpellDisplay = Aligns = ItemType =None
+Pdolls = SpellDisplay = Aligns = ItemType = None
+WeapProfs = CharProfs = None
 
 def Load():
 	global Classes, KitList, ClassSkills, Races, NextLevel
 	global Pdolls, StrModEx, StrMod, SpellDisplay, Aligns
-	global ItemType
+	global ItemType, WeapProfs, CharProfs
 
 	print # so the following output isn't appended to an existing line
 	if not Classes:
@@ -53,3 +54,7 @@ def Load():
 		Aligns = GemRB.LoadTable ("aligns")
 	if not ItemType:
 		ItemType = GemRB.LoadTable ("itemtype")
+	if not WeapProfs and  GemRB.HasResource("weapprof", RES_2DA):
+		WeapProfs = GemRB.LoadTable ("weapprof")
+	if not CharProfs and  GemRB.HasResource("charprof", RES_2DA):
+		CharProfs = GemRB.LoadTable ("charprof")

--- a/gemrb/GUIScripts/GUICommon.py
+++ b/gemrb/GUIScripts/GUICommon.py
@@ -558,17 +558,22 @@ def IsMultiClassed (actor, verbose):
 	# return the tuple
 	return (NumClasses, Classes[0], Classes[1], Classes[2])
 
-def NamelessOneClass (actor):
-	# simple check to identify if the actor is TNO
-	# and return his active class (by name)
-
+def IsNamelessOne (actor):
+	# A very simple test to identify the actor as TNO
 	if not GameCheck.IsPST():
-		return None
+		return False
 
 	Specific = GemRB.GetPlayerStat (actor, IE_SPECIFIC)
 	if Specific == 2:
-		Class = GetClassRowName(actor)
-		return Class
+		return True
+
+	return False
+
+def NamelessOneClass (actor):
+	# A shortcut function to determine the identity of the nameless one 
+	# and get his class if that is the case
+	if IsNamelessOne(actor):
+		return GetClassRowName(actor)
 
 	return None
 

--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -824,9 +824,15 @@ def AcceptLevelUp():
 	GemRB.SetPlayerStat (pc, IE_MAXHITPOINTS, HPGained+oldhp)
 	oldhp = GemRB.GetPlayerStat (pc, IE_HITPOINTS, 1)
 	GemRB.SetPlayerStat (pc, IE_HITPOINTS, HPGained+oldhp)
-	#increase weapon proficiency if needed
-	if WeapProfType!=-1:
-		GemRB.SetPlayerStat (pc, WeapProfType, CurrWeapProf + WeapProfGained )
+
+	# Weapon Proficiencies
+	if WeapProfType != -1:
+		# Companion NPC's get points added directly to their chosen weapon
+		GemRB.SetPlayerStat (pc, IE_PROFICIENCYBASTARDSWORD+WeapProfType, CurrWeapProf + WeapProfGained)
+	else:
+		# TNO has points added to the "Unused Slots" dummy proficiency
+		freeSlots = GemRB.GetPlayerStat(pc, IE_FREESLOTS)
+		GemRB.SetPlayerStat (pc, IE_FREESLOTS, freeSlots + WeapProfGained)
 
 	SwitcherClass = GUICommon.NamelessOneClass(pc)
 	if SwitcherClass:

--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -404,13 +404,13 @@ def GetCharacterHeader (pc):
 
 	Class = GemRB.GetPlayerStat (pc, IE_CLASS) - 1
 	Multi = GUICommon.HasMultiClassBits (pc)
-	Specific = "%d"%GemRB.GetPlayerStat (pc, IE_SPECIFIC)
+	Specific = GemRB.GetPlayerStat (pc, IE_SPECIFIC)
 
-	#Nameless is Specific == 1
+	#Nameless is Specific == 2
 	avatar_header['Specific'] = Specific
 
 	# Nameless is a special case (dual class)
-	if Specific == 1:
+	if Specific == 2:
 		avatar_header['PrimClass'] = CommonTables.Classes.GetRowName (Class)
 		avatar_header['SecoClass'] = "*"
 
@@ -872,7 +872,7 @@ def OpenLevelUpWindow ():
 	# These are used to identify Nameless One
 	BioTable = GemRB.LoadTable ("bios")
 	Specific = GemRB.GetPlayerStat (pc, IE_SPECIFIC)
-	AvatarName = BioTable.GetRowName (Specific+1)
+	AvatarName = BioTable.GetRowName (Specific)
 
 	# These will be used for saving throws
 	SavThrUpdated = False
@@ -892,8 +892,8 @@ def OpenLevelUpWindow ():
 	WeapProfType = -1
 	CurrWeapProf = -1
 	#This does not apply to Nameless since he uses unused slots system
-	#Nameless is Specific == 1
-	if Specific != "1":
+	#Nameless is Specific == 2
+	if Specific != 2:
 		# Searching for the column name where value is 1
 		for i in range (6):
 			WeapProfName = CommonTables.WeapProfs.GetRowName (i)
@@ -953,7 +953,7 @@ def OpenLevelUpWindow ():
 		NumOfPrimLevUp = NextLevel - avatar_header['PrimLevel'] # How many levels did we go up?
 
 		# Is avatar Nameless One?
-		if Specific == "1":
+		if Specific == 2:
 			# Saving Throws
 			# Nameless One gets the best possible throws from all the classes except Priest
 			FigSavThrTable = GemRB.LoadTable ("SAVEWAR")

--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -889,16 +889,15 @@ def OpenLevelUpWindow ():
 	Thac0 = 0
 	WeapProfGained = 0
 
-	ClasWeapTable = GemRB.LoadTable ("weapprof")
 	WeapProfType = -1
 	CurrWeapProf = -1
 	#This does not apply to Nameless since he uses unused slots system
 	#Nameless is Specific == 1
 	if Specific != "1":
 		# Searching for the column name where value is 1
-		for i in range (5):
-			WeapProfName = ClasWeapTable.GetRowName (i)
-			value = ClasWeapTable.GetValue (WeapProfName, AvatarName)
+		for i in range (6):
+			WeapProfName = CommonTables.WeapProfs.GetRowName (i)
+			value = CommonTables.WeapProfs.GetValue (WeapProfName,AvatarName)
 			if value == 1:
 				WeapProfType = i
 				break

--- a/gemrb/GUIScripts/pst/GUIREC.py
+++ b/gemrb/GUIScripts/pst/GUIREC.py
@@ -868,6 +868,7 @@ def OpenLevelUpWindow ():
 	Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, AcceptLevelUp)
 
 	pc = GemRB.GameGetSelectedPCSingle ()
+	Class = CommonTables.Classes.GetRowName (GemRB.GetPlayerStat (pc, IE_CLASS) - 1)
 
 	# These are used to identify Nameless One
 	BioTable = GemRB.LoadTable ("bios")
@@ -959,31 +960,53 @@ def OpenLevelUpWindow ():
 		for i in range (NumOfPrimLevUp):
 			WeapProfGained += GainedWeapProfs (pc, CurrWeapProf + WeapProfGained, avatar_header['PrimLevel'] + i, AvatarName)
 
-		# Is avatar Nameless One?
-		if Specific == 2:
-			# Saving Throws
-			# Nameless One gets the best possible throws from all the classes except Priest
+		# Hit Points Gained and Hit Points from Constitution Bonus
+		for i in range (NumOfPrimLevUp):
+			HPGained = HPGained + GetSingleClassHP (Class, avatar_header['PrimLevel'])
+		if Class == "FIGHTER":
+			CONType = 0
+		else:
+			CONType = 1
+		ConHPBon = GetConHPBonus (pc, NumOfPrimLevUp, 0, CONType)
+
+		# Thac0
+		Thac0 = GetThac0 (Class, NextLevel)
+		# Is the new thac0 better than old? (The smaller, the better)
+		if Thac0 < GemRB.GetPlayerStat (pc, IE_TOHIT, 1):
+			Thac0Updated = True
+
+		# Saving Throws
+		if Specific != 2:
+			SavThrTable = GemRB.LoadTable (CommonTables.Classes.GetValue (Class, "SAVE"))
+			# Updating the current saving throws. They are changed only if the
+			# new ones are better than current. The smaller the number, the better.
+			# We need to substract one from the NextLevel, so that we get right values.
+			# We also need to check if NextLevel is larger than 21, since after that point
+			# the table runs out, and the throws remain the same
+			if NextLevel < 22:
+				for i in range (5):
+					Throw = SavThrTable.GetValue (i, NextLevel-1)
+					if Throw < SavThrows[i]:
+						SavThrows[i] = Throw
+						SavThrUpdated = True
+		else:
+			# Nameless One always uses the best possible save from each class
 			FigSavThrTable = GemRB.LoadTable ("SAVEWAR")
 			MagSavThrTable = GemRB.LoadTable ("SAVEWIZ")
 			ThiSavThrTable = GemRB.LoadTable ("SAVEROG")
-			# For Nameless, we also need to know his levels in every class, so that we pick
-			# the right values from the corresponding tables. Also we substract one, so
-			# that we may use them as column indices in tables.
+
 			FighterLevel = GemRB.GetPlayerStat (pc, IE_LEVEL) - 1
 			MageLevel = GemRB.GetPlayerStat (pc, IE_LEVEL2) - 1
 			ThiefLevel = GemRB.GetPlayerStat (pc, IE_LEVEL3) - 1
-			# this is the constitution bonus type for this level
-			CONType = 1
+
 			# We are leveling up one of those levels. Therefore, one of them has to be updated.
-			if avatar_header['PrimClass'] == "FIGHTER":
+			if Class == "FIGHTER":
 				FighterLevel = NextLevel - 1
-				CONType = 0
-			elif avatar_header['PrimClass'] == "MAGE":
+			elif Class == "MAGE":
 				MageLevel = NextLevel - 1
 			else:
 				ThiefLevel = NextLevel - 1
 
-			ConHPBon = GetConHPBonus (pc, NumOfPrimLevUp, 0, CONType)
 			# Now we need to update the saving throws with the best values from those tables.
 			# The smaller the number, the better saving throw it is.
 			# We also need to check if any of the levels are larger than 21, since
@@ -1007,39 +1030,6 @@ def OpenLevelUpWindow ():
 					if Throw < SavThrows[i]:
 						SavThrows[i] = Throw
 						SavThrUpdated = True
-			# Cleaning up
-		else:
-			# Saving Throws
-			# Loading the right saving throw table
-			SavThrTable = GemRB.LoadTable (CommonTables.Classes.GetValue (Class, "SAVE"))
-			# Updating the current saving throws. They are changed only if the
-			# new ones are better than current. The smaller the number, the better.
-			# We need to substract one from the NextLevel, so that we get right values.
-			# We also need to check if NextLevel is larger than 21, since after that point
-			# the table runs out, and the throws remain the same
-			if NextLevel < 22:
-				for i in range (5):
-					Throw = SavThrTable.GetValue (i, NextLevel-1)
-					if Throw < SavThrows[i]:
-						SavThrows[i] = Throw
-						SavThrUpdated = True
-			# Cleaning Up
-
-			# Hit Points Gained and Hit Points from Constitution Bonus
-			for i in range (NumOfPrimLevUp):
-				HPGained = HPGained + GetSingleClassHP (Class, avatar_header['PrimLevel'])
-
-			if avatar_header['PrimClass'] == "FIGHTER":
-				CONType = 0
-			else:
-				CONType = 1
-			ConHPBon = GetConHPBonus (pc, NumOfPrimLevUp, 0, CONType)
-
-			# Thac0
-			Thac0 = GetThac0 (Class, NextLevel)
-			# Is the new thac0 better than old? (The smaller, the better)
-			if Thac0 < GemRB.GetPlayerStat (pc, IE_TOHIT, 1):
-				Thac0Updated = True
 
 	else:
 		# avatar is multi class

--- a/gemrb/unhardcoded/pst/charprof.2da
+++ b/gemrb/unhardcoded/pst/charprof.2da
@@ -1,0 +1,44 @@
+2DA v1.0
+0
+        NAMELESS  DAKKON  MORTE  ANNAH  IGNUS  GRACE  NORDOM  VHAILOR
+1       4         1   	   2      1      1      1      2       2
+2       4         1       2      1      1      1      2       2
+3       5         1       2      1      1      1      2       2
+4       5         1       2      1      1      1      2       2
+5       5         2       3      2      1      1      2       2
+6       6         2       3      2      1      1      2       2
+7       6         2       3      2      1      1      2       2
+8       6         3       4      3      1      1      3       2
+9       7         3       4      3      1      1      3       2
+10      7         3       4      3      1      1      3       2
+11      7         4       4      4      1      1      4       3
+12      8         4       4      4      1      1      4       3
+13      8         4       4      4      1      1      5       4
+14      8         4       4      4      1      1      5       4
+15      9         4       4      4      1      1      5       4
+16      9         4       4      4      1      1      5       4
+17      9         4       4      4      1      1      5       5
+18      10        4       4      4      1      1      5       5
+19      10        4       4      4      1      1      5       5
+20      10        4       4      4      1      1      5       5
+
+# CHARPROF.2DA
+
+# Unhardcoded table to control the individual progression of weapon proficiency points in PST
+# This table defines the total points each character should have at each fighter level
+# 2e D&D rules are only loosely followed, as each character has limited weapon options.
+# The progression was judiciously spread out over the character levels you actually meet the NPCS
+
+# Values drawn up by testing the original game:
+
+# Dakkon and Annah get a point when their fighter level hits 5, 8, 11, capped at 4
+# Morte starts with 2 points, and also gets one at 5,8,11, capped at 5
+# Vhailor starts with 2 at level 9, gets a point at 11, 14 then 17 capped at 5
+# Then Nordom spoils the pattern by getting a point at lv 13 instead of 14
+
+# Grace and Ignus do not recieve proficiencies at all. This can be changed by modifiying the table.
+
+# TNO starts the game at level 3, with 2 spent and 3 unspent points,
+# then gains one at level 6 and every three fighter levels thereafter,
+# regardless of how many levels in other classes. This continues after level 20.
+# However his ability to spend proficiencies in a particular weapon is capped according to his class specialisation

--- a/gemrb/unhardcoded/pst/weapprof.2da
+++ b/gemrb/unhardcoded/pst/weapprof.2da
@@ -1,4 +1,5 @@
 2DA V1.0
+0
            ID      NAME_REF    DESC_REF    NAMELESS  ANNAH MORTE NORDOM  DAKKON  GRACE  IGNUS  VHAILOR
 FIST        0      64190       *           1         1     1     0       0       1      1      0
 DAGGER      1      64187       *           1         0     0     0       1       0      0      0


### PR DESCRIPTION
This is a redo of #1023, implementing the individual character proficiencies via a 2da table

Also includes the various changes to adjacent code : fixing the specific checks, shuffling the hp/thaco, slight tidy up of saving throws

If this is all ok, I can easily move on to finish #176 , all that is remaining are spell slots (which trivially works with LUSpellSelection) and the specialisation bonuses for TNO

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
