### PR TITLE
PST-specific animation- and wall-flag changes

### DIFF
--- a/gemrb/plugins/AREImporter/AREImporter.cpp
+++ b/gemrb/plugins/AREImporter/AREImporter.cpp
@@ -1575,13 +1575,34 @@ void AREImporter::AdjustPSTFlags(AreaAnimation *areaAnim) {
 	 * break things (like stopping early, hiding under FoW).
 	 *
 	 * So far, a better approximation towards handling animations is:
-	 * - always set A_ANI_BLEND, A_ANI_SYNC,
-	 * - unset A_ANI_PLAYONCE, A_ANI_NOT_IN_FOG, A_ANI_BACKGROUND.
+	 * - zero everything
+	 * - always set A_ANI_SYNC
+	 * - copy/map known flags (A_ANI_ACTIVE, A_ANI_NO_WALL, A_ANI_BLEND)
+	 *
+	 * Note that WF_COVERANIMS is enabled by default for PST, so ANI_NO_WALL
+	 *   is important.
 	 *
 	 * The actual use of bits in PST map anims isn't fully solved here.
 	 */
-	areaAnim->Flags |= (A_ANI_BLEND | A_ANI_SYNC);
-	areaAnim->Flags &= ~(A_ANI_PLAYONCE | A_ANI_NOT_IN_FOG | A_ANI_BACKGROUND);
+
+	#define PST_ANI_NO_WALL 0x0008  // A_ANI_PLAYONCE in other games
+	#define PST_ANI_BLEND 0x0100  // A_ANI_BACKGROUND in other games
+
+	areaAnim->Flags = 0;             // Clear everything
+
+	// Set default-on flags (currently only A_ANI_SYNC)
+	areaAnim->Flags |= A_ANI_SYNC;
+
+	// Copy still-relevant A_ANI_* flags
+	areaAnim->Flags |= areaAnim->originalFlags & A_ANI_ACTIVE;
+
+	// Map known flags
+	if (areaAnim->originalFlags & PST_ANI_BLEND) {
+		areaAnim->Flags |= A_ANI_BLEND;
+	}
+	if (areaAnim->originalFlags & PST_ANI_NO_WALL) {
+		areaAnim->Flags |= A_ANI_NO_WALL;
+	}
 }
 
 void AREImporter::ReadEffects(DataStream *ds, EffectQueue *fxqueue, ieDword EffectsCount)

--- a/gemrb/plugins/WEDImporter/WEDImporter.cpp
+++ b/gemrb/plugins/WEDImporter/WEDImporter.cpp
@@ -372,6 +372,9 @@ void WEDImporter::ReadWallPolygons()
 			if (flags&WF_BASELINE) {
 				polygonTable[i]->SetBaseline(base0, base1);
 			}
+			if (core->HasFeature(GF_PST_STATE_FLAGS)) {
+				flags |= WF_COVERANIMS;
+			}
 			polygonTable[i]->SetPolygonFlag(flags);
 		}
 		


### PR DESCRIPTION
## Description
Fix for #167 and some further progress on #163 .

Many bits/flags are still totally ignored -- notably A_ANI_BACKGROUND or whatever replaces it.
I saw improvements in most PST animations with these changes, but they could definitely use some more testing.


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
