### PR TITLE
SDLAudio volume control

### DIFF
--- a/gemrb/plugins/SDLAudio/SDLAudio.cpp
+++ b/gemrb/plugins/SDLAudio/SDLAudio.cpp
@@ -78,7 +78,7 @@ void SDLAudio::SetAudioStreamVolume(uint8_t *stream, int len, int volume)
 	uint8_t *mixData = new uint8_t[len];
 	memcpy(mixData, stream, len * sizeof(uint8_t));
 	memset(stream, 0, len); // mix audio data against silence
-	SDL_MixAudio(static_cast<uint8_t*>(stream), static_cast<const uint8_t*>(mixData), len, volume);
+	SDL_MixAudio(stream, mixData, len, volume);
 	delete[] mixData;
 }
 

--- a/gemrb/plugins/SDLAudio/SDLAudio.h
+++ b/gemrb/plugins/SDLAudio/SDLAudio.h
@@ -30,9 +30,25 @@
 #include <SDL_mixer.h>
 
 #define BUFFER_CACHE_SIZE 50
-#define AUDIO_DISTANCE_ROLLOFF_MOD 1.5
+#define AUDIO_DISTANCE_ROLLOFF_MOD 1.3
 
 namespace GemRB {
+
+class SDLAudioSoundHandle : public SoundHandle 
+{
+public:
+	SDLAudioSoundHandle(Mix_Chunk *chunk, int channel, bool relative) : mixChunk(chunk), chunkChannel(channel), sndRelative(relative) { };
+	virtual ~SDLAudioSoundHandle() { }
+	virtual void SetPos(int XPos, int YPos);
+	virtual bool Playing();
+	virtual void Stop();
+	virtual void StopLooping();
+	void Invalidate() { }
+private:
+	Mix_Chunk *mixChunk;
+	int chunkChannel;
+	bool sndRelative;
+};
 
 struct BufferedData {
 	char *buf;
@@ -80,7 +96,7 @@ private:
 	void clearBufferCache();
 	Mix_Chunk* loadSound(const char *ResRef, unsigned int &time_length);
 
-	int listenerXPos, listenerYPos;
+	Point listenerPos;
 	Holder<SoundMgr> MusicReader;
 
 	bool MusicPlaying;

--- a/gemrb/plugins/SDLAudio/SDLAudio.h
+++ b/gemrb/plugins/SDLAudio/SDLAudio.h
@@ -72,8 +72,9 @@ public:
 private:
 	void FreeBuffers();
 
-	static void music_callback(void *udata, unsigned short *stream, int len);
-	static void buffer_callback(void *udata, char *stream, int len);
+	static void SetAudioStreamVolume(uint8_t *stream, int len, int volume);
+	static void music_callback(void *udata, uint8_t *stream, int len);
+	static void buffer_callback(void *udata, uint8_t *stream, int len);
 	bool evictBuffer();
 	void clearBufferCache();
 	Mix_Chunk* loadSound(const char *ResRef, unsigned int &time_length);

--- a/gemrb/plugins/SDLAudio/SDLAudio.h
+++ b/gemrb/plugins/SDLAudio/SDLAudio.h
@@ -30,6 +30,7 @@
 #include <SDL_mixer.h>
 
 #define BUFFER_CACHE_SIZE 50
+#define AUDIO_DISTANCE_ROLLOFF_MOD 1.5
 
 namespace GemRB {
 
@@ -79,7 +80,7 @@ private:
 	void clearBufferCache();
 	Mix_Chunk* loadSound(const char *ResRef, unsigned int &time_length);
 
-	int XPos, YPos;
+	int listenerXPos, listenerYPos;
 	Holder<SoundMgr> MusicReader;
 
 	bool MusicPlaying;


### PR DESCRIPTION
## Description
Working volume control for SDLAudio plugin. All volume sliders seems to be working now (except ambient, since it's not implemented anyway). Music/Movie volume control is a bit hacky (since `Mix_VolumeMusic` is not supported due to custom music playback function), but functional.


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
