### PR TITLE
OpenAL Audio crash fix

### DIFF
--- a/gemrb/plugins/OpenALAudio/AmbientMgrAL.cpp
+++ b/gemrb/plugins/OpenALAudio/AmbientMgrAL.cpp
@@ -47,9 +47,11 @@ AmbientMgrAL::~AmbientMgrAL()
 	mutex.unlock();
 	
 	cond.notify_all();
-	
-	if (player.joinable())
-		player.join();
+
+	if (player && player->joinable()) {
+		player->join();
+		delete player;
+	}
 }
 
 void AmbientMgrAL::setAmbients(const std::vector<Ambient *> &a)
@@ -62,7 +64,7 @@ void AmbientMgrAL::setAmbients(const std::vector<Ambient *> &a)
 	}
 	core->GetAudioDrv()->UpdateVolume( GEM_SND_VOL_AMBIENTS );
 
-	player = std::thread(&AmbientMgrAL::play, this);
+	player = new std::thread(&AmbientMgrAL::play, this);
 }
 
 void AmbientMgrAL::activate(const std::string &name)

--- a/gemrb/plugins/OpenALAudio/AmbientMgrAL.h
+++ b/gemrb/plugins/OpenALAudio/AmbientMgrAL.h
@@ -35,7 +35,7 @@ class Ambient;
 
 class AmbientMgrAL : public AmbientMgr {
 public:
-	AmbientMgrAL() : AmbientMgr() { }
+	AmbientMgrAL() : AmbientMgr(), player(nullptr) { }
 	~AmbientMgrAL();
 
 	void setAmbients(const std::vector<Ambient *> &a);
@@ -70,7 +70,7 @@ private:
 	void hardStop() const;
 	
 	std::mutex mutex;
-	std::thread player;
+	std::thread *player;
 	std::condition_variable cond;
 };
 


### PR DESCRIPTION
## Description

I tried a recent build and I can realiably reproduce an error when changing a map for example:

```
(gdb) bt
#0  0x00007ffaeaf5f1e7 in msvcrt!abort () from C:\Windows\System32\msvcrt.dll
#1  0x00007ffa9b41ef2a in ?? () from C:\MSYS2\mingw64\bin\libstdc++-6.dll
#2  0x00007ffa9b417929 in ?? () from C:\MSYS2\mingw64\bin\libstdc++-6.dll
#3  0x00007ffa9b4f63a3 in ?? () from C:\MSYS2\mingw64\bin\libstdc++-6.dll
#4  0x00007ffa99c82118 in std::thread::operator= (__t=..., this=0x1f8edb527b8)
    at C:/MSYS2/mingw64/include/c++/10.2.0/thread:170
#5  GemRB::AmbientMgrAL::setAmbients (this=0x1f8edb52770,
    a=std::vector of length 275897130, capacity 1385255304 = {...})
    at D:/Sources/gemrb/gemrb/plugins/OpenALAudio/AmbientMgrAL.cpp:65
#6  0x00007ffa94796b10 in GemRB::Game::GetMap (this=this@entry=0x1f8838ed950,
    areaname=areaname@entry=0x1f8839ae070 "ar6500", change=change@entry=true)
    at D:/Sources/gemrb/gemrb/core/Game.cpp:756
#7  0x00007ffa9477e6db in GemRB::GameControl::ChangeMap (
    this=this@entry=0x1f8838d1f30, pc=0x1f8839ade00,
    forced=forced@entry=false)
    at D:/Sources/gemrb/gemrb/core/GUI/GameControl.cpp:2548
#8  0x00007ffa947cc9b6 in GemRB::Interface::GameLoop (
    this=this@entry=0x1f8eaf15e50)
    at D:/Sources/gemrb/gemrb/core/Interface.cpp:3060
#9  0x00007ffa947d22d5 in GemRB::Interface::Main (this=0x1f8eaf15e50)
    at D:/Sources/gemrb/gemrb/core/Interface.cpp:1025
#10 0x00007ff6d63527d6 in main (argc=1, argv=0x1f8eaf12590)
    at D:/Sources/gemrb/gemrb/GemRB.cpp:152
```

When I read the docs of [std::thread ::operator=](https://en.cppreference.com/w/cpp/thread/thread/operator%3D), it sounds as if you can only do this when a thread is terminated or after detaching the object, nothing what we want there. So let's do it this way instead (until there is std::optional).

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
