### PR TITLE
LevelUp.py Character Generation label

### DIFF
--- a/gemrb/GUIScripts/LevelUp.py
+++ b/gemrb/GUIScripts/LevelUp.py
@@ -81,15 +81,14 @@ def OpenLevelUpWindow():
 		InfoButton = LevelUpWindow.GetControl (125)
 		InfoButton.SetText (13707)
 		InfoButton.SetEvent (IE_GUI_BUTTON_ON_PRESS, LevelUpInfoPress)
+		# hide "Character Generation"
+		LevelUpWindow.DeleteControl(0x1000007e)
 
 	DoneButton = LevelUpWindow.GetControl (0)
 	DoneButton.SetText (11962)
 	DoneButton.SetEvent (IE_GUI_BUTTON_ON_PRESS, LevelUpDonePress)
 	DoneButton.SetState (IE_GUI_BUTTON_DISABLED)
 	DoneButton.MakeDefault()
-
-	# hide "Character Generation"
-	LevelUpWindow.DeleteControl(0x1000007e)
 
 	# name
 	pc = GemRB.GameGetSelectedPCSingle ()


### PR DESCRIPTION
A change from a few months back to clean up the BG2 level up window interferes with the other games, BG for example doesn't have this control, so the UI breaks down on the Level Up screen.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
