### PR TITLE
Modernize code to use override (available since C++11)

### DIFF
--- a/apple/AppleLogger.h
+++ b/apple/AppleLogger.h
@@ -26,11 +26,11 @@ namespace GemRB {
 class GEM_EXPORT AppleLogger : public StdioLogger {
 public:
 	AppleLogger();
-	virtual ~AppleLogger();
+	~AppleLogger() override;
 
-	void textcolor(log_color);
+	void textcolor(log_color) override;
 protected:
-	void LogInternal(log_level level, const char* owner, const char* message, log_color color);
+	void LogInternal(log_level level, const char* owner, const char* message, log_color color) override;
 };
 
 Logger* createAppleLogger();

--- a/gemrb/core/ActorMgr.h
+++ b/gemrb/core/ActorMgr.h
@@ -31,7 +31,7 @@ class DataStream;
 class GEM_EXPORT ActorMgr : public Plugin {
 public:
 	ActorMgr(void);
-	virtual ~ActorMgr(void);
+	~ActorMgr(void) override;
 	virtual bool Open(DataStream* stream) = 0;
 	virtual Actor* GetActor(unsigned char is_in_party) = 0;
   virtual int FindSpellType(char *name, unsigned short &level, unsigned int clsmsk, unsigned int kit) const = 0;

--- a/gemrb/core/AnimationFactory.h
+++ b/gemrb/core/AnimationFactory.h
@@ -39,7 +39,7 @@ private:
 
 public:
 	AnimationFactory(const char* ResRef);
-	~AnimationFactory(void);
+	~AnimationFactory(void) override;
 	void AddFrame(Holder<Sprite2D> frame);
 	void AddCycle(CycleEntry cycle);
 	void LoadFLT(unsigned short* buffer, int count);

--- a/gemrb/core/AnimationMgr.h
+++ b/gemrb/core/AnimationMgr.h
@@ -34,7 +34,7 @@ class Font;
 class GEM_EXPORT AnimationMgr : public Plugin {
 public:
 	AnimationMgr(void);
-	virtual ~AnimationMgr(void);
+	~AnimationMgr(void) override;
 	virtual bool Open(DataStream* stream) = 0;
 	virtual int GetCycleSize(unsigned char Cycle) = 0;
 	virtual AnimationFactory* GetAnimationFactory(const char* ResRef,

--- a/gemrb/core/ArchiveImporter.h
+++ b/gemrb/core/ArchiveImporter.h
@@ -30,7 +30,7 @@ namespace GemRB {
 class GEM_EXPORT ArchiveImporter : public Plugin {
 public:
 	ArchiveImporter(void);
-	virtual ~ArchiveImporter(void);
+	~ArchiveImporter(void) override;
 	virtual int CreateArchive(DataStream *stream) = 0;
 	//decompressing a .sav file similar to CBF
 	virtual int DecompressSaveGame(DataStream *compressed) = 0;

--- a/gemrb/core/Audio.h
+++ b/gemrb/core/Audio.h
@@ -75,7 +75,7 @@ public:
 	virtual void SetPos(int XPos, int YPos) = 0;
 	virtual void Stop() = 0;
 	virtual void StopLooping() = 0;
-	virtual ~SoundHandle();
+	~SoundHandle() override;
 };
 
 class GEM_EXPORT Channel {
@@ -101,7 +101,7 @@ public:
 	static const TypeID ID;
 public:
 	Audio(void);
-	virtual ~Audio();
+	~Audio() override;
 	virtual bool Init(void) = 0;
 	virtual Holder<SoundHandle> Play(const char* ResRef, unsigned int channel,
 				int XPos, int YPos, unsigned int flags = 0, unsigned int *length = 0) = 0;

--- a/gemrb/core/Compressor.h
+++ b/gemrb/core/Compressor.h
@@ -29,7 +29,7 @@ namespace GemRB {
 class GEM_EXPORT Compressor : public Plugin {
 public:
 	Compressor(void);
-	virtual ~Compressor(void);
+	~Compressor(void) override;
 	/** decompresses a datastream (memory or file) to a FILE * stream */
 	virtual int Decompress(DataStream* dest, DataStream* source, unsigned int size_guess = 0) const = 0;
 	/** compresses a datastream (memory or file) to another DataStream */

--- a/gemrb/core/DataFileMgr.h
+++ b/gemrb/core/DataFileMgr.h
@@ -41,7 +41,7 @@ namespace GemRB {
 class GEM_EXPORT DataFileMgr : public Plugin {
 public:
 	DataFileMgr(void);
-	virtual ~DataFileMgr(void);
+	~DataFileMgr(void) override;
 	virtual bool Open(DataStream* stream) = 0;
 	virtual int GetTagsCount() const = 0;
 	virtual const char* GetTagNameByIndex(int index) const = 0;

--- a/gemrb/core/DialogMgr.h
+++ b/gemrb/core/DialogMgr.h
@@ -30,7 +30,7 @@ namespace GemRB {
 class GEM_EXPORT DialogMgr : public Plugin {
 public:
 	DialogMgr(void);
-	virtual ~DialogMgr(void);
+	~DialogMgr(void) override;
 	virtual bool Open(DataStream* stream) = 0;
 	virtual Dialog* GetDialog() const = 0;
 	virtual Condition* GetCondition(char *string) const = 0;

--- a/gemrb/core/EffectMgr.h
+++ b/gemrb/core/EffectMgr.h
@@ -42,7 +42,7 @@ namespace GemRB {
 class GEM_EXPORT EffectMgr : public Plugin {
 public:
 	EffectMgr(void);
-	virtual ~EffectMgr(void);
+	~EffectMgr(void) override;
 	virtual bool Open(DataStream* stream, bool autoFree = true) = 0;
 
 	/** Fills fx with Effect data loaded from the stream */

--- a/gemrb/core/FontManager.h
+++ b/gemrb/core/FontManager.h
@@ -35,7 +35,7 @@ public:
 public:
 	// Public methods
 	FontManager();
-	virtual ~FontManager(void);
+	~FontManager(void) override;
 
 	virtual Font* GetFont(ieWord pxSize, FontStyle style, PaletteHolder = nullptr)=0;
 };

--- a/gemrb/core/GUI/Button.h
+++ b/gemrb/core/GUI/Button.h
@@ -114,17 +114,17 @@ enum BUTTON_IMAGE_TYPE {
 class GEM_EXPORT Button : public Control {
 public:
 	Button(Region& frame);
-	~Button();
+	~Button() override;
 
-	bool IsAnimated() const;
-	bool IsOpaque() const;
+	bool IsAnimated() const override;
+	bool IsOpaque() const override;
 	/** Sets the 'type' Image of the Button to 'img'.
 	see 'BUTTON_IMAGE_TYPE' */
 	void SetImage(BUTTON_IMAGE_TYPE, Holder<Sprite2D> img);
 	/** Sets the Button State */
 	void SetState(unsigned char state);
 	/** Sets the Text of the current control */
-	void SetText(const String& string);
+	void SetText(const String& string) override;
 	/** Sets the Picture */
 	void SetPicture(Holder<Sprite2D> Picture);
 	/** Clears the list of Pictures */
@@ -140,17 +140,17 @@ public:
 	/** Enables or disables specified border/frame */
 	void EnableBorder(int index, bool enabled);
 
-	String QueryText() const { return Text; }
-	String TooltipText() const;
+	String QueryText() const override { return Text; }
+	String TooltipText() const override;
 
-	bool AcceptsDragOperation(const DragOp&) const;
-	void CompleteDragOperation(const DragOp&);
-	Holder<Sprite2D> DragCursor() const;
+	bool AcceptsDragOperation(const DragOp&) const override;
+	void CompleteDragOperation(const DragOp&) override;
+	Holder<Sprite2D> DragCursor() const override;
 
-	Holder<Sprite2D> Cursor() const;
+	Holder<Sprite2D> Cursor() const override;
 
 	/** Refreshes the button from a radio group */
-	void UpdateState(unsigned int Sum);
+	void UpdateState(unsigned int Sum) override;
 	/** Set palette used for drawing button label in normal state.  */
 	void SetTextColor(const Color &fore, const Color &back);
 	/** Sets percent (0-1.0) of width for clipping picture */
@@ -203,24 +203,24 @@ private: // Private attributes
 	void UnregisterHotKey();
 
 	bool HandleHotKey(const Event&);
-	bool HitTest (const Point&) const;
+	bool HitTest (const Point&) const override;
 	void DoToggle();
 
-	void WillDraw(const Region& /*drawFrame*/, const Region& /*clip*/);
+	void WillDraw(const Region& /*drawFrame*/, const Region& /*clip*/) override;
 	/** Draws the Control on the Output Display */
-	void DrawSelf(Region drawFrame, const Region& clip);
+	void DrawSelf(Region drawFrame, const Region& clip) override;
 	
 protected:
 	/** Mouse Enter */
-	void OnMouseEnter(const MouseEvent& /*me*/, const DragOp*);
+	void OnMouseEnter(const MouseEvent& /*me*/, const DragOp*) override;
 	/** Mouse Leave */
-	void OnMouseLeave(const MouseEvent& /*me*/, const DragOp*);
+	void OnMouseLeave(const MouseEvent& /*me*/, const DragOp*) override;
 	/** Mouse Over */
-	bool OnMouseOver(const MouseEvent&);
+	bool OnMouseOver(const MouseEvent&) override;
 	/** Mouse Button Down */
-	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short Mod);
+	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short Mod) override;
 	/** Mouse Button Up */
-	bool OnMouseUp(const MouseEvent& /*me*/, unsigned short Mod);
+	bool OnMouseUp(const MouseEvent& /*me*/, unsigned short Mod) override;
 };
 
 }

--- a/gemrb/core/GUI/Console.h
+++ b/gemrb/core/GUI/Console.h
@@ -57,15 +57,15 @@ private:
 
 public:
 	Console(const Region& frame, TextArea* ta);
-	~Console();
+	~Console() override;
 
 	/** Sets the Text of the current control */
 	void SetText(const String& string);
 	bool SetEvent(int eventType, ControlEventHandler handler);
 	bool Execute(const String&);
 
-	void DidFocus() { textContainer.DidFocus(); }
-	void DidUnFocus() { textContainer.DidUnFocus(); }
+	void DidFocus() override { textContainer.DidFocus(); }
+	void DidUnFocus() override { textContainer.DidUnFocus(); }
 
 private:
 	void UpdateTextArea();
@@ -76,9 +76,9 @@ private:
 	
 protected:
 	/** Key Press Event */
-	bool OnKeyPress(const KeyboardEvent& Key, unsigned short Mod);
-	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short /*Mod*/);
-	void OnTextInput(const TextEvent& /*te*/);
+	bool OnKeyPress(const KeyboardEvent& Key, unsigned short Mod) override;
+	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short /*Mod*/) override;
+	void OnTextInput(const TextEvent& /*te*/) override;
 };
 
 }

--- a/gemrb/core/GUI/Control.h
+++ b/gemrb/core/GUI/Control.h
@@ -113,7 +113,7 @@ public: // Public attributes
 			return static_cast<Control*>(dropView);
 		}
 		
-		~ControlDragOp() {
+		~ControlDragOp() override {
 			Control* src = Source();
 			ActionKey srckey(Action::DragDropSource);
 			
@@ -147,9 +147,9 @@ public: // Public attributes
 
 public:
 	Control(const Region& frame);
-	virtual ~Control();
+	~Control() override;
 
-	virtual bool IsAnimated() const override { return animation && AnimPicture; }
+	bool IsAnimated() const override { return animation && AnimPicture; }
 	bool IsOpaque() const override;
 
 	/** Sets the Text of the current control */

--- a/gemrb/core/GUI/GUIAnimation.h
+++ b/gemrb/core/GUI/GUIAnimation.h
@@ -71,8 +71,8 @@ public:
 	}
 
 private:
-	Point GenerateNext(unsigned long time);
-	bool HasEnded() const;
+	Point GenerateNext(unsigned long time) override;
+	bool HasEnded() const override;
 };
 
 class ColorCycle {
@@ -120,8 +120,8 @@ public:
 	}
 
 private:
-	Color GenerateNext(unsigned long time);
-	bool HasEnded() const;
+	Color GenerateNext(unsigned long time) override;
+	bool HasEnded() const override;
 };
 
 }

--- a/gemrb/core/GUI/GUIFactory.h
+++ b/gemrb/core/GUI/GUIFactory.h
@@ -50,7 +50,7 @@ protected:
 public:
 	GUIFactory()
 	: winmgr(NULL) {};
-	virtual ~GUIFactory() {};
+	~GUIFactory() override {};
 
 	void SetWindowManager(WindowManager& mgr) { winmgr = &mgr; }
 

--- a/gemrb/core/GUI/GUIScriptInterface.h
+++ b/gemrb/core/GUI/GUIScriptInterface.h
@@ -32,12 +32,12 @@ public:
 	ViewScriptingRef(View* view, ScriptingId id, ResRef group)
 	: ScriptingRef(view, id), group(group) {}
 
-	const ResRef& ScriptingGroup() const {
+	const ResRef& ScriptingGroup() const override {
 		return group;
 	}
 
 	// class to instantiate on the script side (Python)
-	virtual const ScriptingClassId ScriptingClass() const {
+	const ScriptingClassId ScriptingClass() const override {
 		return {"View"};
 	};
 
@@ -56,12 +56,12 @@ public:
 	: ViewScriptingRef(win, id, winpack) {}
 
 	// class to instantiate on the script side (Python)
-	virtual const ScriptingClassId ScriptingClass() const {
+	const ScriptingClassId ScriptingClass() const override {
 		static ScriptingClassId cls("Window");
 		return cls;
 	};
 
-	virtual ViewScriptingRef* Clone(ScriptingId id, ResRef group) const {
+	ViewScriptingRef* Clone(ScriptingId id, ResRef group) const override {
 		return new WindowScriptingRef(static_cast<Window*>(GetObject()), id, group);
 	}
 };
@@ -74,7 +74,7 @@ public:
 	: ViewScriptingRef(ctrl, id, group) {}
 
 	// class to instantiate on the script side (Python)
-	const ScriptingClassId ScriptingClass() const {
+	const ScriptingClassId ScriptingClass() const override {
 		Control* ctrl = static_cast<Control*>(GetObject());
 
 		// would just use type_info here, but its implementation specific...
@@ -94,7 +94,7 @@ public:
 		}
 	};
 
-	virtual ViewScriptingRef* Clone(ScriptingId id, ResRef group) const {
+	ViewScriptingRef* Clone(ScriptingId id, ResRef group) const override {
 		return new ControlScriptingRef(static_cast<Control*>(GetObject()), id, group);
 	}
 };

--- a/gemrb/core/GUI/GameControl.h
+++ b/gemrb/core/GUI/GameControl.h
@@ -153,7 +153,7 @@ private:
 	void HandleDoor(Door *door, Actor *actor);
 	
 	void UpdateCursor();
-	bool IsDisabledCursor() const;
+	bool IsDisabledCursor() const override;
 
 	void PerformSelectedAction(const Point& p);
 	void CommandSelectedMovement(const Point& p, bool append = false, bool tryToRun = false);
@@ -163,18 +163,18 @@ private:
 	bool OnGlobalMouseMove(const Event&);
 
 	/** Draws the Control on the Output Display */
-	void DrawSelf(Region drawFrame, const Region& clip);
-	void WillDraw(const Region& /*drawFrame*/, const Region& /*clip*/);
+	void DrawSelf(Region drawFrame, const Region& clip) override;
+	void WillDraw(const Region& /*drawFrame*/, const Region& /*clip*/) override;
 	
-	bool CanLockFocus() const { return true; };
-	void FlagsChanged(unsigned int /*oldflags*/);
+	bool CanLockFocus() const override { return true; };
+	void FlagsChanged(unsigned int /*oldflags*/) override;
 
 public:
 	GameControl(const Region& frame);
-	~GameControl(void);
+	~GameControl(void) override;
 
 	// GameControl always needs to redraw unless we arent in a game (disabled)
-	bool IsAnimated() const { return !IsDisabled(); }
+	bool IsAnimated() const override { return !IsDisabled(); }
 	void DrawTargetReticle(int size, const Color& color, const Point& p) const;
 	/** Draws the target reticle for Actor movement. */
 	void DrawTargetReticle(const Movable* target, const Point& point) const;
@@ -183,7 +183,7 @@ public:
 	void SetTracker(Actor *actor, ieDword dist);
 
 	void DrawTooltip(const Point& p) const;
-	String TooltipText() const;
+	String TooltipText() const override;
 
 	void SetTargetMode(int mode);
 	int GetTargetMode() { return target_mode; }
@@ -216,7 +216,7 @@ public:
 
 	// returns the default cursor fitting the targeting mode
 	Holder<Sprite2D> GetTargetActionCursor() const;
-	Holder<Sprite2D> Cursor() const;
+	Holder<Sprite2D> Cursor() const override;
 
 	bool HandleActiveRegion(InfoPoint *trap, Actor *actor, const Point& p);
 
@@ -244,27 +244,27 @@ public:
 protected:
 	//Events
 	/** Key Press Event */
-	bool OnKeyPress(const KeyboardEvent& Key, unsigned short Mod);
+	bool OnKeyPress(const KeyboardEvent& Key, unsigned short Mod) override;
 	/** Key Release Event */
-	bool OnKeyRelease(const KeyboardEvent& Key, unsigned short Mod);
+	bool OnKeyRelease(const KeyboardEvent& Key, unsigned short Mod) override;
 	/** Mouse Over Event */
-	bool OnMouseOver(const MouseEvent&);
-	bool OnMouseDrag(const MouseEvent& /*me*/);
+	bool OnMouseOver(const MouseEvent&) override;
+	bool OnMouseDrag(const MouseEvent& /*me*/) override;
 
-	bool OnTouchDown(const TouchEvent& /*te*/, unsigned short /*Mod*/);
-	bool OnTouchUp(const TouchEvent& /*te*/, unsigned short /*Mod*/);
-	bool OnTouchGesture(const GestureEvent& gesture);
+	bool OnTouchDown(const TouchEvent& /*te*/, unsigned short /*Mod*/) override;
+	bool OnTouchUp(const TouchEvent& /*te*/, unsigned short /*Mod*/) override;
+	bool OnTouchGesture(const GestureEvent& gesture) override;
 
 	/** Currently only deals with the GEM_TAB exception */
 	bool DispatchEvent(const Event& event);
 	
 	/** Mouse Button Down */
-	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short Mod);
+	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short Mod) override;
 	/** Mouse Button Up */
-	bool OnMouseUp(const MouseEvent& /*me*/, unsigned short Mod);
-	bool OnMouseWheelScroll(const Point& delta);
+	bool OnMouseUp(const MouseEvent& /*me*/, unsigned short Mod) override;
+	bool OnMouseWheelScroll(const Point& delta) override;
 	
-	bool OnControllerButtonDown(const ControllerEvent& ce);
+	bool OnControllerButtonDown(const ControllerEvent& ce) override;
 };
 
 }

--- a/gemrb/core/GUI/Label.h
+++ b/gemrb/core/GUI/Label.h
@@ -49,15 +49,15 @@ using PaletteHolder = Holder<Palette>;
 class GEM_EXPORT Label : public Control {
 private:
 	/** Draws the Control on the Output Display */
-	void DrawSelf(Region drawFrame, const Region& clip);
+	void DrawSelf(Region drawFrame, const Region& clip) override;
 
 public: 
 	Label(const Region& frame, Font* font, const String& string);
-	~Label();
+	~Label() override;
 
 	/** This function sets the actual Label Text */
 	using Control::SetText;
-	void SetText(const String& string);
+	void SetText(const String& string) override;
 	/** Sets the Foreground Font Color */
 	void SetColor(Color col, Color bac);
 	/** Set the font being used */
@@ -65,7 +65,7 @@ public:
 	/** Sets the Alignment of Text */
 	void SetAlignment(unsigned char Alignment);
 	/** Simply returns the pointer to the text, don't modify it! */
-	String QueryText() const;
+	String QueryText() const override;
 
 private: // Private attributes
 	/** Text String Buffer */

--- a/gemrb/core/GUI/MapControl.h
+++ b/gemrb/core/GUI/MapControl.h
@@ -60,8 +60,8 @@ public:
 	MapControl(const Region& frame, AnimationFactory* af);
 
 	/** Refreshes the control after its associated variable has changed */
-	void UpdateState(unsigned int Sum);
-	bool IsAnimated() const { return true; } // map must constantly update actor positions
+	void UpdateState(unsigned int Sum) override;
+	bool IsAnimated() const override { return true; } // map must constantly update actor positions
 
 private:
 	/** Call event handler on click */
@@ -74,9 +74,9 @@ private:
 	const MapNote* MapNoteAtPoint(const Point& p) const;
 
 	Region GetViewport() const;
-	void WillDraw(const Region& /*drawFrame*/, const Region& /*clip*/);
+	void WillDraw(const Region& /*drawFrame*/, const Region& /*clip*/) override;
 	/** Draws the Control on the Output Display */
-	void DrawSelf(Region drawFrame, const Region& clip);
+	void DrawSelf(Region drawFrame, const Region& clip) override;
 	void DrawFog(const Region& rgn) const;
 	
 	Point ConvertPointToGame(Point) const;
@@ -84,14 +84,14 @@ private:
 	
 protected:
 	/** Key Press Event */
-	bool OnKeyPress(const KeyboardEvent& Key, unsigned short Mod);
+	bool OnKeyPress(const KeyboardEvent& Key, unsigned short Mod) override;
 	/** Mouse Over Event */
-	bool OnMouseOver(const MouseEvent&);
-	bool OnMouseDrag(const MouseEvent& /*me*/);
+	bool OnMouseOver(const MouseEvent&) override;
+	bool OnMouseDrag(const MouseEvent& /*me*/) override;
 	/** Mouse Button Down */
-	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short Mod);
+	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short Mod) override;
 	/** Mouse Button Up */
-	bool OnMouseUp(const MouseEvent& /*me*/, unsigned short Mod);
+	bool OnMouseUp(const MouseEvent& /*me*/, unsigned short Mod) override;
 };
 
 }

