### PR TITLE
Avoid running UpdateActionsWindow on repeated MS_NONE modal state updates

### DIFF
--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -6646,8 +6646,9 @@ void Actor::SetModal(ieDword newstate, bool force)
 		}
 
 		//update the action bar
-		if (Modal.State != newstate || newstate != MS_NONE)
+		if (Modal.State != newstate || newstate != MS_NONE) {
 			core->SetEventFlag(EF_ACTION);
+		}
 
 		// when called with the same state twice, toggle to MS_NONE
 		if (!force && Modal.State == newstate) {

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -6645,15 +6645,16 @@ void Actor::SetModal(ieDword newstate, bool force)
 			displaymsg->DisplayStringName(ModalStates[Modal.State].leaving_str, DMC_WHITE, this, IE_STR_SOUND|IE_STR_SPEECH);
 		}
 
+		//update the action bar
+		if (Modal.State != newstate || newstate != MS_NONE)
+			core->SetEventFlag(EF_ACTION);
+
 		// when called with the same state twice, toggle to MS_NONE
 		if (!force && Modal.State == newstate) {
 			Modal.State = MS_NONE;
 		} else {
 			Modal.State = newstate;
 		}
-
-		//update the action bar
-		core->SetEventFlag(EF_ACTION);
 	} else {
 		Modal.State = newstate;
 	}


### PR DESCRIPTION
## Description
Prevents running UpdateActionsWindow on repeated MS_NONE modal state updates (while walking to open/close the door or during the spell casting).

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
