### PR TITLE
BG1: Add a BG2/IWD style rest button to the main sidebar

### DIFF
--- a/gemrb/GUIScripts/GUICommonWindows.py
+++ b/gemrb/GUIScripts/GUICommonWindows.py
@@ -271,6 +271,18 @@ def SetupMenuWindowControls (Window, Gears=None, CloseWindowCallback=None):
 		Button.SetTooltip (OptionTip['Rest'])
 		Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, RestPress)
 
+	# BG1 doesn't have a rest button on the main window, so this creates one 
+	# from what would be the multiplayer arbitration control
+	if bg1:
+		Button = Window.GetControl (8)
+		Button.SetSprites("GUIRSBUT", 0,0,1,0,0)
+		Button.SetStatus (IE_GUI_BUTTON_ENABLED)
+		Button.SetSize(55,37)
+		Button.SetPos(4,359)
+		Button.SetFlags (IE_GUI_BUTTON_PICTURE, OP_SET)
+		Button.SetTooltip (OptionTip['Rest'])
+		Button.SetEvent (IE_GUI_BUTTON_ON_PRESS, RestPress)
+
 	return
 
 def OnLockViewPress ():


### PR DESCRIPTION
An extra rest button that wasn't in the original game, this adds a nice improvement from bg2/iwd and also works around the issue in #1074 

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