--- a/gemrb/core/GUI/Progressbar.h
+++ b/gemrb/core/GUI/Progressbar.h
@@ -43,7 +43,7 @@ namespace GemRB {
 class GEM_EXPORT Progressbar : public Control  {
 private:
 	/** Draws the Control on the Output Display */
-	void DrawSelf(Region drawFrame, const Region& clip);
+	void DrawSelf(Region drawFrame, const Region& clip) override;
 
 public:
 	struct Action {
@@ -52,9 +52,9 @@ public:
 	};
 
 	Progressbar(const Region& frame, unsigned short KnobStepsCount);
-	~Progressbar();
+	~Progressbar() override;
 
-	bool IsOpaque() const;
+	bool IsOpaque() const override;
 
 	void SetImages(Holder<Sprite2D> bg, Holder<Sprite2D> cap);
 	/** Sets a bam resource for progressbar */
@@ -62,7 +62,7 @@ public:
 	/** Sets the mos coordinates for the progressbar filler mos/cap */
 	void SetSliderPos(const Point& knob, const Point& cap);
 	/** Refreshes a progressbar which is associated with VariableName */
-	void UpdateState(unsigned int Sum);
+	void UpdateState(unsigned int Sum) override;
 
 private: // Private attributes
 	Holder<Sprite2D> BackGround2; //mos resource for the filling of the bar

--- a/gemrb/core/GUI/ScrollBar.h
+++ b/gemrb/core/GUI/ScrollBar.h
@@ -66,18 +66,18 @@ public:
 	ScrollBar(const ScrollBar& sb);
 	ScrollBar& operator=(const ScrollBar& sb);
 
-	bool IsOpaque() const;
+	bool IsOpaque() const override;
 
 	/* scroll so the slider is centered at point p */
-	void ScrollDelta(const Point& p);
-	void ScrollTo(const Point& p);
+	void ScrollDelta(const Point& p) override;
+	void ScrollTo(const Point& p) override;
 	void ScrollUp();
 	void ScrollDown();
 	void ScrollBySteps(int steps);
 
 	/** refreshes scrollbar if associated with VarName */
-	void UpdateState(unsigned int Sum);
-	bool TracksMouseDown() const { return true; }
+	void UpdateState(unsigned int Sum) override;
+	bool TracksMouseDown() const override { return true; }
 
 private: //Private attributes
 	/** Images for drawing the Scroll Bar */
@@ -102,25 +102,25 @@ private:
 		SetFrameSize(s);
 	}
 
-	void DrawSelf(Region drawFrame, const Region& clip);
+	void DrawSelf(Region drawFrame, const Region& clip) override;
 	Point AxisPosFromValue() const;
 	int GetFrameHeight(int frame) const;
 	/** Range of the slider in pixels. The height - buttons - slider */
 	int SliderPxRange() const;
 	
-	bool IsPerPixelScrollable() const { return false; }
+	bool IsPerPixelScrollable() const override { return false; }
 	
 protected:
 	/** Mouse Button Down */
-	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short Mod);
+	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short Mod) override;
 	/** Mouse Button Up */
-	bool OnMouseUp(const MouseEvent& /*me*/, unsigned short Mod);
+	bool OnMouseUp(const MouseEvent& /*me*/, unsigned short Mod) override;
 	/** Mouse Drag Event */
-	bool OnMouseDrag(const MouseEvent&);
+	bool OnMouseDrag(const MouseEvent&) override;
 	/** Mouse Wheel Scroll Event */
-	bool OnMouseWheelScroll(const Point& delta);
+	bool OnMouseWheelScroll(const Point& delta) override;
 	
-	bool OnKeyPress(const KeyboardEvent& /*Key*/, unsigned short /*Mod*/);
+	bool OnKeyPress(const KeyboardEvent& /*Key*/, unsigned short /*Mod*/) override;
 };
 
 }

--- a/gemrb/core/GUI/ScrollView.h
+++ b/gemrb/core/GUI/ScrollView.h
@@ -30,19 +30,19 @@ namespace GemRB {
 
 		class ContentView : public View {
 		private:
-			void SizeChanged(const Size& /* oldsize */);
+			void SizeChanged(const Size& /* oldsize */) override;
 			
-			void SubviewAdded(View* view, View* parent);
-			void SubviewRemoved(View* view, View* parent);
+			void SubviewAdded(View* view, View* parent) override;
+			void SubviewRemoved(View* view, View* parent) override;
 			
-			void WillDraw(const Region& /*drawFrame*/, const Region& /*clip*/);
-			void DidDraw(const Region& /*drawFrame*/, const Region& /*clip*/);
+			void WillDraw(const Region& /*drawFrame*/, const Region& /*clip*/) override;
+			void DidDraw(const Region& /*drawFrame*/, const Region& /*clip*/) override;
 			
 		public:
 			ContentView(const Region& frame)
 			: View(frame) {}
 			
-			bool CanLockFocus() const { return false; }
+			bool CanLockFocus() const override { return false; }
 			// TODO: this should be private and happen automatically
 			void ResizeToSubviews();
 		};
@@ -70,7 +70,7 @@ namespace GemRB {
 
 	public:
 		ScrollView(const Region& frame);
-		~ScrollView();
+		~ScrollView() override;
 		
 		bool IsAnimated() const override { return animation; }
 

--- a/gemrb/core/GUI/Slider.h
+++ b/gemrb/core/GUI/Slider.h
@@ -49,7 +49,7 @@ namespace GemRB {
 class GEM_EXPORT Slider : public Control  {
 private:
 	/** Draws the Control on the Output Display */
-	void DrawSelf(Region drawFrame, const Region& clip);
+	void DrawSelf(Region drawFrame, const Region& clip) override;
 	
 	// set postion pased on a point expressed in local (frame) coordinates
 	void SetPosition(const Point& p);
@@ -67,7 +67,7 @@ public:
 	/** Sets the State of the Slider */
 	void SetState(int arg) { State=(unsigned char) arg; }
 	/** Refreshes a slider which is associated with VariableName */
-	void UpdateState(unsigned int Sum);
+	void UpdateState(unsigned int Sum) override;
 
 private: // Private attributes
 	/** Knob Image */
@@ -88,11 +88,11 @@ private: // Private attributes
 
 protected:
 	/** Mouse Button Down */
-	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short Mod);
+	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short Mod) override;
 	/** Mouse Button Up */
-	bool OnMouseUp(const MouseEvent& /*me*/, unsigned short Mod);
+	bool OnMouseUp(const MouseEvent& /*me*/, unsigned short Mod) override;
 	/** Mouse Over Event */
-	bool OnMouseDrag(const MouseEvent& /*me*/);
+	bool OnMouseDrag(const MouseEvent& /*me*/) override;
 };
 
 }

--- a/gemrb/core/GUI/TextArea.h
+++ b/gemrb/core/GUI/TextArea.h
@@ -48,7 +48,7 @@ static const Color SelectOptionSelected(55, 100, 0, 0);// default selected color
 class GEM_EXPORT TextArea : public Control, public View::Scrollable {
 private:
 	/** Draws the Control on the Output Display */
-	void DrawSelf(Region drawFrame, const Region& clip);
+	void DrawSelf(Region drawFrame, const Region& clip) override;
 	
 	class SpanSelector : public ContentContainer {
 		struct OptSpan : public TextContainer {
@@ -56,12 +56,12 @@ private:
 			: TextContainer(frame, font, pal) {}
 			
 			// forward OnMouseLeave to superview (SpanSelector) as a mouse over
-			void OnMouseLeave(const MouseEvent& me, const DragOp*) {
+			void OnMouseLeave(const MouseEvent& me, const DragOp*) override {
 				assert(superView);
 				superView->MouseOver(me);
 			}
 
-			bool Editable() const { return false; }
+			bool Editable() const override { return false; }
 		};
 	private:
 		TextArea& ta;
@@ -74,14 +74,14 @@ private:
 		TextContainer* TextAtPoint(const Point&);
 		TextContainer* TextAtIndex(size_t idx);
 
-		bool OnMouseOver(const MouseEvent& /*me*/);
-		bool OnMouseUp(const MouseEvent& /*me*/, unsigned short Mod);
-		void OnMouseLeave(const MouseEvent& /*me*/, const DragOp*);
+		bool OnMouseOver(const MouseEvent& /*me*/) override;
+		bool OnMouseUp(const MouseEvent& /*me*/, unsigned short Mod) override;
+		void OnMouseLeave(const MouseEvent& /*me*/, const DragOp*) override;
 
-		bool OnKeyPress(const KeyboardEvent& /*Key*/, unsigned short /*Mod*/);
+		bool OnKeyPress(const KeyboardEvent& /*Key*/, unsigned short /*Mod*/) override;
 		bool KeyEvent(const Event& event);
 
-		void SizeChanged(const Size&);
+		void SizeChanged(const Size&) override;
 
 		bool Editable() const { return false; }
 
@@ -89,13 +89,13 @@ private:
 		// FIXME: we get messed up is SetMargin is called. there is no notification that they have changed and so our subviews are overflowing.
 		// working around that by passing them in the ctor, but its a poor fix.
 		SpanSelector(TextArea& ta, const std::vector<const String*>&, bool numbered, ContentContainer::Margin m = Margin());
-		~SpanSelector();
+		~SpanSelector() override;
 
 		size_t NumOpts() const { return size;};
 		void MakeSelection(size_t idx);
 		TextContainer* Selection() const { return selectedSpan; }
 		
-		bool CanLockFocus() const { return false; }
+		bool CanLockFocus() const override { return false; }
 	};
 
 public:
@@ -103,10 +103,10 @@ public:
 	TextArea(const Region& frame, Font* text, Font* caps,
 			 Color hitextcolor, Color initcolor, Color lowtextcolor);
 
-	bool IsOpaque() const { return false; }
+	bool IsOpaque() const override { return false; }
 
 	/** Sets the Actual Text */
-	void SetText(const String& text);
+	void SetText(const String& text) override;
 	/** Clears the textarea */
 	void ClearText();
 
@@ -116,8 +116,8 @@ public:
 	// int InsertText(const char* text, int pos);
 
 	/** Per Pixel scrolling */
-	void ScrollDelta(const Point& p);
-	void ScrollTo(const Point& p);
+	void ScrollDelta(const Point& p) override;
+	void ScrollTo(const Point& p) override;
 	void ScrollToY(int y, ieDword lineduration = 0);
 	int ContentHeight() const;
 
@@ -130,19 +130,19 @@ public:
 	void SelectAvailableOption(size_t idx);
 	/** Set Selectable */
 	void SetSelectable(bool val);
-	void SetAnimPicture(Holder<Sprite2D> Picture);
+	void SetAnimPicture(Holder<Sprite2D> Picture) override;
 
 	ContentContainer::Margin GetMargins() const;
 	void SetMargins(ContentContainer::Margin m);
 
 	/** Returns the selected text */
-	String QueryText() const;
+	String QueryText() const override;
 	/** Marks textarea for redraw with a new value */
-	void UpdateState(unsigned int optIdx);
-	void DidFocus();
-	void DidUnFocus();
+	void UpdateState(unsigned int optIdx) override;
+	void DidFocus() override;
+	void DidUnFocus() override;
 	
-	void AddSubviewInFrontOfView(View*, const View* = NULL);
+	void AddSubviewInFrontOfView(View*, const View* = NULL) override;
 
 private: // Private attributes
 	// dialog and listbox handling
@@ -177,8 +177,8 @@ private: //internal functions
 
 	void UpdateScrollview();
 	Region UpdateTextFrame();
-	void SizeChanged(const Size&) { UpdateScrollview(); }
-	void FlagsChanged(unsigned int /*oldflags*/);
+	void SizeChanged(const Size&) override { UpdateScrollview(); }
+	void FlagsChanged(unsigned int /*oldflags*/) override;
 
 	int TextHeight() const;
 	int OptionsHeight() const;

--- a/gemrb/core/GUI/TextEdit.h
+++ b/gemrb/core/GUI/TextEdit.h
@@ -47,11 +47,11 @@ private:
 private:
 	// TextContainer can respond to keys by itself, but we want to interpose so we can capture return/esc
 	// we simply forward all other key presses. For this to work textContainer needs View::IgnoreEvents set
-	bool OnKeyPress(const KeyboardEvent& Key, unsigned short Mod);
+	bool OnKeyPress(const KeyboardEvent& Key, unsigned short Mod) override;
 
 	// this forwards to textContainer. only needed because we set View::IgnoreEvents on textContainer in order to interpose key events
-	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short /*Mod*/);
-	void OnTextInput(const TextEvent& /*te*/);
+	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short /*Mod*/) override;
+	void OnTextInput(const TextEvent& /*te*/) override;
 
 	void TextChanged(TextContainer& tc);
 
