### PR TITLE
Dualclass kitindex

### DIFF
--- a/gemrb/GUIScripts/GUICommon.py
+++ b/gemrb/GUIScripts/GUICommon.py
@@ -515,8 +515,7 @@ def IsDualSwap (actor, override=None):
 	if Dual[0] > 1:
 		BaseClass = GetClassRowName(Dual[1], "index")
 	else:
-		BaseClass = GetKitIndex (actor)
-		BaseClass = CommonTables.KitList.GetValue (BaseClass, 7)
+		BaseClass = CommonTables.KitList.GetValue (Dual[1], 7)
 		if BaseClass == "*":
 			# mod boilerplate
 			return 0

--- a/gemrb/GUIScripts/GUICommon.py
+++ b/gemrb/GUIScripts/GUICommon.py
@@ -520,7 +520,7 @@ def IsDualSwap (actor, override=None):
 		if BaseClass == "*":
 			# mod boilerplate
 			return 0
-		BaseClass = GetClassRowName(BaseClass, "index")
+		BaseClass = GetClassRowName(BaseClass, "class")
 
 	# if our old class is the first class, we need to swap
 	if Class[0] == BaseClass:


### PR DESCRIPTION
For #819

Although I've found other issues with dual class worth chasing while testing, this particular fix for DC from kitted classes seems to be ok, I tested with a kensai, berserker, swashbuckler, beastmaster, avenger and cleric of lathander to various different combinations, and levelled each one up with 250000 XP to be sure the correct class was being used.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
