### PR TITLE
TextArea conflict with windows winuser.h

### DIFF
--- a/gemrb/core/GUI/TextArea.cpp
+++ b/gemrb/core/GUI/TextArea.cpp
@@ -47,8 +47,8 @@ TextArea::SpanSelector::SpanSelector(TextArea& ta, const std::vector<const Strin
 	r.w = std::max(r.w - margin.left - margin.right, 0);
 	r.h = std::max(r.h - margin.top - margin.bottom, 0);
 	
-	Font::PrintColors colors {ta.colors[COLOR_OPTIONS], ta.colors[COLOR_BACKGROUND]};
-	Font::PrintColors selectedCol {ta.colors[COLOR_SELECTED], ta.colors[COLOR_BACKGROUND]};
+	Font::PrintColors colors {ta.colors[COLOR_OPTIONS], ta.colors[COLOR_BACKDROP]};
+	Font::PrintColors selectedCol {ta.colors[COLOR_SELECTED], ta.colors[COLOR_BACKDROP]};
 
 	for (size_t i = 0; i < opts.size(); i++) {
 		TextContainer* selOption = new OptSpan(r, ta.ftext, colors.fg, colors.bg);
@@ -133,10 +133,10 @@ void TextArea::SpanSelector::ClearHover()
 {
 	if (hoverSpan) {
 		if (hoverSpan == selectedSpan) {
-			hoverSpan->SetColors(ta.colors[COLOR_SELECTED], ta.colors[COLOR_BACKGROUND]);
+			hoverSpan->SetColors(ta.colors[COLOR_SELECTED], ta.colors[COLOR_BACKDROP]);
 		} else {
 			// reset the old hover span
-			hoverSpan->SetColors(ta.colors[COLOR_OPTIONS], ta.colors[COLOR_BACKGROUND]);
+			hoverSpan->SetColors(ta.colors[COLOR_OPTIONS], ta.colors[COLOR_BACKDROP]);
 		}
 		hoverSpan = NULL;
 	}
@@ -152,12 +152,12 @@ void TextArea::SpanSelector::MakeSelection(size_t idx)
 
 	if (selectedSpan && selectedSpan != optspan) {
 		// reset the previous selection
-		selectedSpan->SetColors(ta.colors[COLOR_OPTIONS], ta.colors[COLOR_BACKGROUND]);
+		selectedSpan->SetColors(ta.colors[COLOR_OPTIONS], ta.colors[COLOR_BACKDROP]);
 	}
 	selectedSpan = optspan;
 	
 	if (selectedSpan) {
-		selectedSpan->SetColors(ta.colors[COLOR_SELECTED], ta.colors[COLOR_BACKGROUND]);
+		selectedSpan->SetColors(ta.colors[COLOR_SELECTED], ta.colors[COLOR_BACKDROP]);
 	}
 
 	// beware, this will recursively call this function.
@@ -192,7 +192,7 @@ bool TextArea::SpanSelector::OnMouseOver(const MouseEvent& me)
 	ClearHover();
 	if (span) {
 		hoverSpan = span;
-		hoverSpan->SetColors(ta.colors[COLOR_HOVER], ta.colors[COLOR_BACKGROUND]);
+		hoverSpan->SetColors(ta.colors[COLOR_HOVER], ta.colors[COLOR_BACKDROP]);
 	}
 	return true;
 }
@@ -228,7 +228,7 @@ TextArea::TextArea(const Region& frame, Font* text, Font* caps,
 {
 	colors[COLOR_NORMAL] = textcolor;
 	colors[COLOR_INITIALS] = initcolor;
-	colors[COLOR_BACKGROUND] = textBgColor;
+	colors[COLOR_BACKDROP] = textBgColor;
 
 	// quick font optimization (prevents creating unnecessary cap spans)
 	finit = (caps && caps != ftext) ? caps : ftext;
@@ -679,7 +679,7 @@ void TextArea::ClearText()
 
 	parser.Reset(); // reset in case any tags were left open from before
 	textContainer = new TextContainer(Region(Point(), Dimensions()), ftext);
-	textContainer->SetColors(colors[COLOR_NORMAL], colors[COLOR_BACKGROUND]);
+	textContainer->SetColors(colors[COLOR_NORMAL], colors[COLOR_BACKDROP]);
 	textContainer->SetMargin(textMargins);
 	textContainer->callback = METHOD_CALLBACK(&TextArea::TextChanged, this);
 	if (Flags()&Editable) {

--- a/gemrb/core/GUI/TextArea.h
+++ b/gemrb/core/GUI/TextArea.h
@@ -166,7 +166,7 @@ private: // Private attributes
 	enum COLOR_TYPE {
 		COLOR_NORMAL = 0,	// standard text color
 		COLOR_INITIALS,	// color for finit. used only is some cases.
-		COLOR_BACKGROUND, // the background color for all text
+		COLOR_BACKDROP, // the background color for all text
 		COLOR_OPTIONS,	// normal palette for selectable options (dialog/listbox)
 		COLOR_HOVER,	// color for hovering options (dialog/listbox)
 		COLOR_SELECTED,	// selected list box/dialog option.


### PR DESCRIPTION
I was just trying to get up to date again and found another thing that Visual studio does not like

It appears that COLOR_BACKGROUND is already defined in winuser.h as 1 , so the the enumeration here in COLOR_TYPE https://github.com/gemrb/gemrb/blob/d8822e12c2f264fbd6fb5462bac459535b006547/gemrb/core/GUI/TextArea.h#L166-L172
fails because it inherits the number from that header instead of making a new one when trying to build I guess.

I just came up with a random alternative from ye trusty thesaurus, because I actually don't know which use case this color type is intended for and was hastily trying to make it build - please disregard this PR, if you have a more preferable label for it. I just wanted to highlight the build issue that's all.

Other than this , no other build issues encountered with Visual Studio from latest Subviews branch. Noice. 

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