@@ -70,22 +70,22 @@ public:
 	};
 
 	TextEdit(const Region& frame, unsigned short maxLength, Point p);
-	~TextEdit();
+	~TextEdit() override;
 
 	// these all forward to the underlying TextContainer
 	void SetFont(Font* f);
 
 	/** Sets the Text of the current control */
-	void SetText(const String& string);
+	void SetText(const String& string) override;
 	/** Gets the Text of the current control */
-	String QueryText() const;
+	String QueryText() const override;
 	/** Sets the buffer length */
 	void SetBufferLength(size_t buflen);
 	/** Sets the alignment */
 	void SetAlignment(unsigned char Alignment);
 
-	void DidFocus() { textContainer.DidFocus(); }
-	void DidUnFocus() { textContainer.DidUnFocus(); }
+	void DidFocus() override { textContainer.DidFocus(); }
+	void DidUnFocus() override { textContainer.DidUnFocus(); }
 };
 
 }

--- a/gemrb/core/GUI/TextSystem/Font.h
+++ b/gemrb/core/GUI/TextSystem/Font.h
@@ -113,7 +113,7 @@ private:
 				pageData = (ieByte*)calloc(pageSize.h, pageSize.w);
 			}
 
-			~GlyphAtlasPage() {
+			~GlyphAtlasPage() override {
 				if (Sheet == NULL) {
 					free(pageData);
 				}

--- a/gemrb/core/GUI/TextSystem/TextContainer.h
+++ b/gemrb/core/GUI/TextSystem/TextContainer.h
@@ -182,7 +182,7 @@ protected:
 
 public:
 	ContentContainer(const Region& frame);
-	virtual ~ContentContainer();
+	~ContentContainer() override;
 
 	// append a container to the end of the container. The container takes ownership of the span.
 	virtual void AppendContent(Content* content);
@@ -207,7 +207,7 @@ public:
 	inline void SetMargin(ieByte top) { SetMargin(top, top, top, top); }
 
 protected:
-	void SubviewAdded(View* view, View* parent);
+	void SubviewAdded(View* view, View* parent) override;
 	void LayoutContentsFrom(ContentList::const_iterator);
 	void LayoutContentsFrom(const Content*);
 	Content* RemoveContent(const Content* content, bool doLayout);
@@ -217,16 +217,16 @@ protected:
 	const Layout& LayoutForContent(const Content*) const;
 	const Layout* LayoutAtPoint(const Point& p) const;
 
-	void DrawSelf(Region drawFrame, const Region& clip);
+	void DrawSelf(Region drawFrame, const Region& clip) override;
 	virtual void DrawContents(const Layout& layout, Point point);
 	
-	void SizeChanged(const Size& oldSize);
+	void SizeChanged(const Size& oldSize) override;
 
 private:
 	virtual void ContentRemoved(const Content* /*content*/) {};
 	
-	void WillDraw(const Region& /*drawFrame*/, const Region& /*clip*/);
-	void DidDraw(const Region& /*drawFrame*/, const Region& /*clip*/);
+	void WillDraw(const Region& /*drawFrame*/, const Region& /*clip*/) override;
+	void DidDraw(const Region& /*drawFrame*/, const Region& /*clip*/) override;
 };
 
 // TextContainers can hold any content, but they represent a string of text that is divided into TextSpans
@@ -245,7 +245,7 @@ private:
 private:
 	String TextFrom(ContentList::const_iterator) const;
 
-	void ContentRemoved(const Content* content);
+	void ContentRemoved(const Content* content) override;
 
 	void MoveCursorToPoint(const Point& p);
 	LayoutRegions::const_iterator FindCursorRegion(const Layout&);
@@ -254,16 +254,16 @@ private:
 	void InsertText(const String& text);
 	void DeleteText(size_t len);
 
-	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short /*Mod*/);
-	bool OnMouseDrag(const MouseEvent& /*me*/);
-	bool OnKeyPress(const KeyboardEvent& /*Key*/, unsigned short /*Mod*/);
-	void OnTextInput(const TextEvent& /*te*/);
+	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short /*Mod*/) override;
+	bool OnMouseDrag(const MouseEvent& /*me*/) override;
+	bool OnKeyPress(const KeyboardEvent& /*Key*/, unsigned short /*Mod*/) override;
+	void OnTextInput(const TextEvent& /*te*/) override;
 
-	void DrawSelf(Region drawFrame, const Region& clip);
-	virtual void DrawContents(const Layout& layout, Point point);
+	void DrawSelf(Region drawFrame, const Region& clip) override;
+	void DrawContents(const Layout& layout, Point point) override;
 
 	virtual bool Editable() const { return IsReceivingEvents(); }
-	void SizeChanged(const Size& oldSize);
+	void SizeChanged(const Size& oldSize) override;
 
 	typedef std::pair<size_t, ContentList::iterator> ContentIndex;
 	ContentIndex FindContentForChar(size_t idx);
@@ -276,8 +276,8 @@ public:
 	String TextFrom(const Content*) const;
 	String Text() const;
 
-	void DidFocus();
-	void DidUnFocus();
+	void DidFocus() override;
+	void DidUnFocus() override;
 
 	void SetPalette(Holder<Palette> pal);
 	Holder<Palette> TextPalette() const { return palette; }

--- a/gemrb/core/GUI/WorldMapControl.h
+++ b/gemrb/core/GUI/WorldMapControl.h
@@ -55,14 +55,14 @@ class WorldMapControl;
 class GEM_EXPORT WorldMapControl : public Control, public View::Scrollable {
 private:
 	/** Draws the Control on the Output Display */
-	void DrawSelf(Region drawFrame, const Region&);
+	void DrawSelf(Region drawFrame, const Region&) override;
 
 public:
 	WorldMapControl(const Region& frame, const char *fontname, int direction);
 
 	/** Allows modification of the scrolling factor from outside */
-	void ScrollDelta(const Point& delta);
-	void ScrollTo(const Point& pos);
+	void ScrollDelta(const Point& delta) override;
+	void ScrollTo(const Point& pos) override;
 	/** Sets the exit direction (we need this to calculate distances) */
 	void SetDirection(int direction);
 	/** Set color for one type of area labels */
@@ -74,18 +74,18 @@ public:
 
 protected:
 	/** Mouse Over Event */
-	bool OnMouseOver(const MouseEvent& /*me*/);
-	bool OnMouseDrag(const MouseEvent& /*me*/);
+	bool OnMouseOver(const MouseEvent& /*me*/) override;
+	bool OnMouseDrag(const MouseEvent& /*me*/) override;
 	/** Mouse Leave Event */
-	void OnMouseLeave(const MouseEvent& /*me*/, const DragOp*);
+	void OnMouseLeave(const MouseEvent& /*me*/, const DragOp*) override;
 	/** Mouse Button Down */
-	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short Mod);
+	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short Mod) override;
 	/** Mouse Button Up */
-	bool OnMouseUp(const MouseEvent& /*me*/, unsigned short Mod);
+	bool OnMouseUp(const MouseEvent& /*me*/, unsigned short Mod) override;
 	/** Mouse Wheel Event */
-	bool OnMouseWheelScroll(const Point& delta);
+	bool OnMouseWheelScroll(const Point& delta) override;
 
-	bool OnKeyPress(const KeyboardEvent& /*Key*/, unsigned short /*Mod*/);
+	bool OnKeyPress(const KeyboardEvent& /*Key*/, unsigned short /*Mod*/) override;
 
 private:
 	//font for printing area names

