### PR TITLE
pst/GUIPR: Store the Window ID as a global

### DIFF
--- a/gemrb/GUIScripts/pst/GUIPR.py
+++ b/gemrb/GUIScripts/pst/GUIPR.py
@@ -37,6 +37,9 @@ PriestSpellUnmemorizeWindow = None
 
 
 def InitPriestWindow (Window):
+	global PriestSpellWindow
+	PriestSpellWindow = Window
+
 	Button = Window.GetControl (0)
 	Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, PriestPrevLevelPress)
 


### PR DESCRIPTION
fixes #1057

There was simply nothing saving the window ID as a global so that UpdatePriestWindow could manage it.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
