### PR TITLE
GSUtils: Disable the printing of verbal constants to the console in PST

### DIFF
--- a/gemrb/core/GameScript/GSUtils.cpp
+++ b/gemrb/core/GameScript/GSUtils.cpp
@@ -497,6 +497,13 @@ void DisplayStringCore(Scriptable* const Sender, int Strref, int flags)
 		}
 	}
 
+	// PST does not echo verbal constants in the console, their strings
+	// actually contain development related identifying comments
+	// thus the console flag is unset.
+	if (core->HasFeature(GF_ONSCREEN_TEXT)) {
+		flags &= ~DS_CONSOLE;
+	}
+
 	if ((Strref != -1) && !soundRef[0]) {
 		StringBlock sb = core->strings->GetStringBlock( Strref );
 		memcpy(Sound, sb.Sound, sizeof(ieResRef) );


### PR DESCRIPTION
This is to fix the annoyance in #1053

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