--- a/gemrb/core/Game.h
+++ b/gemrb/core/Game.h
@@ -246,7 +246,7 @@ typedef int CRRow[MAX_CRLEVEL];
 class GEM_EXPORT Game : public Scriptable {
 public:
 	Game(void);
-	~Game(void);
+	~Game(void) override;
 private:
 	std::vector< Actor*> PCs;
 	std::vector< Actor*> NPCs;

--- a/gemrb/core/ImageMgr.h
+++ b/gemrb/core/ImageMgr.h
@@ -41,7 +41,7 @@ public:
 	static const TypeID ID;
 public:
 	ImageMgr(void);
-	virtual ~ImageMgr(void);
+	~ImageMgr(void) override;
 	/** Returns a \ref Sprite2D containing the image. */
 	virtual Holder<Sprite2D> GetSprite2D() = 0;
 	virtual Image* GetImage();

--- a/gemrb/core/ImageWriter.h
+++ b/gemrb/core/ImageWriter.h
@@ -28,7 +28,7 @@ namespace GemRB {
 class GEM_EXPORT ImageWriter : public Plugin {
 public:
 	ImageWriter(void);
-	~ImageWriter(void);
+	~ImageWriter(void) override;
 
 	/** Writes an Sprite2D to a stream and frees the sprite. */
 	virtual void PutImage(DataStream *output, Holder<Sprite2D> sprite) = 0;

--- a/gemrb/core/IndexedArchive.h
+++ b/gemrb/core/IndexedArchive.h
@@ -30,7 +30,7 @@ namespace GemRB {
 class GEM_EXPORT IndexedArchive : public Plugin {
 public:
 	IndexedArchive(void);
-	virtual ~IndexedArchive(void);
+	~IndexedArchive(void) override;
 	virtual int OpenArchive(const char* filename) = 0;
 	virtual DataStream* GetStream(unsigned long Resource, unsigned long Type) = 0;
 };

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -2873,15 +2873,15 @@ int Interface::PlayMovie(const char* resref)
 			}
 		}
 
-		~IESubtitles() {
+		~IESubtitles() override {
 			delete cachedSub;
 		}
 
-		size_t NextSubtitleFrame() const {
+		size_t NextSubtitleFrame() const override {
 			return nextSubFrame;
 		}
 
-		const String& SubtitleAtFrame(size_t frameNum) const {
+		const String& SubtitleAtFrame(size_t frameNum) const override {
 			// FIXME: we cant go backwards now... we dont need to, but this is ugly
 			if (frameNum >= NextSubtitleFrame()) {
 				FrameMap::const_iterator it;

--- a/gemrb/core/InterfaceConfig.h
+++ b/gemrb/core/InterfaceConfig.h
@@ -56,7 +56,7 @@ private:
 
 public:
 	CFGConfig(int argc, char *argv[]);
-	~CFGConfig();
+	~CFGConfig() override;
 
 	bool IsValidConfig() {return isValid;};
 };

--- a/gemrb/core/ItemMgr.h
+++ b/gemrb/core/ItemMgr.h
@@ -47,7 +47,7 @@ protected:
 	AutoTable dialogTable; // dialogs attached to items (conversables such as Lilarcor)
 public:
 	ItemMgr(void);
-	virtual ~ItemMgr(void);
+	~ItemMgr(void) override;
 	virtual bool Open(DataStream* stream) = 0;
 	virtual Item* GetItem(Item *s) = 0;
 };

--- a/gemrb/core/Map.h
+++ b/gemrb/core/Map.h
@@ -420,7 +420,7 @@ private:
 
 public:
 	Map(void);
-	~Map(void);
+	~Map(void) override;
 	static void ReleaseMemory();
 	static void NormalizeDeltas(double &dx, double &dy, const double &factor = 1);
 

--- a/gemrb/core/MapMgr.h
+++ b/gemrb/core/MapMgr.h
@@ -42,7 +42,7 @@ class Map;
 class GEM_EXPORT MapMgr : public Plugin {
 public:
 	MapMgr(void);
-	virtual ~MapMgr(void);
+	~MapMgr(void) override;
 	virtual bool Open(DataStream* stream) = 0;
 	virtual bool ChangeMap(Map *map, bool day_or_night) = 0;
 	virtual Map* GetMap(const char* ResRef, bool day_or_night) = 0;

--- a/gemrb/core/MoviePlayer.h
+++ b/gemrb/core/MoviePlayer.h
@@ -94,7 +94,7 @@ protected:
 
 public:
 	MoviePlayer(void);
-	virtual ~MoviePlayer(void);
+	~MoviePlayer(void) override;
 
 	Size Dimensions() { return movieSize; }
 	void Play(Window* win);
@@ -110,9 +110,9 @@ class MoviePlayerControls : public View {
 
 private:
 	// currently dont have any real controls
-	void DrawSelf(Region /*drawFrame*/, const Region& /*clip*/) {}
+	void DrawSelf(Region /*drawFrame*/, const Region& /*clip*/) override {}
 	
-	bool OnKeyPress(const KeyboardEvent& Key, unsigned short /*Mod*/) {
+	bool OnKeyPress(const KeyboardEvent& Key, unsigned short /*Mod*/) override {
 		KeyboardKey keycode = Key.keycode;
 		switch (keycode) {
 			case 's':
@@ -126,7 +126,7 @@ private:
 		return true;
 	}
 	
-	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short /*Mod*/) {
+	bool OnMouseDown(const MouseEvent& /*me*/, unsigned short /*Mod*/) override {
 		player.Stop();
 		return true;
 	}

--- a/gemrb/core/MusicMgr.h
+++ b/gemrb/core/MusicMgr.h
@@ -28,7 +28,7 @@ namespace GemRB {
 class GEM_EXPORT MusicMgr : public Plugin {
 public: 
 	MusicMgr();
-	virtual ~MusicMgr();
+	~MusicMgr() override;
 	/** Ends the Current PlayList Execution */
 	virtual void End(void) = 0;
 	virtual void HardEnd(void) = 0;

--- a/gemrb/core/PalettedImageMgr.h
+++ b/gemrb/core/PalettedImageMgr.h
@@ -38,7 +38,7 @@ public:
 	static const TypeID ID;
 public:
 	PalettedImageMgr(void);
-	virtual ~PalettedImageMgr(void);
+	~PalettedImageMgr(void) override;
 	/**
 	 * Returns a @ref{Sprite2D} that has been colored with the given palette.
 	 *

--- a/gemrb/core/Pixels.h
+++ b/gemrb/core/Pixels.h
@@ -68,7 +68,7 @@ inline void ShaderBlend(const Color& src, Color& dst) {
 
 template <bool MASKED, bool SRCALPHA>
 struct OneMinusSrcA : RGBBlender {
-	void operator()(const Color& c, Color& dst, uint8_t mask) const {
+	void operator()(const Color& c, Color& dst, uint8_t mask) const override {
 		ShaderBlend<SRCALPHA>(c, dst);
 		if (MASKED) {
 			dst.a = (mask) ? (255-mask) + (c.a * mask) : c.a; // FIXME: not sure this is 100% correct, but it passes my known tests
@@ -78,7 +78,7 @@ struct OneMinusSrcA : RGBBlender {
 
 template <bool MASKED>
 struct TintDst : RGBBlender {
-	void operator()(const Color& c, Color& dst, uint8_t mask) const {
+	void operator()(const Color& c, Color& dst, uint8_t mask) const override {
 		ShaderTint(c, dst);
 		if (MASKED) {
 			dst.a = (mask) ? (255-mask) + (c.a * mask) : c.a; // FIXME: not sure this is 100% correct, but it passes my known tests
@@ -88,7 +88,7 @@ struct TintDst : RGBBlender {
 
 template <bool MASKED>
 struct SrcRGBA : RGBBlender {
-	void operator()(const Color& c, Color& dst, uint8_t mask) const {
+	void operator()(const Color& c, Color& dst, uint8_t mask) const override {
 		dst = c;
 		if (MASKED) {
 			dst.a = (mask) ? (255-mask) + (c.a * mask) : c.a; // FIXME: not sure this is 100% correct, but it passes my known tests
@@ -128,7 +128,7 @@ public:
 		}
 	}
 
-	void operator()(const Color& src, Color& dst, uint8_t mask) const {
+	void operator()(const Color& src, Color& dst, uint8_t mask) const override {
 		if (SRCALPHA && src.a == 0) {
 			return;
 		}
@@ -236,15 +236,15 @@ struct PixelIterator : IPixelIterator
 		return static_cast<PIXEL*>(pixel);
 	}
 
-	uint8_t Channel(uint32_t mask, uint8_t shift) const {
+	uint8_t Channel(uint32_t mask, uint8_t shift) const override {
 		return ((*static_cast<PIXEL*>(pixel))&mask) >> shift;
 	}
 
-	IPixelIterator* Clone() const {
+	IPixelIterator* Clone() const override {
 		return new PixelIterator<PIXEL>(*this);
 	}
 
-	void Advance(int dx) {
+	void Advance(int dx) override {
 		if (dx == 0 || size.IsEmpty()) return;
 
 		uint8_t* ptr = static_cast<uint8_t*>(pixel);
@@ -279,7 +279,7 @@ struct PixelIterator : IPixelIterator
 		pixel = ptr;
 	}
 	
-	const Point& Position() const {
+	const Point& Position() const override {
 		return pos;
 	}
 };
@@ -304,11 +304,11 @@ struct StaticAlphaIterator : public IAlphaIterator
 
 	StaticAlphaIterator(uint8_t a) : alpha(a) {}
 
-	uint8_t operator*() const {
+	uint8_t operator*() const override {
 		return alpha;
 	}
 
-	void Advance(int) {}
+	void Advance(int) override {}
 };
 
 struct RGBAChannelIterator : public IAlphaIterator
@@ -321,11 +321,11 @@ struct RGBAChannelIterator : public IAlphaIterator
 	: mask(mask), shift(shift), pixelIt(it)
 	{}
 
-	uint8_t operator*() const {
+	uint8_t operator*() const override {
 		return pixelIt->Channel(mask, shift);
 	}
 	
-	void Advance(int amt) {
+	void Advance(int amt) override {
 		pixelIt->Advance(amt);
 	}
 };

--- a/gemrb/core/Plugin.h
+++ b/gemrb/core/Plugin.h
@@ -45,7 +45,7 @@ namespace GemRB {
 class GEM_EXPORT Plugin : public Held<Plugin> {
 public:
 	Plugin(void);
-	virtual ~Plugin(void);
+	~Plugin(void) override;
 };
 
 }

--- a/gemrb/core/ProjectileMgr.h
+++ b/gemrb/core/ProjectileMgr.h
@@ -30,7 +30,7 @@ namespace GemRB {
 class GEM_EXPORT ProjectileMgr : public Plugin {
 public:
 	ProjectileMgr(void);
-	virtual ~ProjectileMgr(void);
+	~ProjectileMgr(void) override;
 	virtual bool Open(DataStream* stream) = 0;
 	virtual Projectile* GetProjectile( Projectile *) = 0;
 };

--- a/gemrb/core/Resource.h
+++ b/gemrb/core/Resource.h
@@ -127,7 +127,7 @@ protected:
 	DataStream* str;
 public:
 	Resource();
-	virtual ~Resource();
+	~Resource() override;
 	/**
 	 * Reads the resource from the given stream.
 	 *

--- a/gemrb/core/ResourceSource.h
+++ b/gemrb/core/ResourceSource.h
@@ -35,7 +35,7 @@ class ResourceDesc;
 class GEM_EXPORT ResourceSource : public Plugin {
 public:
 	ResourceSource(void);
-	virtual ~ResourceSource(void);
+	~ResourceSource(void) override;
 	virtual bool Open(const char *filename, const char *description) = 0;
 	virtual bool HasResource(const char* resname, SClass_ID type) = 0;
 	virtual bool HasResource(const char* resname, const ResourceDesc &type) = 0;

--- a/gemrb/core/SaveGame.h
+++ b/gemrb/core/SaveGame.h
@@ -37,7 +37,7 @@ public:
 	static const TypeID ID;
 public:
 	SaveGame(const char* path, const char* name, const char* prefix, const char* slotname, int pCount, int saveID);
-	~SaveGame();
+	~SaveGame() override;
 	int GetPortraitCount() const
 	{
 		return PortraitCount;

--- a/gemrb/core/SaveGameMgr.h
+++ b/gemrb/core/SaveGameMgr.h
@@ -29,7 +29,7 @@ namespace GemRB {
 class GEM_EXPORT SaveGameMgr : public Plugin {
 public:
 	SaveGameMgr(void);
-	virtual ~SaveGameMgr(void);
+	~SaveGameMgr(void) override;
 	virtual bool Open(DataStream* stream) = 0;
 	virtual Game* LoadGame(Game *newGame, int ver_override = 0) = 0;
 

--- a/gemrb/core/ScriptEngine.h
+++ b/gemrb/core/ScriptEngine.h
@@ -105,12 +105,12 @@ public:
 			T value;
 			ConcreteType(T value) : value(value) {}
 
-			virtual TypeInterface *Clone() const
+			TypeInterface *Clone() const override
 			{
 				return new ConcreteType(value);
 			}
 
-			const std::type_info& Type() const {
+			const std::type_info& Type() const override {
 				return typeid(T);
 			}
 		};
@@ -165,7 +165,7 @@ public:
 
 public:
 	ScriptEngine(void) {};
-	virtual ~ScriptEngine(void) {};
+	~ScriptEngine(void) override {};
 	/** Initialization Routine */
 	virtual bool Init(void) = 0;
 	/** Load Script */

--- a/gemrb/core/Scriptable/Actor.h
+++ b/gemrb/core/Scriptable/Actor.h
@@ -469,7 +469,7 @@ private:
 
 public:
 	Actor(void);
-	~Actor(void);
+	~Actor(void) override;
 	/** releases memory */
 	static void ReleaseMemory();
 	/** sets game specific parameter (which stat should determine the fist weapon type */

--- a/gemrb/core/Scriptable/Container.h
+++ b/gemrb/core/Scriptable/Container.h
@@ -39,7 +39,7 @@ namespace GemRB {
 class GEM_EXPORT Container : public Highlightable {
 public:
 	Container(void);
-	~Container(void);
+	~Container(void) override;
 	void SetContainerLocked(bool lock);
 	//turns the container to a pile
 	void DestroyContainer();

--- a/gemrb/core/Scriptable/Door.h
+++ b/gemrb/core/Scriptable/Door.h
@@ -69,7 +69,7 @@ public:
 class GEM_EXPORT Door : public Highlightable {
 public:
 	Door(TileOverlay* Overlay, DoorTrigger&& trigger);
-	~Door(void);
+	~Door(void) override;
 public:
 	ieVariable LinkedInfo;
 	ieResRef ID; //WED ID
@@ -106,7 +106,7 @@ public:
 	void ToggleTiles(int State, int playsound = false);
 	void SetName(const char* Name); // sets door ID
 	void SetTiles(unsigned short* Tiles, int count);
-	bool CanDetectTrap() const;
+	bool CanDetectTrap() const override;
 	void SetDoorLocked(int Locked, int playsound);
 	void SetDoorOpen(int Open, int playsound, ieDword ID, bool addTrigger = true);
 	int IsOpen() const;
@@ -117,7 +117,7 @@ public:
 	void TryDetectSecret(int skill, ieDword actorID);
 	bool Visible() const;
 	void dump() const;
-	int TrapResets() const { return Flags & DOOR_RESET; }
+	int TrapResets() const override { return Flags & DOOR_RESET; }
 	bool CantAutoClose() const { return Flags & (DOOR_CANTCLOSE | DOOR_LOCKED); }
 	void SetNewOverlay(TileOverlay *Overlay);
 

--- a/gemrb/core/Scriptable/InfoPoint.h
+++ b/gemrb/core/Scriptable/InfoPoint.h
@@ -28,10 +28,10 @@ namespace GemRB {
 class GEM_EXPORT InfoPoint : public Highlightable {
 public:
 	InfoPoint(void);
-	~InfoPoint(void);
+	~InfoPoint(void) override;
 	//returns true if trap has been triggered, tumble skill???
 	void SetEnter(const char *resref);
-	bool TriggerTrap(int skill, ieDword ID);
+	bool TriggerTrap(int skill, ieDword ID) override;
 	//call this to check if an actor entered the trigger zone
 	bool Entered(Actor *actor);
   //returns true if
@@ -39,9 +39,9 @@ public:
 	//checks if the actor may use this travel trigger
 	int CheckTravel(Actor *actor);
 	void dump() const;
-	int TrapResets() const { return Flags & TRAP_RESET; }
-	bool CanDetectTrap() const;
-	bool PossibleToSeeTrap() const;
+	int TrapResets() const override { return Flags & TRAP_RESET; }
+	bool CanDetectTrap() const override;
+	bool PossibleToSeeTrap() const override;
 	bool IsPortal() const;
 
 public:

--- a/gemrb/core/Scriptable/Scriptable.h
+++ b/gemrb/core/Scriptable/Scriptable.h
@@ -494,7 +494,7 @@ public:
 		randomBackoff--;
 	}
 	Movable(ScriptableType type);
-	virtual ~Movable(void);
+	~Movable(void) override;
 	Point Destination;
 	ieResRef Area;
 	Point HomeLocation;//spawnpoint, return here after rest
@@ -544,7 +544,7 @@ public:
 	void MoveLine(int steps, ieDword Orient);
 	void WalkTo(const Point &Des, int MinDistance = 0);
 	void MoveTo(const Point &Des);
-	void Stop();
+	void Stop() override;
 	void ClearPath(bool resetDestination = true);
 
 	/* returns the most likely position of this actor */

--- a/gemrb/core/ScriptedAnimation.cpp
+++ b/gemrb/core/ScriptedAnimation.cpp
@@ -783,7 +783,7 @@ ScriptedAnimation *ScriptedAnimation::DetachTwin()
 	ScriptedAnimation * ret = twin;
 	//ret->Frame.y+=ret->ZPos+1;
 	if (ret->ZOffset >= 0) {
-		ret->ZOffset =- 1;
+		ret->ZOffset = -1;
 	}
 	twin=NULL;
 	return ret;

--- a/gemrb/core/SoundMgr.h
+++ b/gemrb/core/SoundMgr.h
@@ -36,7 +36,7 @@ public:
 	static const TypeID ID;
 public:
 	SoundMgr(void);
-	virtual ~SoundMgr(void);
+	~SoundMgr(void) override;
 	/**
 	 * Read up to cnt samples into memory
 	 *

--- a/gemrb/core/SpellMgr.h
+++ b/gemrb/core/SpellMgr.h
@@ -41,7 +41,7 @@ namespace GemRB {
 class GEM_EXPORT SpellMgr : public Plugin {
 public:
 	SpellMgr(void);
-	virtual ~SpellMgr(void);
+	~SpellMgr(void) override;
 	virtual bool Open(DataStream* stream) = 0;
 	virtual Spell* GetSpell(Spell *spl, bool silent=false) = 0;
 };

--- a/gemrb/core/Sprite2D.h
+++ b/gemrb/core/Sprite2D.h
@@ -64,7 +64,7 @@ public:
 	Sprite2D(const Region&, int Bpp, void* pixels);
 	Sprite2D(const Sprite2D &obj);
 	virtual Holder<Sprite2D> copy() const = 0;
-	virtual ~Sprite2D();
+	~Sprite2D() override;
 
 	bool IsPixelTransparent(const Point& p) const;
 

--- a/gemrb/core/StoreMgr.h
+++ b/gemrb/core/StoreMgr.h
@@ -42,7 +42,7 @@ namespace GemRB {
 class GEM_EXPORT StoreMgr : public Plugin {
 public:
 	StoreMgr(void);
-	virtual ~StoreMgr(void);
+	~StoreMgr(void) override;
 	virtual bool Open(DataStream* stream) = 0;
 	virtual Store* GetStore(Store *s) = 0;
 

--- a/gemrb/core/StringMgr.h
+++ b/gemrb/core/StringMgr.h
@@ -61,7 +61,7 @@ struct StringBlock {
 class GEM_EXPORT StringMgr : public Plugin {
 public:
 	StringMgr(void);
-	virtual ~StringMgr(void);
+	~StringMgr(void) override;
 	virtual void OpenAux() = 0;
 	virtual void CloseAux() = 0;
 	virtual bool Open(DataStream* stream) = 0;

--- a/gemrb/core/SymbolMgr.h
+++ b/gemrb/core/SymbolMgr.h
@@ -38,7 +38,7 @@ namespace GemRB {
 class GEM_EXPORT SymbolMgr : public Plugin {
 public:
 	SymbolMgr(void);
-	virtual ~SymbolMgr(void);
+	~SymbolMgr(void) override;
 	virtual bool Open(DataStream* stream) = 0;
 	/// Returns -1 if string isn't found.
 	virtual int GetValue(const char* text) const = 0;

--- a/gemrb/core/System/FileFilters.h
+++ b/gemrb/core/System/FileFilters.h
@@ -29,7 +29,7 @@ struct ExtFilter : DirectoryIterator::FileFilterPredicate {
 		strncpy(extension, ext, sizeof(extension) - 1);
 	}
 
-	bool operator()(const char* fname) const {
+	bool operator()(const char* fname) const override {
 		const char* extpos = strrchr(fname, '.');
 		if (extpos) {
 			return stricmp(++extpos, extension) == 0;
@@ -47,11 +47,11 @@ struct EndsWithFilter : DirectoryIterator::FileFilterPredicate {
 		len = strlen(endMatch);
 	}
 
-	~EndsWithFilter() {
+	~EndsWithFilter() override {
 		free(endMatch);
 	}
 
-	bool operator()(const char* fname) const {
+	bool operator()(const char* fname) const override {
 		// this filter ignores file extension
 		const char* rpos = strrchr(fname, '.');
 		if (rpos) {

--- a/gemrb/core/System/FileStream.h
+++ b/gemrb/core/System/FileStream.h
@@ -50,17 +50,17 @@ private:
 	bool opened, created;
 public:
 	FileStream(void);
-	~FileStream(void);
-	DataStream* Clone();
+	~FileStream(void) override;
+	DataStream* Clone() override;
 
 	bool Open(const char* filename);
 	bool Modify(const char* filename);
 	bool Create(const char* folder, const char* filename, SClass_ID ClassID);
 	bool Create(const char* filename, SClass_ID ClassID);
 	bool Create(const char* filename);
-	int Read(void* dest, unsigned int length);
-	int Write(const void* src, unsigned int length);
-	int Seek(int pos, int startpos);
+	int Read(void* dest, unsigned int length) override;
+	int Write(const void* src, unsigned int length) override;
+	int Seek(int pos, int startpos) override;
 
 	void Close();
 public:

--- a/gemrb/core/System/Logger/Android.h
+++ b/gemrb/core/System/Logger/Android.h
@@ -26,10 +26,10 @@ namespace GemRB {
 class GEM_EXPORT AndroidLogger : public Logger {
 public:
 	AndroidLogger();
-	virtual ~AndroidLogger();
+	~AndroidLogger() override;
 
 protected:
-	void LogInternal(log_level, const char*, const char*, log_color);
+	void LogInternal(log_level, const char*, const char*, log_color) override;
 };
 
 Logger* createAndroidLogger();

--- a/gemrb/core/System/Logger/File.h
+++ b/gemrb/core/System/Logger/File.h
@@ -28,9 +28,9 @@ class DataStream;
 class GEM_EXPORT FileLogger : public StdioLogger {
 public:
 	FileLogger(DataStream*);
-	virtual ~FileLogger();
+	~FileLogger() override;
 
-	void print(const char* message);
+	void print(const char* message) override;
 
 private:
 	DataStream* log_file;

--- a/gemrb/core/System/Logger/MessageWindowLogger.h
+++ b/gemrb/core/System/Logger/MessageWindowLogger.h
@@ -25,9 +25,9 @@ namespace GemRB {
 class GEM_EXPORT MessageWindowLogger : public Logger {
 public:
 	MessageWindowLogger( log_level = WARNING ); // this logger has a diffrent default level than its base class.
-	virtual ~MessageWindowLogger();
+	~MessageWindowLogger() override;
 protected:
-	void LogInternal(log_level level, const char* owner, const char* message, log_color color);
+	void LogInternal(log_level level, const char* owner, const char* message, log_color color) override;
 private:
 	void PrintStatus(bool);
 };

--- a/gemrb/core/System/Logger/Stdio.h
+++ b/gemrb/core/System/Logger/Stdio.h
@@ -26,10 +26,10 @@ namespace GemRB {
 class GEM_EXPORT StdioLogger : public Logger {
 public:
 	StdioLogger(bool useColor);
-	virtual ~StdioLogger();
-	virtual void destroy();
+	~StdioLogger() override;
+	void destroy() override;
 protected:
-	virtual void LogInternal(log_level, const char* owner, const char* message, log_color color);
+	void LogInternal(log_level, const char* owner, const char* message, log_color color) override;
 	virtual void print(const char*);
 	virtual void textcolor(log_color);
 	bool useColor;

--- a/gemrb/core/System/Logger/Vita.h
+++ b/gemrb/core/System/Logger/Vita.h
@@ -26,10 +26,10 @@ namespace GemRB {
 class GEM_EXPORT VitaLogger : public Logger {
 public:
 	VitaLogger();
-	virtual ~VitaLogger();
+	~VitaLogger() override;
 
 protected:
-	void LogInternal(log_level, const char*, const char*, log_color);
+	void LogInternal(log_level, const char*, const char*, log_color) override;
 };
 
 Logger* createVitaLogger();

--- a/gemrb/core/System/Logger/Win32Console.h
+++ b/gemrb/core/System/Logger/Win32Console.h
@@ -27,10 +27,10 @@ namespace GemRB {
 class GEM_EXPORT Win32ConsoleLogger : public StdioLogger {
 public:
 	Win32ConsoleLogger(bool useColor);
-	virtual ~Win32ConsoleLogger();
+	~Win32ConsoleLogger() override;
 
-	void print(const char* message);
-	void textcolor(log_color);
+	void print(const char* message) override;
+	void textcolor(log_color) override;
 
 private:
 	HANDLE hConsole;

--- a/gemrb/core/System/MappedFileMemoryStream.h
+++ b/gemrb/core/System/MappedFileMemoryStream.h
@@ -26,7 +26,7 @@ namespace GemRB {
 class GEM_EXPORT MappedFileMemoryStream : public MemoryStream {
 	public:
 		explicit MappedFileMemoryStream(const std::string& fileName);
-		~MappedFileMemoryStream();
+		~MappedFileMemoryStream() override;
 
 		bool isOk() const;
 

--- a/gemrb/core/System/MemoryStream.h
+++ b/gemrb/core/System/MemoryStream.h
@@ -33,7 +33,7 @@ protected:
 	char *data;
 public:
 	MemoryStream(const char *name, void* data, unsigned long size);
-	~MemoryStream();
+	~MemoryStream() override;
 	DataStream* Clone() override;
 
 	int Read(void* dest, unsigned int length) override;

--- a/gemrb/core/System/SlicedStream.h
+++ b/gemrb/core/System/SlicedStream.h
@@ -35,12 +35,12 @@ private:
 	DataStream* str;
 public:
 	SlicedStream(DataStream* cfs, int startpos, int size);
-	~SlicedStream();
-	DataStream* Clone();
+	~SlicedStream() override;
+	DataStream* Clone() override;
 
-	int Read(void* dest, unsigned int length);
-	int Write(const void* src, unsigned int length);
-	int Seek(int pos, int startpos);
+	int Read(void* dest, unsigned int length) override;
+	int Write(const void* src, unsigned int length) override;
+	int Seek(int pos, int startpos) override;
 };
 
 GEM_EXPORT DataStream* SliceStream(DataStream* str, unsigned long startpos, unsigned long size, bool preservepos = false);

--- a/gemrb/core/TableMgr.h
+++ b/gemrb/core/TableMgr.h
@@ -42,7 +42,7 @@ namespace GemRB {
 class GEM_EXPORT TableMgr : public Plugin {
 public: 
 	TableMgr();
-	virtual ~TableMgr();
+	~TableMgr() override;
 	/** Returns the actual number of Rows in the Table */
 	virtual ieDword GetRowCount() const = 0;
 	/** Returns the number of Columns in the Table */

--- a/gemrb/core/TileMapMgr.h
+++ b/gemrb/core/TileMapMgr.h
@@ -30,7 +30,7 @@ namespace GemRB {
 class GEM_EXPORT TileMapMgr : public Plugin {
 public:
 	TileMapMgr(void);
-	virtual ~TileMapMgr(void);
+	~TileMapMgr(void) override;
 	virtual bool Open(DataStream* stream) = 0;
 	virtual TileMap* GetTileMap(TileMap *tm) const = 0;
 	virtual ieWord* GetDoorIndices(char* ResRef, int* count,

--- a/gemrb/core/TileSetMgr.h
+++ b/gemrb/core/TileSetMgr.h
@@ -30,7 +30,7 @@ namespace GemRB {
 class GEM_EXPORT TileSetMgr : public Plugin {
 public:
 	TileSetMgr(void);
-	virtual ~TileSetMgr(void);
+	~TileSetMgr(void) override;
 	virtual bool Open(DataStream* stream) = 0;
 	virtual Tile* GetTile(unsigned short* indexes, int count,
 		unsigned short* secondary = NULL) = 0;

--- a/gemrb/core/Video.h
+++ b/gemrb/core/Video.h
@@ -160,7 +160,7 @@ private:
 
 public:
 	Video(void);
-	virtual ~Video(void);
+	~Video(void) override;
 
 	virtual int Init(void) = 0;
 

--- a/gemrb/core/WorldMapMgr.h
+++ b/gemrb/core/WorldMapMgr.h
@@ -41,7 +41,7 @@ namespace GemRB {
 class GEM_EXPORT WorldMapMgr : public Plugin {
 public:
 	WorldMapMgr(void);
-	virtual ~WorldMapMgr(void);
+	~WorldMapMgr(void) override;
 	virtual bool Open(DataStream* stream1, DataStream* stream2) = 0;
 	virtual WorldMapArray* GetWorldMapArray() = 0;
 

--- a/gemrb/plugins/2DAImporter/2DAImporter.h
+++ b/gemrb/plugins/2DAImporter/2DAImporter.h
@@ -41,21 +41,21 @@ private:
 	char defVal[32];
 public:
 	p2DAImporter(void);
-	~p2DAImporter(void);
-	bool Open(DataStream* stream);
+	~p2DAImporter(void) override;
+	bool Open(DataStream* stream) override;
 	/** Returns the actual number of Rows in the Table */
-	inline ieDword GetRowCount() const
+	inline ieDword GetRowCount() const override
 	{
 		return ( ieDword ) rows.size();
 	}
 
-	inline ieDword GetColNamesCount() const
+	inline ieDword GetColNamesCount() const override
 	{
 		return (ieDword) colNames.size();
 	}
 
 	/** Returns the actual number of Columns in the Table */
-	inline ieDword GetColumnCount(unsigned int row = 0) const
+	inline ieDword GetColumnCount(unsigned int row = 0) const override
 	{
 		if (rows.size() <= row) {
 			return 0;
@@ -64,7 +64,7 @@ public:
 	}
 	/** Returns a pointer to a zero terminated 2da element,
 		if it cannot return a value, it returns the default */
-	inline const char* QueryField(size_t row = 0, size_t column = 0) const
+	inline const char* QueryField(size_t row = 0, size_t column = 0) const override
 	{
 		if (rows.size() <= row) {
 			return ( char * ) defVal;
@@ -79,7 +79,7 @@ public:
 	}
 	/** Returns a pointer to a zero terminated 2da element,
 		 uses column name and row name to search the field */
-	inline const char* QueryField(const char* row, const char* column) const
+	inline const char* QueryField(const char* row, const char* column) const override
 	{
 		int rowi, coli;
 
@@ -98,12 +98,12 @@ public:
 		return QueryField((unsigned int) rowi, (unsigned int) coli);
 	}
 
-	virtual const char* QueryDefault() const
+	const char* QueryDefault() const override
 	{
 		return defVal;
 	}
 
-	inline int GetRowIndex(const char* string) const
+	inline int GetRowIndex(const char* string) const override
 	{
 		for (unsigned int index = 0; index < rowNames.size(); index++) {
 			if (stricmp( rowNames[index], string ) == 0) {
@@ -113,7 +113,7 @@ public:
 		return -1;
 	}
 
-	inline int GetColumnIndex(const char* string) const
+	inline int GetColumnIndex(const char* string) const override
 	{
 		for (unsigned int index = 0; index < colNames.size(); index++) {
 			if (stricmp( colNames[index], string ) == 0) {
@@ -123,7 +123,7 @@ public:
 		return -1;
 	}
 
-	inline const char* GetColumnName(unsigned int index) const
+	inline const char* GetColumnName(unsigned int index) const override
 	{
 		if (index < colNames.size()) {
 			return colNames[index];
@@ -131,7 +131,7 @@ public:
 		return "";
 	}
 
-	inline const char* GetRowName(unsigned int index) const
+	inline const char* GetRowName(unsigned int index) const override
 	{
 		if (index < rowNames.size()) {
 			return rowNames[index];
@@ -139,7 +139,7 @@ public:
 		return "";
 	}
 
-	inline int FindTableValue(unsigned int col, long val, int start) const
+	inline int FindTableValue(unsigned int col, long val, int start) const override
 	{
 		ieDword row, max;
 		
@@ -153,7 +153,7 @@ public:
 		return -1;
 	}
 
-	inline int FindTableValue(unsigned int col, const char* val, int start) const
+	inline int FindTableValue(unsigned int col, const char* val, int start) const override
 	{
 		ieDword row, max;
 
@@ -166,13 +166,13 @@ public:
 		return -1;
 	}
 
-	inline int FindTableValue(const char* col, long val, int start) const
+	inline int FindTableValue(const char* col, long val, int start) const override
 	{
 		ieDword coli = GetColumnIndex(col);
 		return FindTableValue(coli, val, start);
 	}
 
-	inline int FindTableValue(const char* col, const char* val, int start) const
+	inline int FindTableValue(const char* col, const char* val, int start) const override
 	{
 		ieDword coli = GetColumnIndex(col);
 		return FindTableValue(coli, val, start);

--- a/gemrb/plugins/ACMReader/ACMReader.h
+++ b/gemrb/plugins/ACMReader/ACMReader.h
@@ -51,7 +51,7 @@ public:
 		samples_ready( 0 ), unpacker( NULL ), decoder( NULL )
 	{
 	}
-	virtual ~ACMReader()
+	~ACMReader() override
 	{
 		Close();
 	}
@@ -68,8 +68,8 @@ public:
 		}
 	}
 
-	bool Open(DataStream* stream);
-	virtual int read_samples(short* buffer, int count);
+	bool Open(DataStream* stream) override;
+	int read_samples(short* buffer, int count) override;
 };
 
 }

--- a/gemrb/plugins/AREImporter/AREImporter.h
+++ b/gemrb/plugins/AREImporter/AREImporter.h
@@ -62,13 +62,13 @@ private:
 	ieByte AreaDifficulty;
 public:
 	AREImporter(void);
-	~AREImporter(void);
-	bool Open(DataStream* stream);
-	bool ChangeMap(Map *map, bool day_or_night);
-	Map* GetMap(const char* ResRef, bool day_or_night);
-	int GetStoredFileSize(Map *map);
+	~AREImporter(void) override;
+	bool Open(DataStream* stream) override;
+	bool ChangeMap(Map *map, bool day_or_night) override;
+	Map* GetMap(const char* ResRef, bool day_or_night) override;
+	int GetStoredFileSize(Map *map) override;
 	/* stores an area in the Cache (swaps it out) */
-	int PutArea(DataStream *stream, Map *map);
+	int PutArea(DataStream *stream, Map *map) override;
 private:
 	void AdjustPSTFlags(AreaAnimation*);
 	void ReadEffects(DataStream *ds, EffectQueue *fx, ieDword EffectsCount);

--- a/gemrb/plugins/BAMImporter/BAMFontManager.h
+++ b/gemrb/plugins/BAMImporter/BAMFontManager.h
@@ -35,7 +35,7 @@ private:
 	ResRef resRef;
 public:
 	/** public methods */
-	~BAMFontManager(void);
+	~BAMFontManager(void) override;
 	BAMFontManager();
 
 	bool Open(DataStream* stream) override;

--- a/gemrb/plugins/BAMImporter/BAMImporter.h
+++ b/gemrb/plugins/BAMImporter/BAMImporter.h
@@ -58,14 +58,14 @@ private:
 	ieWord * CacheFLT(unsigned int &count);
 public:
 	BAMImporter(void);
-	~BAMImporter(void);
-	bool Open(DataStream* stream);
-	int GetCycleSize(unsigned char Cycle);
+	~BAMImporter(void) override;
+	bool Open(DataStream* stream) override;
+	int GetCycleSize(unsigned char Cycle) override;
 	AnimationFactory* GetAnimationFactory(const char* ResRef,
-		unsigned char mode = IE_NORMAL, bool allowCompression = true);
+		unsigned char mode = IE_NORMAL, bool allowCompression = true) override;
 	/** Debug Function: Returns the Global Animation Palette as a Sprite2D Object.
 	If the Global Animation Palette is NULL, returns NULL. */
-	Holder<Sprite2D> GetPalette();
+	Holder<Sprite2D> GetPalette() override;
 
 	/** Gets a Pixel Index from the Image, unused */
 	unsigned int GetPixelIndex(unsigned int /*x*/, unsigned int /*y*/)
@@ -78,7 +78,7 @@ public:
 		return Color();
 	}
 public:
-	int GetCycleCount()
+	int GetCycleCount() override
 	{
 		return CyclesCount;
 	}

--- a/gemrb/plugins/BIFImporter/BIFImporter.h
+++ b/gemrb/plugins/BIFImporter/BIFImporter.h
@@ -54,9 +54,9 @@ private:
 	DataStream* stream;
 public:
 	BIFImporter(void);
-	~BIFImporter(void);
-	int OpenArchive(const char* filename);
-	DataStream* GetStream(unsigned long Resource, unsigned long Type);
+	~BIFImporter(void) override;
+	int OpenArchive(const char* filename) override;
+	DataStream* GetStream(unsigned long Resource, unsigned long Type) override;
 private:
 	static DataStream* DecompressBIF(DataStream* compressed, const char* path);
 	static DataStream* DecompressBIFC(DataStream* compressed, const char* path);

--- a/gemrb/plugins/BIKPlayer/BIKPlayer.h
+++ b/gemrb/plugins/BIKPlayer/BIKPlayer.h
@@ -277,12 +277,12 @@ private:
 	int EndVideo();
 
 protected:
-	bool DecodeFrame(VideoBuffer&);
+	bool DecodeFrame(VideoBuffer&) override;
 
 public:
 	BIKPlayer(void);
-	~BIKPlayer(void);
-	bool Open(DataStream* stream);
+	~BIKPlayer(void) override;
+	bool Open(DataStream* stream) override;
 
 	void Stop();
 };

--- a/gemrb/plugins/BMPImporter/BMPImporter.h
+++ b/gemrb/plugins/BMPImporter/BMPImporter.h
@@ -42,15 +42,15 @@ private:
 	unsigned int PaddedRowLength;
 public:
 	BMPImporter(void);
-	~BMPImporter(void);
-	bool Open(DataStream* stream);
-	Holder<Sprite2D> GetSprite2D();
-	virtual Bitmap* GetBitmap();
-	virtual Image* GetImage();
-	int GetPalette(int colors, Color* pal);
+	~BMPImporter(void) override;
+	bool Open(DataStream* stream) override;
+	Holder<Sprite2D> GetSprite2D() override;
+	Bitmap* GetBitmap() override;
+	Image* GetImage() override;
+	int GetPalette(int colors, Color* pal) override;
 
-	int GetWidth() { return (int) Width; }
-	int GetHeight() { return (int) Height; }
+	int GetWidth() override { return (int) Width; }
+	int GetHeight() override { return (int) Height; }
 private:
 	void Read8To8(void *rpixels);
 	void Read4To8(void *rpixels);

--- a/gemrb/plugins/BMPWriter/BMPWriter.h
+++ b/gemrb/plugins/BMPWriter/BMPWriter.h
@@ -5,9 +5,9 @@ namespace GemRB {
 class BMPWriter : public ImageWriter {
 public:
 	BMPWriter(void);
-	~BMPWriter(void);
+	~BMPWriter(void) override;
 
-	void PutImage(DataStream *output, Holder<Sprite2D> sprite);
+	void PutImage(DataStream *output, Holder<Sprite2D> sprite) override;
 };
 
 }

--- a/gemrb/plugins/CHUImporter/CHUImporter.h
+++ b/gemrb/plugins/CHUImporter/CHUImporter.h
@@ -38,14 +38,14 @@ private:
 	ieDword WindowCount, CTOffset, WEOffset;
 public: 
 	CHUImporter();
-	~CHUImporter();
+	~CHUImporter() override;
 	/** Returns the number of available windows */
-	unsigned int GetWindowsCount();
-	bool LoadWindowPack(const ResRef&);
+	unsigned int GetWindowsCount() override;
+	bool LoadWindowPack(const ResRef&) override;
 	/** Returns the i-th window in the Previously Loaded Stream */
-	Window* GetWindow(ScriptingId) const;
+	Window* GetWindow(ScriptingId) const override;
 	/** This function loads all available windows from the 'stream' parameter. */
-	bool Open(DataStream* stream);
+	bool Open(DataStream* stream) override;
 };
 
 }

--- a/gemrb/plugins/CREImporter/CREImporter.h
+++ b/gemrb/plugins/CREImporter/CREImporter.h
@@ -65,16 +65,16 @@ private:
 	int QITCount; //items
 public:
 	CREImporter(void);
-	~CREImporter(void);
-	bool Open(DataStream* stream);
-	Actor* GetActor(unsigned char is_in_party);
+	~CREImporter(void) override;
+	bool Open(DataStream* stream) override;
+	Actor* GetActor(unsigned char is_in_party) override;
 
-	int FindSpellType(char *name, unsigned short &level, unsigned int clsmsk, unsigned int kit) const;
+	int FindSpellType(char *name, unsigned short &level, unsigned int clsmsk, unsigned int kit) const override;
 
 	//returns saved size, updates internal offsets before save
-	int GetStoredFileSize(Actor *ac);
+	int GetStoredFileSize(Actor *ac) override;
 	//saves file
-	int PutActor(DataStream *stream, Actor *actor, bool chr=false);
+	int PutActor(DataStream *stream, Actor *actor, bool chr=false) override;
 private:
 	/** sets up some variables based on creature version for serializing the object */
 	void SetupSlotCounts();

--- a/gemrb/plugins/DLGImporter/DLGImporter.h
+++ b/gemrb/plugins/DLGImporter/DLGImporter.h
@@ -70,10 +70,10 @@ private:
 
 public:
 	DLGImporter(void);
-	~DLGImporter(void);
-	bool Open(DataStream* stream);
-	Dialog* GetDialog() const;
-	Condition* GetCondition(char *string) const;
+	~DLGImporter(void) override;
+	bool Open(DataStream* stream) override;
+	Dialog* GetDialog() const override;
+	Condition* GetCondition(char *string) const override;
 private:
 	DialogState* GetDialogState(Dialog *d, unsigned int index) const;
 	DialogTransition* GetTransition(unsigned int index) const;

--- a/gemrb/plugins/DirectoryImporter/DirectoryImporter.h
+++ b/gemrb/plugins/DirectoryImporter/DirectoryImporter.h
@@ -33,14 +33,14 @@ protected:
 
 public:
 	DirectoryImporter(void);
-	~DirectoryImporter(void);
-	bool Open(const char *dir, const char *desc);
+	~DirectoryImporter(void) override;
+	bool Open(const char *dir, const char *desc) override;
 	/** predicts the availability of a resource */
-	bool HasResource(const char* resname, SClass_ID type);
-	bool HasResource(const char* resname, const ResourceDesc &type);
+	bool HasResource(const char* resname, SClass_ID type) override;
+	bool HasResource(const char* resname, const ResourceDesc &type) override;
 	/** returns resource */
-	DataStream* GetResource(const char* resname, SClass_ID type);
-	DataStream* GetResource(const char* resname, const ResourceDesc &type);
+	DataStream* GetResource(const char* resname, SClass_ID type) override;
+	DataStream* GetResource(const char* resname, const ResourceDesc &type) override;
 };
 
 class CachedDirectoryImporter : public DirectoryImporter {
@@ -49,16 +49,16 @@ protected:
 
 public:
 	CachedDirectoryImporter();
-	~CachedDirectoryImporter();
+	~CachedDirectoryImporter() override;
 
-	bool Open(const char *dir, const char *desc);
+	bool Open(const char *dir, const char *desc) override;
 	void Refresh();
 	/** predicts the availability of a resource */
-	bool HasResource(const char* resname, SClass_ID type);
-	bool HasResource(const char* resname, const ResourceDesc &type);
+	bool HasResource(const char* resname, SClass_ID type) override;
+	bool HasResource(const char* resname, const ResourceDesc &type) override;
 	/** returns resource */
-	DataStream* GetResource(const char* resname, SClass_ID type);
-	DataStream* GetResource(const char* resname, const ResourceDesc &type);
+	DataStream* GetResource(const char* resname, SClass_ID type) override;
+	DataStream* GetResource(const char* resname, const ResourceDesc &type) override;
 };
 
 

--- a/gemrb/plugins/EFFImporter/EFFImporter.h
+++ b/gemrb/plugins/EFFImporter/EFFImporter.h
@@ -37,14 +37,14 @@ private:
 
 public:
 	EFFImporter(void);
-	~EFFImporter(void);
+	~EFFImporter(void) override;
 	// We need this autoFree, since Effects are included inline
 	// in other file types, without a size header.
-	bool Open(DataStream* stream, bool autoFree = true);
-	Effect* GetEffect(Effect *fx);
-	Effect* GetEffectV1(Effect *fx);
-	Effect* GetEffectV20(Effect *fx);
-	void PutEffectV2(DataStream *stream, const Effect *fx); // used in the area and cre importer
+	bool Open(DataStream* stream, bool autoFree = true) override;
+	Effect* GetEffect(Effect *fx) override;
+	Effect* GetEffectV1(Effect *fx) override;
+	Effect* GetEffectV20(Effect *fx) override;
+	void PutEffectV2(DataStream *stream, const Effect *fx) override; // used in the area and cre importer
 };
 
 

--- a/gemrb/plugins/GAMImporter/GAMImporter.h
+++ b/gemrb/plugins/GAMImporter/GAMImporter.h
@@ -51,13 +51,13 @@ private:
 	ieDword PPLocOffset, PPLocCount;
 public:
 	GAMImporter(void);
-	~GAMImporter(void);
-	bool Open(DataStream* stream);
-	Game* LoadGame(Game *newGame, int ver_override = 0);
+	~GAMImporter(void) override;
+	bool Open(DataStream* stream) override;
+	Game* LoadGame(Game *newGame, int ver_override = 0) override;
 
-	int GetStoredFileSize(Game *game);
+	int GetStoredFileSize(Game *game) override;
 	/* stores a gane in the savegame folder */
-	int PutGame(DataStream *stream, Game *game);
+	int PutGame(DataStream *stream, Game *game) override;
 private:
 	Actor* GetActor(Holder<ActorMgr> aM, bool is_in_party );
 	void GetPCStats(PCStatsStruct* ps, bool extended);

--- a/gemrb/plugins/GUIScript/GUIScript.h
+++ b/gemrb/plugins/GUIScript/GUIScript.h
@@ -63,22 +63,22 @@ private:
 
 public:
 	GUIScript(void);
-	~GUIScript(void);
+	~GUIScript(void) override;
 	/** Initialization Routine */
-	bool Init(void);
+	bool Init(void) override;
 	/** Autodetect GameType */
 	bool Autodetect(void);
 	/** Load Script */
-	bool LoadScript(const char* filename);
+	bool LoadScript(const char* filename) override;
 	/** Run Function */
-	bool RunFunction(const char* Modulename, const char* FunctionName, const FunctionParameters& params, bool report_error = true);
+	bool RunFunction(const char* Modulename, const char* FunctionName, const FunctionParameters& params, bool report_error = true) override;
 	// TODO: eleminate these RunFunction variants.
-	bool RunFunction(const char *module, const char* fname, bool report_error=true, int intparam=-1);
-	bool RunFunction(const char *module, const char* fname, bool report_error, Point param);
+	bool RunFunction(const char *module, const char* fname, bool report_error=true, int intparam=-1) override;
+	bool RunFunction(const char *module, const char* fname, bool report_error, Point param) override;
 	/** Exec a single File */
 	bool ExecFile(const char* file);
 	/** Exec a single String */
-	bool ExecString(const char* string, bool feedback=false);
+	bool ExecString(const char* string, bool feedback=false) override;
 	PyObject *RunFunction(const char* moduleName, const char* fname, PyObject* pArgs, bool report_error = true);
 
 	PyObject* ConstructObjectForScriptable(const ScriptingRefBase*);

--- a/gemrb/plugins/IDSImporter/IDSImporter.h
+++ b/gemrb/plugins/IDSImporter/IDSImporter.h
@@ -39,16 +39,16 @@ private:
 
 public:
 	IDSImporter(void);
-	~IDSImporter(void);
-	bool Open(DataStream* stream);
-	int GetValue(const char* txt) const;
-	char* GetValue(int val) const;
-	char* GetStringIndex(unsigned int Index) const;
-	int GetValueIndex(unsigned int Index) const;
-	int FindString(char *str, int len) const;
-	int FindValue(int val) const;
-	int GetSize() const { return pairs.size(); }
-	int GetHighestValue() const;
+	~IDSImporter(void) override;
+	bool Open(DataStream* stream) override;
+	int GetValue(const char* txt) const override;
+	char* GetValue(int val) const override;
+	char* GetStringIndex(unsigned int Index) const override;
+	int GetValueIndex(unsigned int Index) const override;
+	int FindString(char *str, int len) const override;
+	int FindValue(int val) const override;
+	int GetSize() const override { return pairs.size(); }
+	int GetHighestValue() const override;
 };
 
 #endif

--- a/gemrb/plugins/INIImporter/INIImporter.h
+++ b/gemrb/plugins/INIImporter/INIImporter.h
@@ -187,27 +187,27 @@ private:
 
 public:
 	INIImporter(void);
-	~INIImporter(void);
-	bool Open(DataStream* stream);
-	int GetTagsCount() const
+	~INIImporter(void) override;
+	bool Open(DataStream* stream) override;
+	int GetTagsCount() const override
 	{
 		return ( int ) tags.size();
 	}
-	const char* GetTagNameByIndex(int index) const
+	const char* GetTagNameByIndex(int index) const override
 	{
 		return tags[index]->GetTagName();
 	}
 
-	int GetKeysCount(const char* Tag) const;
-	const char* GetKeyNameByIndex(const char* Tag, int index) const;
+	int GetKeysCount(const char* Tag) const override;
+	const char* GetKeyNameByIndex(const char* Tag, int index) const override;
 	const char* GetKeyAsString(const char* Tag, const char* Key,
-		const char* Default) const;
+		const char* Default) const override;
 	int GetKeyAsInt(const char* Tag, const char* Key, 
-		const int Default) const;
+		const int Default) const override;
 	float GetKeyAsFloat(const char* Tag, const char* Key, 
-		const float Default) const;
+		const float Default) const override;
 	bool GetKeyAsBool(const char* Tag, const char* Key, 
-		const bool Default) const;
+		const bool Default) const override;
 };
 
 }

--- a/gemrb/plugins/ITMImporter/ITMImporter.h
+++ b/gemrb/plugins/ITMImporter/ITMImporter.h
@@ -40,9 +40,9 @@ private:
 
 public:
 	ITMImporter(void);
-	~ITMImporter(void);
-	bool Open(DataStream* stream);
-	Item* GetItem(Item *s);
+	~ITMImporter(void) override;
+	bool Open(DataStream* stream) override;
+	Item* GetItem(Item *s) override;
 private:
 	void GetExtHeader(Item *s, ITMExtHeader* eh);
 	void GetFeature(Effect *f, Item *s);

--- a/gemrb/plugins/KEYImporter/KEYImporter.h
+++ b/gemrb/plugins/KEYImporter/KEYImporter.h
@@ -136,14 +136,14 @@ private:
 	DataStream *GetStream(const char *resname, ieWord type);
 public:
 	KEYImporter(void);
-	~KEYImporter(void);
-	bool Open(const char *file, const char *desc);
+	~KEYImporter(void) override;
+	bool Open(const char *file, const char *desc) override;
 	/* predicts the availability of a resource */
-	bool HasResource(const char* resname, SClass_ID type);
-	bool HasResource(const char* resname, const ResourceDesc &type);
+	bool HasResource(const char* resname, SClass_ID type) override;
+	bool HasResource(const char* resname, const ResourceDesc &type) override;
 	/* returns resource */
-	DataStream* GetResource(const char* resname, SClass_ID type);
-	DataStream* GetResource(const char* resname, const ResourceDesc &type);
+	DataStream* GetResource(const char* resname, SClass_ID type) override;
+	DataStream* GetResource(const char* resname, const ResourceDesc &type) override;
 };
 
 }

--- a/gemrb/plugins/MOSImporter/MOSImporter.h
+++ b/gemrb/plugins/MOSImporter/MOSImporter.h
@@ -31,11 +31,11 @@ private:
 	ieDword BlockSize, PalOffset;
 public:
 	MOSImporter(void);
-	~MOSImporter(void);
-	bool Open(DataStream* stream);
-	Holder<Sprite2D> GetSprite2D();
-	int GetWidth() { return (int) Width; }
-	int GetHeight() { return (int) Height; }
+	~MOSImporter(void) override;
+	bool Open(DataStream* stream) override;
+	Holder<Sprite2D> GetSprite2D() override;
+	int GetWidth() override { return (int) Width; }
+	int GetHeight() override { return (int) Height; }
 };
 
 }

--- a/gemrb/plugins/MUSImporter/MUSImporter.h
+++ b/gemrb/plugins/MUSImporter/MUSImporter.h
@@ -58,24 +58,24 @@ private:
 	void PlayMusic(char* name);
 public:
 	MUSImporter();
-	~MUSImporter();
+	~MUSImporter() override;
 	/** Loads a PlayList for playing */
-	bool OpenPlaylist(const char* name);
+	bool OpenPlaylist(const char* name) override;
 	/** Initializes the PlayList Manager */
-	bool Init();
+	bool Init() override;
 	/** Switches the current PlayList while playing the current one */
-	int SwitchPlayList(const char* name, bool Hard);
+	int SwitchPlayList(const char* name, bool Hard) override;
 	/** Ends the Current PlayList Execution */
-	void End();
-	void HardEnd();
+	void End() override;
+	void HardEnd() override;
 	/** Start the PlayList Music Execution */
-	void Start();
+	void Start() override;
 	/** Plays the Next Entry */
-	void PlayNext();
+	void PlayNext() override;
 	/** Returns whether music is currently playing */
-	bool IsPlaying() { return Playing; }
+	bool IsPlaying() override { return Playing; }
 	/** Returns whether given playlist is currently loaded */
-	bool CurrentPlayList(const char* name);
+	bool CurrentPlayList(const char* name) override;
 };
 
 }

--- a/gemrb/plugins/MVEPlayer/MVEPlayer.h
+++ b/gemrb/plugins/MVEPlayer/MVEPlayer.h
@@ -53,12 +53,12 @@ private:
 				int size, int samplerate);
 
 protected:
-	bool DecodeFrame(VideoBuffer&);
+	bool DecodeFrame(VideoBuffer&) override;
 
 public:
 	MVEPlay(void);
-	~MVEPlay(void);
-	bool Open(DataStream* stream);
+	~MVEPlay(void) override;
+	bool Open(DataStream* stream) override;
 };
 
 }

--- a/gemrb/plugins/NullSound/NullSound.h
+++ b/gemrb/plugins/NullSound/NullSound.h
@@ -28,28 +28,28 @@ namespace GemRB {
 class NullSound : public Audio {
 public:
 	NullSound(void);
-	~NullSound(void);
-	bool Init(void);
+	~NullSound(void) override;
+	bool Init(void) override;
 	Holder<SoundHandle> Play(const char* ResRef, unsigned int channel,
-		int XPos, int YPos, unsigned int flags = 0, unsigned int *length = 0);
-	int CreateStream(Holder<SoundMgr>);
-	bool Play();
-	bool Stop();
-	bool Pause();
-	bool Resume();
-	bool CanPlay();
-	void ResetMusics();
-	void UpdateListenerPos(int XPos, int YPos);
-	void GetListenerPos(int& XPos, int& YPos);
-	void UpdateVolume(unsigned int) {}
+		int XPos, int YPos, unsigned int flags = 0, unsigned int *length = 0) override;
+	int CreateStream(Holder<SoundMgr>) override;
+	bool Play() override;
+	bool Stop() override;
+	bool Pause() override;
+	bool Resume() override;
+	bool CanPlay() override;
+	void ResetMusics() override;
+	void UpdateListenerPos(int XPos, int YPos) override;
+	void GetListenerPos(int& XPos, int& YPos) override;
+	void UpdateVolume(unsigned int) override {}
 
-	int SetupNewStream(ieWord x, ieWord y, ieWord z, ieWord gain, bool point, int ambientRange);
-	int QueueAmbient(int stream, const char* sound);
-	bool ReleaseStream(int stream, bool hardstop);
-	void SetAmbientStreamVolume(int stream, int gain);
-	void SetAmbientStreamPitch(int stream, int pitch);
+	int SetupNewStream(ieWord x, ieWord y, ieWord z, ieWord gain, bool point, int ambientRange) override;
+	int QueueAmbient(int stream, const char* sound) override;
+	bool ReleaseStream(int stream, bool hardstop) override;
+	void SetAmbientStreamVolume(int stream, int gain) override;
+	void SetAmbientStreamPitch(int stream, int pitch) override;
 	void QueueBuffer(int stream, unsigned short bits, int channels,
-				short* memory, int size, int samplerate);
+				short* memory, int size, int samplerate) override;
 
 private:
 	int XPos, YPos;

--- a/gemrb/plugins/NullSource/NullSource.h
+++ b/gemrb/plugins/NullSource/NullSource.h
@@ -28,12 +28,12 @@ namespace GemRB {
 class NullSource : public ResourceSource {
 public:
 	NullSource(void);
-	virtual ~NullSource(void);
-	virtual bool Open(const char *filename, const char *description);
-	virtual bool HasResource(const char* resname, SClass_ID type);
-	virtual bool HasResource(const char* resname, const ResourceDesc &type);
-	virtual DataStream* GetResource(const char* resname, SClass_ID type);
-	virtual DataStream* GetResource(const char* resname, const ResourceDesc &type);
+	~NullSource(void) override;
+	bool Open(const char *filename, const char *description) override;
+	bool HasResource(const char* resname, SClass_ID type) override;
+	bool HasResource(const char* resname, const ResourceDesc &type) override;
+	DataStream* GetResource(const char* resname, SClass_ID type) override;
+	DataStream* GetResource(const char* resname, const ResourceDesc &type) override;
 };
 
 }

--- a/gemrb/plugins/OGGReader/OGGReader.h
+++ b/gemrb/plugins/OGGReader/OGGReader.h
@@ -42,7 +42,7 @@ public:
 	{
 		memset(&OggStream, 0, sizeof(OggStream) );
 	}
-	virtual ~OGGReader()
+	~OGGReader() override
 	{
 		Close();
 	}
@@ -50,8 +50,8 @@ public:
 	{
 		ov_clear(&OggStream);
 	}
-	bool Open(DataStream* stream);
-	int read_samples(short* buffer, int count);
+	bool Open(DataStream* stream) override;
+	int read_samples(short* buffer, int count) override;
 };
 
 }

--- a/gemrb/plugins/OpenALAudio/AmbientMgrAL.h
+++ b/gemrb/plugins/OpenALAudio/AmbientMgrAL.h
@@ -37,13 +37,13 @@ class AmbientMgrAL : public AmbientMgr {
 public:
 	AmbientMgrAL() : AmbientMgr(), mutex(SDL_CreateMutex()), 
 			player(NULL), cond(SDL_CreateCond()) { }
-	~AmbientMgrAL() { reset(); SDL_DestroyMutex(mutex); SDL_DestroyCond(cond); }
-	void reset();
-	void setAmbients(const std::vector<Ambient *> &a);
-	void activate(const std::string &name);
-	void activate();
-	void deactivate(const std::string &name);
-	void deactivate();
+	~AmbientMgrAL() override { reset(); SDL_DestroyMutex(mutex); SDL_DestroyCond(cond); }
+	void reset() override;
+	void setAmbients(const std::vector<Ambient *> &a) override;
+	void activate(const std::string &name) override;
+	void activate() override;
+	void deactivate(const std::string &name) override;
+	void deactivate() override;
 	void UpdateVolume(unsigned short value);
 private:
 	class AmbientSource {

--- a/gemrb/plugins/OpenALAudio/OpenALAudio.h
+++ b/gemrb/plugins/OpenALAudio/OpenALAudio.h
@@ -68,11 +68,11 @@ protected:
 
 public:
 	OpenALSoundHandle(AudioStream *p) : parent(p) { }
-	virtual ~OpenALSoundHandle() { }
-	virtual void SetPos(int XPos, int YPos);
-	virtual bool Playing();
-	virtual void Stop();
-	virtual void StopLooping();
+	~OpenALSoundHandle() override { }
+	void SetPos(int XPos, int YPos) override;
+	bool Playing() override;
+	void Stop() override;
+	void StopLooping() override;
 	void Invalidate() { parent = 0; }
 };
 
@@ -102,32 +102,32 @@ struct CacheEntry {
 class OpenALAudioDriver : public Audio {
 public:
 	OpenALAudioDriver(void);
-	~OpenALAudioDriver(void);
+	~OpenALAudioDriver(void) override;
 	void PrintDeviceList();
-	bool Init(void);
+	bool Init(void) override;
 	Holder<SoundHandle> Play(const char* ResRef, unsigned int channel,
 					int XPos, int YPos, unsigned int flags = 0,
-					unsigned int *length = 0);
-	void UpdateVolume(unsigned int flags);
-	bool CanPlay();
-	void ResetMusics();
-	bool Play();
-	bool Stop();
-	bool Pause();
-	bool Resume();
-	int CreateStream(Holder<SoundMgr>);
-	void UpdateListenerPos(int XPos, int YPos );
-	void GetListenerPos( int &XPos, int &YPos );
-	bool ReleaseStream(int stream, bool HardStop);
+					unsigned int *length = 0) override;
+	void UpdateVolume(unsigned int flags) override;
+	bool CanPlay() override;
+	void ResetMusics() override;
+	bool Play() override;
+	bool Stop() override;
+	bool Pause() override;
+	bool Resume() override;
+	int CreateStream(Holder<SoundMgr>) override;
+	void UpdateListenerPos(int XPos, int YPos ) override;
+	void GetListenerPos( int &XPos, int &YPos ) override;
+	bool ReleaseStream(int stream, bool HardStop) override;
 	int SetupNewStream( ieWord x, ieWord y, ieWord z,
-					ieWord gain, bool point, int ambientRange);
-	int QueueAmbient(int stream, const char* sound);
-	void SetAmbientStreamVolume(int stream, int volume);
-	void SetAmbientStreamPitch(int stream, int pitch);
+					ieWord gain, bool point, int ambientRange) override;
+	int QueueAmbient(int stream, const char* sound) override;
+	void SetAmbientStreamVolume(int stream, int volume) override;
+	void SetAmbientStreamPitch(int stream, int pitch) override;
 	void QueueBuffer(int stream, unsigned short bits,
 				int channels, short* memory,
-				int size, int samplerate);
-	void UpdateMapAmbient(MapReverb&);
+				int size, int samplerate) override;
+	void UpdateMapAmbient(MapReverb&) override;
 private:
 	int QueueALBuffer(ALuint source, ALuint buffer);
 

--- a/gemrb/plugins/PLTImporter/PLTImporter.h
+++ b/gemrb/plugins/PLTImporter/PLTImporter.h
@@ -31,9 +31,9 @@ private:
 	void* pixels;
 public:
 	PLTImporter(void);
-	~PLTImporter(void);
-	bool Open(DataStream* stream);
-	Holder<Sprite2D> GetSprite2D(unsigned int type, ieDword col[8]);
+	~PLTImporter(void) override;
+	bool Open(DataStream* stream) override;
+	Holder<Sprite2D> GetSprite2D(unsigned int type, ieDword col[8]) override;
 };
 
 }

--- a/gemrb/plugins/PNGImporter/PNGImporter.h
+++ b/gemrb/plugins/PNGImporter/PNGImporter.h
@@ -35,13 +35,13 @@ private:
 	bool hasPalette;
 public:
 	PNGImporter(void);
-	~PNGImporter(void);
+	~PNGImporter(void) override;
 	void Close();
-	bool Open(DataStream* stream);
-	Holder<Sprite2D> GetSprite2D();
-	int GetPalette(int colors, Color* pal);
-	int GetWidth() { return (int) Width; }
-	int GetHeight() { return (int) Height; }
+	bool Open(DataStream* stream) override;
+	Holder<Sprite2D> GetSprite2D() override;
+	int GetPalette(int colors, Color* pal) override;
+	int GetWidth() override { return (int) Width; }
+	int GetHeight() override { return (int) Height; }
 };
 
 }

--- a/gemrb/plugins/PROImporter/PROImporter.h
+++ b/gemrb/plugins/PROImporter/PROImporter.h
@@ -37,9 +37,9 @@ private:
 
 public:
 	PROImporter(void);
-	~PROImporter(void);
-	bool Open(DataStream* stream);
-	Projectile* GetProjectile(Projectile *s);
+	~PROImporter(void) override;
+	bool Open(DataStream* stream) override;
+	Projectile* GetProjectile(Projectile *s) override;
 private:
 	void GetAreaExtension(ProjectileExtension *s);
 };

--- a/gemrb/plugins/SAVImporter/SAVImporter.h
+++ b/gemrb/plugins/SAVImporter/SAVImporter.h
@@ -32,10 +32,10 @@ namespace GemRB {
 class SAVImporter : public ArchiveImporter {
 public:
 	SAVImporter(void);
-	~SAVImporter(void);
-	int DecompressSaveGame(DataStream *compressed);
-	int AddToSaveGame(DataStream *str, DataStream *uncompressed);
-	int CreateArchive(DataStream *compressed);
+	~SAVImporter(void) override;
+	int DecompressSaveGame(DataStream *compressed) override;
+	int AddToSaveGame(DataStream *str, DataStream *uncompressed) override;
+	int CreateArchive(DataStream *compressed) override;
 };
 
 }

--- a/gemrb/plugins/SDLAudio/SDLAudio.h
+++ b/gemrb/plugins/SDLAudio/SDLAudio.h
@@ -46,28 +46,28 @@ struct CacheEntry {
 class SDLAudio : public Audio {
 public:
 	SDLAudio(void);
-	~SDLAudio(void);
-	bool Init(void);
+	~SDLAudio(void) override;
+	bool Init(void) override;
 	Holder<SoundHandle> Play(const char* ResRef, unsigned int channel,
-		int XPos, int YPos, unsigned int flags = 0, unsigned int *length = 0);
-	int CreateStream(Holder<SoundMgr>);
-	bool Play();
-	bool Stop();
-	bool Pause() { return true; } /*not implemented*/
-	bool Resume() { return true; } /*not implemented*/
-	bool CanPlay();
-	void ResetMusics();
-	void UpdateListenerPos(int XPos, int YPos);
-	void GetListenerPos(int& XPos, int& YPos);
-	void UpdateVolume(unsigned int) {}
+		int XPos, int YPos, unsigned int flags = 0, unsigned int *length = 0) override;
+	int CreateStream(Holder<SoundMgr>) override;
+	bool Play() override;
+	bool Stop() override;
+	bool Pause() override { return true; } /*not implemented*/
+	bool Resume() override { return true; } /*not implemented*/
+	bool CanPlay() override;
+	void ResetMusics() override;
+	void UpdateListenerPos(int XPos, int YPos) override;
+	void GetListenerPos(int& XPos, int& YPos) override;
+	void UpdateVolume(unsigned int) override {}
 
-	int SetupNewStream(ieWord x, ieWord y, ieWord z, ieWord gain, bool point, int ambientRange);
-	int QueueAmbient(int stream, const char* sound);
-	bool ReleaseStream(int stream, bool hardstop);
-	void SetAmbientStreamVolume(int stream, int gain);
-	void SetAmbientStreamPitch(int stream, int pitch);
+	int SetupNewStream(ieWord x, ieWord y, ieWord z, ieWord gain, bool point, int ambientRange) override;
+	int QueueAmbient(int stream, const char* sound) override;
+	bool ReleaseStream(int stream, bool hardstop) override;
+	void SetAmbientStreamVolume(int stream, int gain) override;
+	void SetAmbientStreamPitch(int stream, int pitch) override;
 	void QueueBuffer(int stream, unsigned short bits, int channels,
-				short* memory, int size, int samplerate);
+				short* memory, int size, int samplerate) override;
 
 private:
 	void FreeBuffers();

--- a/gemrb/plugins/SDLVideo/SDL12Video.h
+++ b/gemrb/plugins/SDLVideo/SDL12Video.h
@@ -34,7 +34,7 @@ private:
 
 public:
 	SDL12VideoDriver(void);
-	~SDL12VideoDriver();
+	~SDL12VideoDriver() override;
 	
 	int Init(void) override;
 	void SetWindowTitle(const char *title) override { SDL_WM_SetCaption(title, 0); };
@@ -104,11 +104,11 @@ public:
 		Clear();
 	}
 
-	~SDLSurfaceVideoBuffer() {
+	~SDLSurfaceVideoBuffer() override {
 		SDL_FreeSurface(buffer);
 	}
 
-	void Clear() {
+	void Clear() override {
 		if (buffer->flags & SDL_SRCCOLORKEY) {
 			SDL_FillRect(buffer, NULL, buffer->format->colorkey);
 		} else {
@@ -120,14 +120,14 @@ public:
 		return buffer;
 	}
 
-	bool RenderOnDisplay(void* display) const {
+	bool RenderOnDisplay(void* display) const override {
 		SDL_Surface* sdldisplay = static_cast<SDL_Surface*>(display);
 		SDL_Rect dst = RectFromRegion(rect);
 		SDL_BlitSurface( buffer, NULL, sdldisplay, &dst );
 		return true;
 	}
 
-	void CopyPixels(const Region& bufDest, const void* pixelBuf, const int* pitch = NULL, ...) {
+	void CopyPixels(const Region& bufDest, const void* pixelBuf, const int* pitch = NULL, ...) override {
 		SDL_Surface* sprite = NULL;
 
 		// we can safely const_cast pixelBuf because the surface is destroyed before return and we dont alter it
@@ -164,13 +164,13 @@ public:
 		changed = false;
 	}
 
-	~SDLOverlayVideoBuffer() {
+	~SDLOverlayVideoBuffer() override {
 		SDL_FreeYUVOverlay(overlay);
 	}
 
-	void Clear() {}
+	void Clear() override {}
 
-	bool RenderOnDisplay(void* /*display*/) const {
+	bool RenderOnDisplay(void* /*display*/) const override {
 		if (changed) {
 			SDL_Rect dest = RectFromRegion(rect);
 			SDL_DisplayYUVOverlay(overlay, &dest);
@@ -190,7 +190,7 @@ public:
 		return false;
 	}
 
-	void CopyPixels(const Region& bufDest, const void* pixelBuf, const int* pitch = NULL, ...) {
+	void CopyPixels(const Region& bufDest, const void* pixelBuf, const int* pitch = NULL, ...) override {
 		va_list args;
 		va_start(args, pitch);
 

--- a/gemrb/plugins/SDLVideo/SDL20Video.h
+++ b/gemrb/plugins/SDLVideo/SDL20Video.h
@@ -100,12 +100,12 @@ public:
 		Clear();
 	}
 
-	~SDLTextureVideoBuffer() {
+	~SDLTextureVideoBuffer() override {
 		SDL_DestroyTexture(texture);
 		SDL_FreeSurface(conversionBuffer);
 	}
 
-	void Clear() {
+	void Clear() override {
 		SDL_SetRenderTarget(renderer, texture);
 		SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_TRANSPARENT);
 #if SDL_COMPILEDVERSION == SDL_VERSIONNUM(2, 0, 10)
@@ -119,7 +119,7 @@ public:
 		SDL_RenderClear(renderer);
 	}
 
-	bool RenderOnDisplay(void* display) const {
+	bool RenderOnDisplay(void* display) const override {
 		SDL_Renderer* renderer = static_cast<SDL_Renderer*>(display);
 		SDL_Rect dst = RectFromRegion(rect);
 		SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
@@ -130,7 +130,7 @@ public:
 		return true;
 	}
 
-	void CopyPixels(const Region& bufDest, const void* pixelBuf, const int* pitch = NULL, ...) {
+	void CopyPixels(const Region& bufDest, const void* pixelBuf, const int* pitch = NULL, ...) override {
 		int sdlpitch = bufDest.w * SDL_BYTESPERPIXEL(nativeFormat);
 		SDL_Rect dest = RectFromRegion(bufDest);
 
@@ -212,7 +212,7 @@ private:
 
 public:
 	SDL20VideoDriver(void);
-	~SDL20VideoDriver(void);
+	~SDL20VideoDriver(void) override;
 
 	int Init() override;
 

--- a/gemrb/plugins/SDLVideo/SDLPixelIterator.h
+++ b/gemrb/plugins/SDLVideo/SDLPixelIterator.h
@@ -144,7 +144,7 @@ public:
 		colorKey = orig.colorKey;
 	}
 
-	~SDLPixelIterator() {
+	~SDLPixelIterator() override {
 		delete imp;
 	}
 
@@ -188,7 +188,7 @@ public:
 		return static_cast<Uint8*>(imp->pixel);
 	}
 
-	Uint8 Channel(Uint32 mask, Uint8 shift) const {
+	Uint8 Channel(Uint32 mask, Uint8 shift) const override {
 		switch (format->BytesPerPixel) {
 			case 1:
 				return static_cast<PixelIterator<Uint8>*>(imp)->Channel(mask, shift);
@@ -203,11 +203,11 @@ public:
 		}
 	}
 
-	IPixelIterator* Clone() const {
+	IPixelIterator* Clone() const override {
 		return new SDLPixelIterator(*this);
 	}
 
-	void Advance(int amt) {
+	void Advance(int amt) override {
 		imp->Advance(amt);
 	}
 	
@@ -291,7 +291,7 @@ public:
 		}
 	}
 	
-	const Point& Position() const {
+	const Point& Position() const override {
 		return imp->Position();
 	}
 };

--- a/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.h
+++ b/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.h
@@ -39,7 +39,7 @@ protected:
 		PaletteHolder palette; // simply a cache for comparing against calls to SetPalette for performance reasons.
 
 		SurfaceHolder(SDL_Surface* surf) : surface(surf), palette(NULL) {}
-		~SurfaceHolder() { SDL_FreeSurface(surface); }
+		~SurfaceHolder() override { SDL_FreeSurface(surface); }
 
 		SDL_Surface* operator->() { return surface; }
 		operator SDL_Surface* () { return surface; }

--- a/gemrb/plugins/SDLVideo/SDLVideo.h
+++ b/gemrb/plugins/SDLVideo/SDLVideo.h
@@ -65,7 +65,7 @@ inline int GetModState(int modstate)
 class SDLVideoDriver : public Video {
 public:
 	SDLVideoDriver(void);
-	virtual ~SDLVideoDriver(void);
+	~SDLVideoDriver(void) override;
 	int Init(void) override;
 
 	Holder<Sprite2D> CreateSprite(const Region& rgn, int bpp, ieDword rMask,

--- a/gemrb/plugins/SPLImporter/SPLImporter.h
+++ b/gemrb/plugins/SPLImporter/SPLImporter.h
@@ -37,9 +37,9 @@ private:
 
 public:
 	SPLImporter(void);
-	~SPLImporter(void);
-	bool Open(DataStream* stream);
-	Spell* GetSpell(Spell *spl, bool silent=false);
+	~SPLImporter(void) override;
+	bool Open(DataStream* stream) override;
+	Spell* GetSpell(Spell *spl, bool silent=false) override;
 private:
 	void GetExtHeader(Spell *s, SPLExtHeader* eh);
 	void GetFeature(Spell *s, Effect *f);

--- a/gemrb/plugins/STOImporter/STOImporter.h
+++ b/gemrb/plugins/STOImporter/STOImporter.h
@@ -37,14 +37,14 @@ private:
 
 public:
 	STOImporter(void);
-	~STOImporter(void);
-	bool Open(DataStream* stream);
-	Store* GetStore(Store *store);
+	~STOImporter(void) override;
+	bool Open(DataStream* stream) override;
+	Store* GetStore(Store *store) override;
 
 	//returns saved size, updates internal offsets before save
 	void CalculateStoredFileSize(Store *st) const;
 	//saves file
-	bool PutStore(DataStream *stream, Store *store);
+	bool PutStore(DataStream *stream, Store *store) override;
 
 private:
 	void GetItem(STOItem *item, Store* s);

--- a/gemrb/plugins/TISImporter/TISImporter.h
+++ b/gemrb/plugins/TISImporter/TISImporter.h
@@ -34,10 +34,10 @@ private:
 	ieDword TileSize = 0;
 public:
 	TISImporter(void);
-	~TISImporter(void);
-	bool Open(DataStream* stream);
+	~TISImporter(void) override;
+	bool Open(DataStream* stream) override;
 	Tile* GetTile(unsigned short* indexes, int count,
-		unsigned short* secondary = NULL);
+		unsigned short* secondary = NULL) override;
 	Holder<Sprite2D> GetTile(int index);
 public:
 };

--- a/gemrb/plugins/TLKImporter/TLKImporter.h
+++ b/gemrb/plugins/TLKImporter/TLKImporter.h
@@ -42,20 +42,20 @@ private:
 
 public:
 	TLKImporter(void);
-	~TLKImporter(void);
+	~TLKImporter(void) override;
 	/** open string refs coming from saved game */
-	void OpenAux();
+	void OpenAux() override;
 	/** purge string defs coming from saved game */
 	void CloseAux() final;
-	bool Open(DataStream* stream);
+	bool Open(DataStream* stream) override;
 	/** construct a new custom string */
-	ieStrRef UpdateString(ieStrRef strref, const char *newvalue);
+	ieStrRef UpdateString(ieStrRef strref, const char *newvalue) override;
 	/** resolve a string reference */
-	String* GetString(ieStrRef strref, ieDword flags = 0);
-	char* GetCString(ieStrRef strref, ieDword flags = 0);
-	StringBlock GetStringBlock(ieStrRef strref, unsigned int flags = 0);
+	String* GetString(ieStrRef strref, ieDword flags = 0) override;
+	char* GetCString(ieStrRef strref, ieDword flags = 0) override;
+	StringBlock GetStringBlock(ieStrRef strref, unsigned int flags = 0) override;
 	void FreeString(char *str);
-	bool HasAltTLK() const;
+	bool HasAltTLK() const override;
 private:
 	/** resolves day and monthname tokens */
 	void GetMonthName(int dayandmonth);

--- a/gemrb/plugins/TTFImporter/TTFFont.h
+++ b/gemrb/plugins/TTFImporter/TTFFont.h
@@ -38,10 +38,10 @@ private:
 
 public:
 	TTFFont(PaletteHolder pal, FT_Face face, int lineheight, int baseline);
-	~TTFFont(void);
+	~TTFFont(void) override;
 
-	const Glyph& GetGlyph(ieWord chr) const;
-	int GetKerningOffset(ieWord leftChr, ieWord rightChr) const;
+	const Glyph& GetGlyph(ieWord chr) const override;
+	int GetKerningOffset(ieWord leftChr, ieWord rightChr) const override;
 };
 
 }

--- a/gemrb/plugins/TTFImporter/TTFFontManager.h
+++ b/gemrb/plugins/TTFImporter/TTFFontManager.h
@@ -39,7 +39,7 @@ public:
 /*
 Public methods
 */
-	~TTFFontManager(void);
+	~TTFFontManager(void) override;
 	TTFFontManager(void);
 
 	bool Open(DataStream* stream) override;

--- a/gemrb/plugins/VLCPlayer/VLCPlayer.h
+++ b/gemrb/plugins/VLCPlayer/VLCPlayer.h
@@ -57,14 +57,14 @@ private:
 	static unsigned setup(void **opaque, char *chroma, unsigned *width, unsigned *height, unsigned *pitches, unsigned *lines);
 
 private:
-	bool DecodeFrame(VideoBuffer&);
+	bool DecodeFrame(VideoBuffer&) override;
 	void DestroyPlayer();
 
 public:
 	VLCPlayer();
-	~VLCPlayer();
+	~VLCPlayer() override;
 
-	bool Open(DataStream* stream);
+	bool Open(DataStream* stream) override;
 };
 
 }

--- a/gemrb/plugins/WAVReader/WAVReader.h
+++ b/gemrb/plugins/WAVReader/WAVReader.h
@@ -44,8 +44,8 @@ public:
 	{
 	}
 
-	bool Open(DataStream* stream);
-	virtual int read_samples(short* buffer, int count);
+	bool Open(DataStream* stream) override;
+	int read_samples(short* buffer, int count) override;
 };
 
 // WAV files
@@ -55,7 +55,7 @@ public:
 		: RawPCMReader( 16 )
 	{
 	}
-	bool Open(DataStream* stream);
+	bool Open(DataStream* stream) override;
 };
 
 }

--- a/gemrb/plugins/WEDImporter/WEDImporter.h
+++ b/gemrb/plugins/WEDImporter/WEDImporter.h
@@ -65,21 +65,21 @@ private:
 	void GetDoorPolygonCount(ieWord count, ieDword offset);
 	int AddOverlay(TileMap *tm, const Overlay *overlays, bool rain) const;
 	void ReadWallPolygons();
-	WallPolygonGroup MakeGroupFromTableEntries(size_t idx, size_t cnt) const;
+	WallPolygonGroup MakeGroupFromTableEntries(size_t idx, size_t cnt) const override;
 
 public:
 	WEDImporter(void);
-	~WEDImporter(void);
-	bool Open(DataStream* stream);
+	~WEDImporter(void) override;
+	bool Open(DataStream* stream) override;
 	//if tilemap already exists, don't create it
-	TileMap* GetTileMap(TileMap *tm) const;
-	ieWord* GetDoorIndices(char* ResRef, int* count, bool& BaseClosed);
+	TileMap* GetTileMap(TileMap *tm) const override;
+	ieWord* GetDoorIndices(char* ResRef, int* count, bool& BaseClosed) override;
 
-	std::vector<WallPolygonGroup> GetWallGroups() const;
+	std::vector<WallPolygonGroup> GetWallGroups() const override;
 
-	WallPolygonGroup OpenDoorPolygons() const;
-	WallPolygonGroup ClosedDoorPolygons() const;
-	void SetExtendedNight(bool night) { ExtendedNight = night; }
+	WallPolygonGroup OpenDoorPolygons() const override;
+	WallPolygonGroup ClosedDoorPolygons() const override;
+	void SetExtendedNight(bool night) override { ExtendedNight = night; }
 };
 
 }

--- a/gemrb/plugins/WMPImporter/WMPImporter.h
+++ b/gemrb/plugins/WMPImporter/WMPImporter.h
@@ -41,12 +41,12 @@ private:
 
 public:
 	WMPImporter(void);
-	~WMPImporter(void);
-	bool Open(DataStream* stream1, DataStream* stream2);
-	WorldMapArray *GetWorldMapArray();
+	~WMPImporter(void) override;
+	bool Open(DataStream* stream1, DataStream* stream2) override;
+	WorldMapArray *GetWorldMapArray() override;
 
-	int GetStoredFileSize(WorldMapArray *wmap, unsigned int index);
-	int PutWorldMap(DataStream* stream1, DataStream* stream2, WorldMapArray *wmap);
+	int GetStoredFileSize(WorldMapArray *wmap, unsigned int index) override;
+	int PutWorldMap(DataStream* stream1, DataStream* stream2, WorldMapArray *wmap) override;
 private:
 	void GetWorldMap(DataStream *str, WorldMap *m, unsigned int index);
 

--- a/gemrb/plugins/ZLibManager/ZLibManager.h
+++ b/gemrb/plugins/ZLibManager/ZLibManager.h
@@ -28,11 +28,11 @@ namespace GemRB {
 class ZLibManager : public Compressor {
 public:
 	ZLibManager(void);
-	~ZLibManager(void);
+	~ZLibManager(void) override;
 	// ZLib Decompression Routine
-	int Decompress(DataStream* dest, DataStream* source, unsigned int size_guess) const;
+	int Decompress(DataStream* dest, DataStream* source, unsigned int size_guess) const override;
 	// ZLib Compression
-	int Compress(DataStream* dest, DataStream* source) const;
+	int Compress(DataStream* dest, DataStream* source) const override;
 };
 
 }

--- a/platforms/android/GemRB.cpp
+++ b/platforms/android/GemRB.cpp
@@ -34,12 +34,12 @@
 // pause audio playing if app goes in background
 static void appPutToBackground()
 {
-  core->GetAudioDrv()->Pause();
+  GemRB::core->GetAudioDrv()->Pause();
 }
 // resume audio playing if app return to foreground
 static void appPutToForeground()
 {
-  core->GetAudioDrv()->Resume();
+  GemRB::core->GetAudioDrv()->Resume();
 }
 
 #endif


### PR DESCRIPTION
## Description
Hello, I've been browsing issues list, and found information about modernizing code. I thought it would be fun to give clang-tidy a try.

This MR adds `override` support. I've disabled all other checks, and used only [modernize-use-override](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-override.html). Worked remarkably well, there were few issues (`GLuint` was replaced with `uint`, and one file had dos endings, so I converted it to unix format). I checked all changes, and didn't notice further problems. It builds cleanly with gcc and clang. And since gemrb already requires C++11 compiler, I hope it builds without problem with MS compiler as well.

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [X] I have tested the proposed changes
- [X] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
