### PR TITLE
wrap win32def.h in a Platform.h

### DIFF
--- a/cmake/cmake_config.h.in
+++ b/cmake/cmake_config.h.in
@@ -1,3 +1,6 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
 // automatically generated file from cmake!
 
 #cmakedefine SIZEOF_INT ${SIZEOF_INT}
@@ -26,3 +29,5 @@
 #cmakedefine HAVE_MMAP ${HAVE_MMAP}
 #cmakedefine SUPPORTS_MEMSTREAM ${SUPPORTS_MEMSTREAM}
 #cmakedefine01 ICONV_ACCEPTS_NONCONST_INPUT
+
+#endif

--- a/gemrb/GemRB.cpp
+++ b/gemrb/GemRB.cpp
@@ -28,9 +28,6 @@
 #ifdef HAVE_MALLOC_H
 #include <malloc.h>
 #endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
 
 using namespace GemRB;
 

--- a/gemrb/core/AmbientMgr.h
+++ b/gemrb/core/AmbientMgr.h
@@ -22,8 +22,8 @@
 #define AMBIENTMGR_H
 
 #include "exports.h"
-#include "Platform.h"
 
+#include <atomic>
 #include <string>
 #include <vector>
 

--- a/gemrb/core/Animation.cpp
+++ b/gemrb/core/Animation.cpp
@@ -20,8 +20,6 @@
 
 #include "Animation.h"
 
-#include "Platform.h"
-
 #include "Game.h"
 #include "Interface.h"
 #include "Map.h"

--- a/gemrb/core/Animation.cpp
+++ b/gemrb/core/Animation.cpp
@@ -20,7 +20,7 @@
 
 #include "Animation.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Game.h"
 #include "Interface.h"

--- a/gemrb/core/AnimationFactory.cpp
+++ b/gemrb/core/AnimationFactory.cpp
@@ -20,7 +20,7 @@
 
 #include "AnimationFactory.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 #include "Sprite2D.h"

--- a/gemrb/core/AnimationFactory.cpp
+++ b/gemrb/core/AnimationFactory.cpp
@@ -20,8 +20,6 @@
 
 #include "AnimationFactory.h"
 
-#include "Platform.h"
-
 #include "Interface.h"
 #include "Sprite2D.h"
 

--- a/gemrb/core/Audio.h
+++ b/gemrb/core/Audio.h
@@ -24,7 +24,6 @@
 #include <vector>
 
 #include "globals.h"
-#include "Platform.h"
 
 #include "Plugin.h"
 #include "Holder.h"

--- a/gemrb/core/Audio.h
+++ b/gemrb/core/Audio.h
@@ -24,7 +24,7 @@
 #include <vector>
 
 #include "globals.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Plugin.h"
 #include "Holder.h"

--- a/gemrb/core/Cache.h
+++ b/gemrb/core/Cache.h
@@ -22,7 +22,7 @@
 #define CACHE_H
 
 #include "globals.h"
-#include "win32def.h"
+#include "Platform.h"
 
 namespace GemRB {
 

--- a/gemrb/core/Cache.h
+++ b/gemrb/core/Cache.h
@@ -22,7 +22,6 @@
 #define CACHE_H
 
 #include "globals.h"
-#include "Platform.h"
 
 namespace GemRB {
 

--- a/gemrb/core/Calendar.cpp
+++ b/gemrb/core/Calendar.cpp
@@ -20,8 +20,6 @@
 
 #include "Calendar.h"
 
-#include "Platform.h"
-
 #include "Interface.h"
 #include "TableMgr.h"
 #include "Variables.h"

--- a/gemrb/core/Calendar.cpp
+++ b/gemrb/core/Calendar.cpp
@@ -20,7 +20,7 @@
 
 #include "Calendar.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 #include "TableMgr.h"

--- a/gemrb/core/CharAnimations.cpp
+++ b/gemrb/core/CharAnimations.cpp
@@ -20,7 +20,7 @@
 
 #include "CharAnimations.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "AnimationFactory.h"
 #include "DataFileMgr.h"

--- a/gemrb/core/CharAnimations.cpp
+++ b/gemrb/core/CharAnimations.cpp
@@ -20,8 +20,6 @@
 
 #include "CharAnimations.h"
 
-#include "Platform.h"
-
 #include "AnimationFactory.h"
 #include "DataFileMgr.h"
 #include "Game.h"

--- a/gemrb/core/ControlAnimation.cpp
+++ b/gemrb/core/ControlAnimation.cpp
@@ -20,8 +20,6 @@
 
 #include "ControlAnimation.h"
 
-#include "Platform.h"
-
 #include "AnimationFactory.h"
 #include "GameData.h"
 #include "GlobalTimer.h"

--- a/gemrb/core/ControlAnimation.cpp
+++ b/gemrb/core/ControlAnimation.cpp
@@ -20,7 +20,7 @@
 
 #include "ControlAnimation.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "AnimationFactory.h"
 #include "GameData.h"

--- a/gemrb/core/Core.cpp
+++ b/gemrb/core/Core.cpp
@@ -38,11 +38,6 @@
 #endif
 
 #ifdef WIN32
-#include "win32def.h"
-#ifdef _DEBUG
-#include <stdlib.h>
-#include <crtdbg.h>
-#endif
 
 BOOL WINAPI DllEntryPoint(HINSTANCE, DWORD, LPVOID);
 BOOL WINAPI DllEntryPoint(HINSTANCE /*hinstDLL*/, DWORD /*fdwReason*/,

--- a/gemrb/core/Dialog.cpp
+++ b/gemrb/core/Dialog.cpp
@@ -20,8 +20,6 @@
 
 #include "Dialog.h"
 
-#include "Platform.h"
-
 #include "GameScript/GameScript.h"
 #include "RNG.h"
 

--- a/gemrb/core/Dialog.cpp
+++ b/gemrb/core/Dialog.cpp
@@ -20,7 +20,7 @@
 
 #include "Dialog.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "GameScript/GameScript.h"
 #include "RNG.h"

--- a/gemrb/core/Factory.cpp
+++ b/gemrb/core/Factory.cpp
@@ -20,10 +20,6 @@
 
 #include "Factory.h"
 
-#include "Platform.h"
-
-#include <cstring>
-
 namespace GemRB {
 
 Factory::Factory(void)

--- a/gemrb/core/Factory.cpp
+++ b/gemrb/core/Factory.cpp
@@ -20,7 +20,7 @@
 
 #include "Factory.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include <cstring>
 

--- a/gemrb/core/FactoryObject.cpp
+++ b/gemrb/core/FactoryObject.cpp
@@ -20,7 +20,7 @@
 
 #include "FactoryObject.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 namespace GemRB {
 

--- a/gemrb/core/FactoryObject.cpp
+++ b/gemrb/core/FactoryObject.cpp
@@ -20,7 +20,7 @@
 
 #include "FactoryObject.h"
 
-#include "Platform.h"
+#include "System/String.h"
 
 namespace GemRB {
 

--- a/gemrb/core/GUI/Button.cpp
+++ b/gemrb/core/GUI/Button.cpp
@@ -25,7 +25,7 @@
 #include "GUI/ScrollBar.h"
 #include "GUI/Window.h"
 
-#include "win32def.h"
+#include "Platform.h"
 #include "defsounds.h"
 #include "ie_cursors.h"
 

--- a/gemrb/core/GUI/Button.cpp
+++ b/gemrb/core/GUI/Button.cpp
@@ -25,7 +25,6 @@
 #include "GUI/ScrollBar.h"
 #include "GUI/Window.h"
 
-#include "Platform.h"
 #include "defsounds.h"
 #include "ie_cursors.h"
 

--- a/gemrb/core/GUI/Console.cpp
+++ b/gemrb/core/GUI/Console.cpp
@@ -20,8 +20,6 @@
 
 #include "GUI/Console.h"
 
-#include "Platform.h"
-
 #include "GameData.h"
 #include "Interface.h"
 #include "Palette.h"

--- a/gemrb/core/GUI/Console.cpp
+++ b/gemrb/core/GUI/Console.cpp
@@ -20,7 +20,7 @@
 
 #include "GUI/Console.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "GameData.h"
 #include "Interface.h"

--- a/gemrb/core/GUI/Control.cpp
+++ b/gemrb/core/GUI/Control.cpp
@@ -23,8 +23,6 @@
 #include "GUI/EventMgr.h"
 #include "GUI/Window.h"
 
-#include "win32def.h"
-
 #include "ControlAnimation.h"
 #include "Interface.h"
 #include "ScriptEngine.h"

--- a/gemrb/core/GUI/Control.h
+++ b/gemrb/core/GUI/Control.h
@@ -45,10 +45,12 @@
 
 #include "RGBAColor.h"
 #include "exports.h"
+#include "globals.h"
 #include "ie_types.h"
-#include "win32def.h"
 
 #include "Callback.h"
+#include "Region.h"
+#include "System/String.h"
 
 namespace GemRB {
 

--- a/gemrb/core/GUI/EventMgr.cpp
+++ b/gemrb/core/GUI/EventMgr.cpp
@@ -22,7 +22,6 @@
 
 #include "GUI/GameControl.h"
 
-#include "Platform.h"
 #include "ie_cursors.h"
 
 #include "Game.h"

--- a/gemrb/core/GUI/EventMgr.cpp
+++ b/gemrb/core/GUI/EventMgr.cpp
@@ -22,7 +22,7 @@
 
 #include "GUI/GameControl.h"
 
-#include "win32def.h"
+#include "Platform.h"
 #include "ie_cursors.h"
 
 #include "Game.h"

--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -20,7 +20,6 @@
 #include "GUI/GameControl.h"
 
 #include "strrefs.h"
-#include "Platform.h"
 
 #include "CharAnimations.h"
 #include "DialogHandler.h"

--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -20,7 +20,7 @@
 #include "GUI/GameControl.h"
 
 #include "strrefs.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "CharAnimations.h"
 #include "DialogHandler.h"

--- a/gemrb/core/GUI/Label.cpp
+++ b/gemrb/core/GUI/Label.cpp
@@ -20,8 +20,6 @@
 
 #include "GUI/Label.h"
 
-#include "Platform.h"
-
 #include "GameData.h"
 #include "Interface.h"
 #include "Sprite2D.h"

--- a/gemrb/core/GUI/Label.cpp
+++ b/gemrb/core/GUI/Label.cpp
@@ -20,7 +20,7 @@
 
 #include "GUI/Label.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "GameData.h"
 #include "Interface.h"

--- a/gemrb/core/GUI/MapControl.cpp
+++ b/gemrb/core/GUI/MapControl.cpp
@@ -19,7 +19,6 @@
 
 #include "GUI/MapControl.h"
 
-#include "Platform.h"
 #include "ie_cursors.h"
 
 #include "Game.h"

--- a/gemrb/core/GUI/MapControl.cpp
+++ b/gemrb/core/GUI/MapControl.cpp
@@ -19,7 +19,7 @@
 
 #include "GUI/MapControl.h"
 
-#include "win32def.h"
+#include "Platform.h"
 #include "ie_cursors.h"
 
 #include "Game.h"

--- a/gemrb/core/GUI/Progressbar.cpp
+++ b/gemrb/core/GUI/Progressbar.cpp
@@ -20,8 +20,6 @@
 
 #include "GUI/Progressbar.h"
 
-#include "Platform.h"
-
 #include "Interface.h"
 #include "GUI/Window.h"
 

--- a/gemrb/core/GUI/Progressbar.cpp
+++ b/gemrb/core/GUI/Progressbar.cpp
@@ -20,7 +20,7 @@
 
 #include "GUI/Progressbar.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 #include "GUI/Window.h"

--- a/gemrb/core/GUI/ScrollBar.cpp
+++ b/gemrb/core/GUI/ScrollBar.cpp
@@ -20,8 +20,6 @@
 
 #include "GUI/ScrollBar.h"
 
-#include "Platform.h"
-
 #include "Interface.h"
 #include "Variables.h"
 #include "GUI/EventMgr.h"

--- a/gemrb/core/GUI/ScrollBar.cpp
+++ b/gemrb/core/GUI/ScrollBar.cpp
@@ -20,7 +20,7 @@
 
 #include "GUI/ScrollBar.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 #include "Variables.h"

--- a/gemrb/core/GUI/Slider.cpp
+++ b/gemrb/core/GUI/Slider.cpp
@@ -20,7 +20,7 @@
 
 #include "GUI/Slider.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 #include "Variables.h"

--- a/gemrb/core/GUI/Slider.cpp
+++ b/gemrb/core/GUI/Slider.cpp
@@ -20,8 +20,6 @@
 
 #include "GUI/Slider.h"
 
-#include "Platform.h"
-
 #include "Interface.h"
 #include "Variables.h"
 #include "GUI/Window.h"

--- a/gemrb/core/GUI/TextArea.cpp
+++ b/gemrb/core/GUI/TextArea.cpp
@@ -20,8 +20,6 @@
 
 #include "TextArea.h"
 
-#include "Platform.h"
-
 #include "GameData.h"
 #include "Interface.h"
 #include "Variables.h"

--- a/gemrb/core/GUI/TextArea.cpp
+++ b/gemrb/core/GUI/TextArea.cpp
@@ -20,7 +20,7 @@
 
 #include "TextArea.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "GameData.h"
 #include "Interface.h"

--- a/gemrb/core/GUI/TextSystem/Font.cpp
+++ b/gemrb/core/GUI/TextSystem/Font.cpp
@@ -20,7 +20,7 @@
 
 #include "Font.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "GameData.h"
 #include "Interface.h"

--- a/gemrb/core/GUI/TextSystem/Font.cpp
+++ b/gemrb/core/GUI/TextSystem/Font.cpp
@@ -20,8 +20,6 @@
 
 #include "Font.h"
 
-#include "Platform.h"
-
 #include "GameData.h"
 #include "Interface.h"
 #include "Palette.h"

--- a/gemrb/core/GUI/Window.cpp
+++ b/gemrb/core/GUI/Window.cpp
@@ -24,8 +24,6 @@
 #include "GUI/MapControl.h"
 #include "GUI/ScrollBar.h"
 
-#include "Platform.h"
-
 #include "ie_cursors.h"
 
 namespace GemRB {

--- a/gemrb/core/GUI/Window.cpp
+++ b/gemrb/core/GUI/Window.cpp
@@ -24,7 +24,7 @@
 #include "GUI/MapControl.h"
 #include "GUI/ScrollBar.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "ie_cursors.h"
 

--- a/gemrb/core/GUI/WorldMapControl.cpp
+++ b/gemrb/core/GUI/WorldMapControl.cpp
@@ -19,7 +19,6 @@
 
 #include "GUI/WorldMapControl.h"
 
-#include "Platform.h"
 #include "ie_cursors.h"
 
 #include "Game.h"

--- a/gemrb/core/GUI/WorldMapControl.cpp
+++ b/gemrb/core/GUI/WorldMapControl.cpp
@@ -19,7 +19,7 @@
 
 #include "GUI/WorldMapControl.h"
 
-#include "win32def.h"
+#include "Platform.h"
 #include "ie_cursors.h"
 
 #include "Game.h"

--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -24,7 +24,6 @@
 
 #include "defsounds.h"
 #include "strrefs.h"
-#include "Platform.h"
 
 #include "DisplayMessage.h"
 #include "GameData.h"

--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -24,7 +24,7 @@
 
 #include "defsounds.h"
 #include "strrefs.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "DisplayMessage.h"
 #include "GameData.h"

--- a/gemrb/core/GameScript/Actions.cpp
+++ b/gemrb/core/GameScript/Actions.cpp
@@ -24,7 +24,6 @@
 #include "GameScript/Matching.h"
 
 #include "voodooconst.h"
-#include "Platform.h"
 
 #include "AmbientMgr.h"
 #include "CharAnimations.h"

--- a/gemrb/core/GameScript/Actions.cpp
+++ b/gemrb/core/GameScript/Actions.cpp
@@ -24,7 +24,7 @@
 #include "GameScript/Matching.h"
 
 #include "voodooconst.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "AmbientMgr.h"
 #include "CharAnimations.h"

--- a/gemrb/core/GameScript/GameScript.cpp
+++ b/gemrb/core/GameScript/GameScript.cpp
@@ -44,8 +44,6 @@
 #include "GameScript/GSUtils.h"
 #include "GameScript/Matching.h"
 
-#include "Platform.h"
-
 #include "Game.h"
 #include "GUI/GameControl.h" // just for DF_POSTPONE_SCRIPTS
 #include "GameData.h"

--- a/gemrb/core/GameScript/GameScript.cpp
+++ b/gemrb/core/GameScript/GameScript.cpp
@@ -44,7 +44,7 @@
 #include "GameScript/GSUtils.h"
 #include "GameScript/Matching.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Game.h"
 #include "GUI/GameControl.h" // just for DF_POSTPONE_SCRIPTS

--- a/gemrb/core/GameScript/Objects.cpp
+++ b/gemrb/core/GameScript/Objects.cpp
@@ -23,7 +23,7 @@
 #include "GameScript/GSUtils.h"
 #include "GameScript/Matching.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "DialogHandler.h"
 #include "Game.h"

--- a/gemrb/core/GameScript/Objects.cpp
+++ b/gemrb/core/GameScript/Objects.cpp
@@ -23,8 +23,6 @@
 #include "GameScript/GSUtils.h"
 #include "GameScript/Matching.h"
 
-#include "Platform.h"
-
 #include "DialogHandler.h"
 #include "Game.h"
 #include "GUI/GameControl.h"

--- a/gemrb/core/GameScript/Triggers.cpp
+++ b/gemrb/core/GameScript/Triggers.cpp
@@ -24,7 +24,6 @@
 #include "GameScript/Matching.h"
 
 #include "voodooconst.h"
-#include "Platform.h"
 
 #include "AmbientMgr.h"
 #include "Calendar.h"

--- a/gemrb/core/GameScript/Triggers.cpp
+++ b/gemrb/core/GameScript/Triggers.cpp
@@ -24,7 +24,7 @@
 #include "GameScript/Matching.h"
 
 #include "voodooconst.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "AmbientMgr.h"
 #include "Calendar.h"

--- a/gemrb/core/GlobalTimer.h
+++ b/gemrb/core/GlobalTimer.h
@@ -21,7 +21,7 @@
 #define GLOBALTIMER_H
 
 #include "exports.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Region.h"
 

--- a/gemrb/core/GlobalTimer.h
+++ b/gemrb/core/GlobalTimer.h
@@ -21,7 +21,6 @@
 #define GLOBALTIMER_H
 
 #include "exports.h"
-#include "Platform.h"
 
 #include "Region.h"
 

--- a/gemrb/core/ImageMgr.cpp
+++ b/gemrb/core/ImageMgr.cpp
@@ -20,8 +20,6 @@
 
 #include "ImageMgr.h"
 
-#include "Platform.h"
-
 #include "ImageFactory.h"
 #include "Interface.h"
 

--- a/gemrb/core/ImageMgr.cpp
+++ b/gemrb/core/ImageMgr.cpp
@@ -20,7 +20,7 @@
 
 #include "ImageMgr.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "ImageFactory.h"
 #include "Interface.h"

--- a/gemrb/core/IniSpawn.cpp
+++ b/gemrb/core/IniSpawn.cpp
@@ -23,8 +23,6 @@
 
 #include "IniSpawn.h"
 
-#include "Platform.h"
-
 #include "CharAnimations.h"
 #include "Game.h"
 #include "GameData.h"

--- a/gemrb/core/IniSpawn.cpp
+++ b/gemrb/core/IniSpawn.cpp
@@ -23,7 +23,7 @@
 
 #include "IniSpawn.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "CharAnimations.h"
 #include "Game.h"

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -18,17 +18,13 @@
 *
 */
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "Interface.h"
 
 #include "defsounds.h" // for DS_TOOLTIP
 #include "exports.h"
 #include "globals.h"
 #include "strrefs.h"
-#include "win32def.h"
+#include "Platform.h"
 #include "ie_cursors.h"
 
 #include "ActorMgr.h"
@@ -87,10 +83,6 @@
 #include "System/FileStream.h"
 #include "System/VFS.h"
 #include "System/StringBuffer.h"
-
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
 
 #include <vector>
 

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -24,7 +24,6 @@
 #include "exports.h"
 #include "globals.h"
 #include "strrefs.h"
-#include "Platform.h"
 #include "ie_cursors.h"
 
 #include "ActorMgr.h"

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -35,6 +35,7 @@
 #include "Holder.h"
 #include "InterfaceConfig.h"
 #include "Resource.h"
+#include "System/VFS.h"
 
 #include <map>
 #include <string>

--- a/gemrb/core/InterfaceConfig.cpp
+++ b/gemrb/core/InterfaceConfig.cpp
@@ -18,18 +18,12 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "globals.h"
 
 #include "InterfaceConfig.h"
 
 #include "System/FileStream.h"
-
-// needed for unused std::string version of GetValueForKey
-//#include <algorithm>
+#include "System/VFS.h"
 
 namespace GemRB {
 

--- a/gemrb/core/Inventory.cpp
+++ b/gemrb/core/Inventory.cpp
@@ -23,7 +23,7 @@
 
 #include "Inventory.h"
 
-#include "win32def.h"
+#include "Platform.h"
 #include "strrefs.h"
 
 #include "CharAnimations.h"

--- a/gemrb/core/Inventory.cpp
+++ b/gemrb/core/Inventory.cpp
@@ -23,7 +23,6 @@
 
 #include "Inventory.h"
 
-#include "Platform.h"
 #include "strrefs.h"
 
 #include "CharAnimations.h"

--- a/gemrb/core/Inventory.h
+++ b/gemrb/core/Inventory.h
@@ -30,7 +30,6 @@
 
 #include "exports.h"
 #include "ie_types.h"
-#include "Platform.h"
 
 #include "Item.h"  //needs item for itmextheader
 #include "Store.h"

--- a/gemrb/core/Inventory.h
+++ b/gemrb/core/Inventory.h
@@ -30,7 +30,7 @@
 
 #include "exports.h"
 #include "ie_types.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Item.h"  //needs item for itmextheader
 #include "Store.h"

--- a/gemrb/core/Item.cpp
+++ b/gemrb/core/Item.cpp
@@ -23,7 +23,6 @@
 
 #include "Item.h"
 
-#include "Platform.h"
 #include "voodooconst.h"
 
 #include "Interface.h"

--- a/gemrb/core/Item.cpp
+++ b/gemrb/core/Item.cpp
@@ -23,7 +23,7 @@
 
 #include "Item.h"
 
-#include "win32def.h"
+#include "Platform.h"
 #include "voodooconst.h"
 
 #include "Interface.h"

--- a/gemrb/core/KeyMap.cpp
+++ b/gemrb/core/KeyMap.cpp
@@ -19,7 +19,6 @@
  */
 
 #include "KeyMap.h"
-#include "Platform.h"
 #include "Interface.h"
 #include "TableMgr.h"
 #include "ScriptEngine.h"

--- a/gemrb/core/KeyMap.cpp
+++ b/gemrb/core/KeyMap.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "KeyMap.h"
-#include "win32def.h"
+#include "Platform.h"
 #include "Interface.h"
 #include "TableMgr.h"
 #include "ScriptEngine.h"

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -22,8 +22,6 @@
 
 #include "Map.h"
 
-#include "Platform.h"
-
 #include "Ambient.h"
 #include "AmbientMgr.h"
 #include "Audio.h"

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -22,7 +22,7 @@
 
 #include "Map.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Ambient.h"
 #include "AmbientMgr.h"

--- a/gemrb/core/MoviePlayer.h
+++ b/gemrb/core/MoviePlayer.h
@@ -29,7 +29,6 @@
 #define MOVIEPLAYER_H
 
 #include "globals.h"
-#include "Platform.h"
 
 #include "Resource.h"
 

--- a/gemrb/core/MoviePlayer.h
+++ b/gemrb/core/MoviePlayer.h
@@ -29,7 +29,7 @@
 #define MOVIEPLAYER_H
 
 #include "globals.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Resource.h"
 

--- a/gemrb/core/PathFinder.cpp
+++ b/gemrb/core/PathFinder.cpp
@@ -41,7 +41,7 @@
 #include "RNG.h"
 #include "Scriptable/Actor.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include <array>
 #include <cmath>

--- a/gemrb/core/PathFinder.cpp
+++ b/gemrb/core/PathFinder.cpp
@@ -41,8 +41,6 @@
 #include "RNG.h"
 #include "Scriptable/Actor.h"
 
-#include "Platform.h"
-
 #include <array>
 #include <cmath>
 #include <limits>

--- a/gemrb/core/PluginLoader.cpp
+++ b/gemrb/core/PluginLoader.cpp
@@ -19,7 +19,7 @@
 #include "PluginLoader.h"
 
 #include "SClassID.h" // For PluginID
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Variables.h"
 #include "Interface.h"

--- a/gemrb/core/PluginLoader.cpp
+++ b/gemrb/core/PluginLoader.cpp
@@ -19,7 +19,6 @@
 #include "PluginLoader.h"
 
 #include "SClassID.h" // For PluginID
-#include "Platform.h"
 
 #include "Variables.h"
 #include "Interface.h"

--- a/gemrb/core/PluginMgr.cpp
+++ b/gemrb/core/PluginMgr.cpp
@@ -18,7 +18,7 @@
 
 #include "PluginMgr.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Plugin.h"
 #include "ResourceDesc.h"

--- a/gemrb/core/PluginMgr.cpp
+++ b/gemrb/core/PluginMgr.cpp
@@ -18,8 +18,6 @@
 
 #include "PluginMgr.h"
 
-#include "Platform.h"
-
 #include "Plugin.h"
 #include "ResourceDesc.h"
 

--- a/gemrb/core/PluginMgr.h
+++ b/gemrb/core/PluginMgr.h
@@ -31,7 +31,6 @@
 #include "exports.h"
 #include "globals.h"
 #include "iless.h"
-#include "Platform.h"
 #include "Holder.h"
 
 #include "ResourceDesc.h"

--- a/gemrb/core/PluginMgr.h
+++ b/gemrb/core/PluginMgr.h
@@ -31,7 +31,7 @@
 #include "exports.h"
 #include "globals.h"
 #include "iless.h"
-#include "win32def.h"
+#include "Platform.h"
 #include "Holder.h"
 
 #include "ResourceDesc.h"

--- a/gemrb/core/Polygon.cpp
+++ b/gemrb/core/Polygon.cpp
@@ -19,8 +19,6 @@
 
 #include "Polygon.h"
 
-#include "Platform.h"
-
 #include "Interface.h"
 
 #include <algorithm>

--- a/gemrb/core/Polygon.cpp
+++ b/gemrb/core/Polygon.cpp
@@ -19,7 +19,7 @@
 
 #include "Polygon.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 

--- a/gemrb/core/Projectile.cpp
+++ b/gemrb/core/Projectile.cpp
@@ -20,7 +20,7 @@
 
 #include "Projectile.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "AnimationFactory.h"
 #include "DisplayMessage.h"

--- a/gemrb/core/Projectile.cpp
+++ b/gemrb/core/Projectile.cpp
@@ -20,8 +20,6 @@
 
 #include "Projectile.h"
 
-#include "Platform.h"
-
 #include "AnimationFactory.h"
 #include "DisplayMessage.h"
 #include "Game.h"

--- a/gemrb/core/SaveGameIterator.cpp
+++ b/gemrb/core/SaveGameIterator.cpp
@@ -22,7 +22,7 @@
 
 #include "iless.h"
 #include "strrefs.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "DisplayMessage.h"
 #include "GameData.h" // For ResourceHolder
@@ -37,9 +37,6 @@
 #include "Scriptable/Actor.h"
 #include "System/FileStream.h"
 
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
 #ifndef R_OK
 #define R_OK 04
 #endif

--- a/gemrb/core/SaveGameIterator.cpp
+++ b/gemrb/core/SaveGameIterator.cpp
@@ -22,7 +22,6 @@
 
 #include "iless.h"
 #include "strrefs.h"
-#include "Platform.h"
 
 #include "DisplayMessage.h"
 #include "GameData.h" // For ResourceHolder

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -29,7 +29,7 @@
 #include "strrefs.h"
 #include "opcode_params.h"
 #include "voodooconst.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Bitmap.h"
 #include "DataFileMgr.h"

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -29,7 +29,6 @@
 #include "strrefs.h"
 #include "opcode_params.h"
 #include "voodooconst.h"
-#include "Platform.h"
 
 #include "Bitmap.h"
 #include "DataFileMgr.h"

--- a/gemrb/core/Scriptable/Container.cpp
+++ b/gemrb/core/Scriptable/Container.cpp
@@ -20,7 +20,6 @@
 #include "Scriptable/Container.h"
 
 #include "strrefs.h"
-#include "Platform.h"
 
 #include "DisplayMessage.h"
 #include "Game.h"

--- a/gemrb/core/Scriptable/Container.cpp
+++ b/gemrb/core/Scriptable/Container.cpp
@@ -20,7 +20,7 @@
 #include "Scriptable/Container.h"
 
 #include "strrefs.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "DisplayMessage.h"
 #include "Game.h"

--- a/gemrb/core/Scriptable/Door.cpp
+++ b/gemrb/core/Scriptable/Door.cpp
@@ -20,7 +20,6 @@
 #include "Scriptable/Door.h"
 
 #include "strrefs.h"
-#include "Platform.h"
 
 #include "DisplayMessage.h"
 #include "Game.h"

--- a/gemrb/core/Scriptable/Door.cpp
+++ b/gemrb/core/Scriptable/Door.cpp
@@ -20,7 +20,7 @@
 #include "Scriptable/Door.h"
 
 #include "strrefs.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "DisplayMessage.h"
 #include "Game.h"

--- a/gemrb/core/Scriptable/InfoPoint.cpp
+++ b/gemrb/core/Scriptable/InfoPoint.cpp
@@ -20,7 +20,6 @@
 #include "Scriptable/InfoPoint.h"
 
 #include "voodooconst.h"
-#include "Platform.h"
 #include "strrefs.h"
 #include "ie_cursors.h"
 

--- a/gemrb/core/Scriptable/InfoPoint.cpp
+++ b/gemrb/core/Scriptable/InfoPoint.cpp
@@ -20,7 +20,7 @@
 #include "Scriptable/InfoPoint.h"
 
 #include "voodooconst.h"
-#include "win32def.h"
+#include "Platform.h"
 #include "strrefs.h"
 #include "ie_cursors.h"
 

--- a/gemrb/core/Scriptable/PCStatStruct.cpp
+++ b/gemrb/core/Scriptable/PCStatStruct.cpp
@@ -19,8 +19,7 @@
  */
 
 #include "Scriptable/PCStatStruct.h"
-
-#include "Platform.h"
+#include "System/Logging.h"
 
 #include <cstring>
 

--- a/gemrb/core/Scriptable/PCStatStruct.cpp
+++ b/gemrb/core/Scriptable/PCStatStruct.cpp
@@ -20,7 +20,7 @@
 
 #include "Scriptable/PCStatStruct.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include <cstring>
 

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -19,7 +19,7 @@
 
 #include "Scriptable/Scriptable.h"
 
-#include "win32def.h"
+#include "Platform.h"
 #include "strrefs.h"
 #include "ie_cursors.h"
 #include "voodooconst.h"

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -19,7 +19,6 @@
 
 #include "Scriptable/Scriptable.h"
 
-#include "Platform.h"
 #include "strrefs.h"
 #include "ie_cursors.h"
 #include "voodooconst.h"

--- a/gemrb/core/ScriptedAnimation.cpp
+++ b/gemrb/core/ScriptedAnimation.cpp
@@ -23,7 +23,7 @@
 
 #include "ScriptedAnimation.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Animation.h"
 #include "AnimationFactory.h"

--- a/gemrb/core/ScriptedAnimation.cpp
+++ b/gemrb/core/ScriptedAnimation.cpp
@@ -23,8 +23,6 @@
 
 #include "ScriptedAnimation.h"
 
-#include "Platform.h"
-
 #include "Animation.h"
 #include "AnimationFactory.h"
 #include "Audio.h"

--- a/gemrb/core/Spell.cpp
+++ b/gemrb/core/Spell.cpp
@@ -22,7 +22,7 @@
 
 #include "Spell.h"
 
-#include "win32def.h"
+#include "Platform.h"
 #include "voodooconst.h"
 
 #include "Audio.h"

--- a/gemrb/core/Spell.cpp
+++ b/gemrb/core/Spell.cpp
@@ -22,7 +22,6 @@
 
 #include "Spell.h"
 
-#include "Platform.h"
 #include "voodooconst.h"
 
 #include "Audio.h"

--- a/gemrb/core/Spellbook.h
+++ b/gemrb/core/Spellbook.h
@@ -30,7 +30,7 @@
 
 #include "exports.h"
 #include "ie_types.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include <vector>
 

--- a/gemrb/core/Spellbook.h
+++ b/gemrb/core/Spellbook.h
@@ -30,7 +30,6 @@
 
 #include "exports.h"
 #include "ie_types.h"
-#include "Platform.h"
 
 #include <vector>
 

--- a/gemrb/core/Sprite2D.cpp
+++ b/gemrb/core/Sprite2D.cpp
@@ -20,8 +20,6 @@
 
 #include "Sprite2D.h"
 
-#include "Platform.h"
-
 namespace GemRB {
 
 const TypeID Sprite2D::ID = { "Sprite2D" };

--- a/gemrb/core/Sprite2D.cpp
+++ b/gemrb/core/Sprite2D.cpp
@@ -20,7 +20,7 @@
 
 #include "Sprite2D.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 namespace GemRB {
 

--- a/gemrb/core/Store.cpp
+++ b/gemrb/core/Store.cpp
@@ -23,8 +23,6 @@
 
 #include "Store.h"
 
-#include "Platform.h"
-
 #include "Game.h"
 #include "GameData.h"
 #include "Interface.h"

--- a/gemrb/core/Store.cpp
+++ b/gemrb/core/Store.cpp
@@ -23,7 +23,7 @@
 
 #include "Store.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Game.h"
 #include "GameData.h"

--- a/gemrb/core/System/DataStream.cpp
+++ b/gemrb/core/System/DataStream.cpp
@@ -20,7 +20,7 @@
 
 #include "System/DataStream.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include <ctype.h>
 

--- a/gemrb/core/System/DataStream.cpp
+++ b/gemrb/core/System/DataStream.cpp
@@ -20,8 +20,6 @@
 
 #include "System/DataStream.h"
 
-#include "Platform.h"
-
 #include <ctype.h>
 
 namespace GemRB {

--- a/gemrb/core/System/DataStream.cpp
+++ b/gemrb/core/System/DataStream.cpp
@@ -20,6 +20,7 @@
 
 #include "System/DataStream.h"
 
+#include "errors.h"
 #include <ctype.h>
 
 namespace GemRB {

--- a/gemrb/core/System/DataStream.h
+++ b/gemrb/core/System/DataStream.h
@@ -28,8 +28,7 @@
 #ifndef DATASTREAM_H
 #define DATASTREAM_H
 
-#include "exports.h"
-#include "globals.h"
+#include "Platform.h"
 
 namespace GemRB {
 

--- a/gemrb/core/System/FileStream.cpp
+++ b/gemrb/core/System/FileStream.cpp
@@ -20,7 +20,7 @@
 
 #include "System/FileStream.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 

--- a/gemrb/core/System/FileStream.cpp
+++ b/gemrb/core/System/FileStream.cpp
@@ -20,8 +20,6 @@
 
 #include "System/FileStream.h"
 
-#include "Platform.h"
-
 #include "Interface.h"
 
 namespace GemRB {

--- a/gemrb/core/System/Logger/Stdio.cpp
+++ b/gemrb/core/System/Logger/Stdio.cpp
@@ -21,11 +21,7 @@
 
 #include <cstdio>
 
-#include "win32def.h"
-
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif
+#include "Platform.h"
 
 #include "Interface.h"
 #include "plugindef.h"

--- a/gemrb/core/System/Logger/Stdio.cpp
+++ b/gemrb/core/System/Logger/Stdio.cpp
@@ -21,8 +21,6 @@
 
 #include <cstdio>
 
-#include "Platform.h"
-
 #include "Interface.h"
 #include "plugindef.h"
 

--- a/gemrb/core/System/Logging.h
+++ b/gemrb/core/System/Logging.h
@@ -27,7 +27,7 @@
 #define LOGGING_H
 
 #include "exports.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "System/Logger.h"
 

--- a/gemrb/core/System/Logging.h
+++ b/gemrb/core/System/Logging.h
@@ -27,7 +27,6 @@
 #define LOGGING_H
 
 #include "exports.h"
-#include "Platform.h"
 
 #include "System/Logger.h"
 

--- a/gemrb/core/System/MemoryStream.cpp
+++ b/gemrb/core/System/MemoryStream.cpp
@@ -20,7 +20,7 @@
 
 #include "System/MemoryStream.h"
 
-#include "win32def.h"
+#include "Platform.h"
 #include "errors.h"
 
 #include "Interface.h"

--- a/gemrb/core/System/MemoryStream.cpp
+++ b/gemrb/core/System/MemoryStream.cpp
@@ -20,7 +20,6 @@
 
 #include "System/MemoryStream.h"
 
-#include "Platform.h"
 #include "errors.h"
 
 #include "Interface.h"

--- a/gemrb/core/System/SlicedStream.cpp
+++ b/gemrb/core/System/SlicedStream.cpp
@@ -22,7 +22,6 @@
 
 #include "System/MemoryStream.h"
 
-#include "Platform.h"
 #include "errors.h"
 
 #include "Interface.h"

--- a/gemrb/core/System/SlicedStream.cpp
+++ b/gemrb/core/System/SlicedStream.cpp
@@ -22,7 +22,7 @@
 
 #include "System/MemoryStream.h"
 
-#include "win32def.h"
+#include "Platform.h"
 #include "errors.h"
 
 #include "Interface.h"

--- a/gemrb/core/System/String.cpp
+++ b/gemrb/core/System/String.cpp
@@ -26,12 +26,6 @@
 #include <cerrno>
 #include <ctype.h>
 #include <cwctype>
-#ifdef WIN32
-#include "win32def.h"
-#ifdef _DEBUG
-#include <crtdbg.h>
-#endif
-#endif
 
 #if HAVE_ICONV
 #include <iconv.h>

--- a/gemrb/core/System/String.h
+++ b/gemrb/core/System/String.h
@@ -25,10 +25,6 @@
 #include <cstring>
 #include <string>
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #ifndef WIN32
 # define stricmp strcasecmp
 # define strnicmp strncasecmp

--- a/gemrb/core/System/StringBuffer.cpp
+++ b/gemrb/core/System/StringBuffer.cpp
@@ -18,7 +18,7 @@
 
 #include "System/StringBuffer.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include <cstdio>
 #if defined(__sgi)

--- a/gemrb/core/System/StringBuffer.cpp
+++ b/gemrb/core/System/StringBuffer.cpp
@@ -18,8 +18,6 @@
 
 #include "System/StringBuffer.h"
 
-#include "Platform.h"
-
 #include <cstdio>
 #if defined(__sgi)
 #  include <stdarg.h>

--- a/gemrb/core/System/VFS.cpp
+++ b/gemrb/core/System/VFS.cpp
@@ -27,10 +27,6 @@
 
 #include "Interface.h"
 
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-
 // in case unistd isn't there or nonconformant
 #ifndef R_OK
 #define R_OK 04

--- a/gemrb/core/System/VFS.h
+++ b/gemrb/core/System/VFS.h
@@ -27,16 +27,9 @@
 #ifndef VFS_H
 #define VFS_H
 
-#ifndef _MAX_PATH
-#ifdef WIN32
-#define _MAX_PATH 260
-#else
-#define _MAX_PATH FILENAME_MAX
-#endif
-#endif
-
 #include "exports.h"
 #include "globals.h"
+#include "Platform.h"
 #include "Predicates.h"
 
 #include <string>
@@ -45,7 +38,6 @@
 #ifdef WIN32
 #include <direct.h>
 #include <io.h>
-#include <windows.h>
 #endif
 
 namespace GemRB {

--- a/gemrb/core/System/VFS.h
+++ b/gemrb/core/System/VFS.h
@@ -29,7 +29,6 @@
 
 #include "exports.h"
 #include "globals.h"
-#include "Platform.h"
 #include "Predicates.h"
 
 #include <string>

--- a/gemrb/core/TableMgr.cpp
+++ b/gemrb/core/TableMgr.cpp
@@ -23,6 +23,8 @@
 #include "GameData.h"
 #include "Interface.h"
 
+#include "System/DataStream.h"
+
 namespace GemRB {
 
 TableMgr::TableMgr()

--- a/gemrb/core/TableMgr.h
+++ b/gemrb/core/TableMgr.h
@@ -34,6 +34,8 @@
 
 namespace GemRB {
 
+class DataStream;
+
 /**
  * @class TableMgr
  * Abstract loader for Table objects (.2DA files)

--- a/gemrb/core/VEFObject.cpp
+++ b/gemrb/core/VEFObject.cpp
@@ -22,7 +22,7 @@
 
 #include "VEFObject.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #define YESNO(x) ( (x)?"Yes":"No")
 

--- a/gemrb/core/VEFObject.cpp
+++ b/gemrb/core/VEFObject.cpp
@@ -22,8 +22,6 @@
 
 #include "VEFObject.h"
 
-#include "Platform.h"
-
 #define YESNO(x) ( (x)?"Yes":"No")
 
 #include "Game.h"

--- a/gemrb/core/Variables.cpp
+++ b/gemrb/core/Variables.cpp
@@ -22,6 +22,7 @@
 
 #include "Interface.h" // for LoadInitialValues
 #include "System/FileStream.h" // for LoadInitialValues
+#include "System/VFS.h"
 
 namespace GemRB {
 

--- a/gemrb/core/Variables.h
+++ b/gemrb/core/Variables.h
@@ -25,7 +25,6 @@
 #include "SClassID.h"
 #include "exports.h"
 #include "globals.h"
-#include "Platform.h"
 
 #include <cassert>
 

--- a/gemrb/core/Variables.h
+++ b/gemrb/core/Variables.h
@@ -25,7 +25,7 @@
 #include "SClassID.h"
 #include "exports.h"
 #include "globals.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include <cassert>
 

--- a/gemrb/core/Video.cpp
+++ b/gemrb/core/Video.cpp
@@ -20,7 +20,7 @@
 
 #include "Video.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 #include "Palette.h"

--- a/gemrb/core/Video.cpp
+++ b/gemrb/core/Video.cpp
@@ -20,8 +20,6 @@
 
 #include "Video.h"
 
-#include "Platform.h"
-
 #include "Interface.h"
 #include "Palette.h"
 #include "Sprite2D.h"

--- a/gemrb/core/WorldMap.cpp
+++ b/gemrb/core/WorldMap.cpp
@@ -20,7 +20,7 @@
 
 #include "WorldMap.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Game.h"
 #include "Interface.h"

--- a/gemrb/core/WorldMap.cpp
+++ b/gemrb/core/WorldMap.cpp
@@ -20,8 +20,6 @@
 
 #include "WorldMap.h"
 
-#include "Platform.h"
-
 #include "Game.h"
 #include "Interface.h"
 #include "TableMgr.h"

--- a/gemrb/includes/Platform.h
+++ b/gemrb/includes/Platform.h
@@ -1,5 +1,5 @@
 /* GemRB - Infinity Engine Emulator
- * Copyright (C) 2004 The GemRB Project
+ * Copyright (C) 2021 The GemRB Project
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -18,35 +18,33 @@
  *
  */
 
-#ifndef AMBIENTMGR_H
-#define AMBIENTMGR_H
+#ifndef PLATFORM_H
+#define PLATFORM_H
+
+#ifdef HAVE_CONFIG_H
+	#include <config.h>
+#endif
 
 #include "exports.h"
-#include "Platform.h"
 
-#include <string>
-#include <vector>
-
-namespace GemRB {
-
-class Ambient;
-
-class GEM_EXPORT AmbientMgr {
-public:
-	AmbientMgr();
-	virtual ~AmbientMgr();
-	virtual void reset() { ambients = std::vector<Ambient *> (); }
-	virtual void setAmbients(const std::vector<Ambient *> &a) { reset(); ambients = a; activate(); }
-	virtual void activate(const std::string &name);
-	virtual void activate() { active = true; } // hard play ;-)
-	virtual void deactivate(const std::string &name);
-	virtual void deactivate() { active = false; } // hard stop
-	virtual bool isActive(const std::string &name) const;
-protected:
-	std::vector<Ambient *> ambients;
-	std::atomic_bool active {false};
-};
-
-}
-
+#ifndef _MAX_PATH
+	#ifdef WIN32
+		#define _MAX_PATH 260
+	#else
+		#define _MAX_PATH FILENAME_MAX
+	#endif
 #endif
+
+#ifdef WIN32
+	#include "win32def.h"
+#elif defined(HAVE_UNISTD_H)
+	#include <unistd.h>
+#endif
+
+#include <cstdio>
+#include <cstdlib>
+
+#include "System/Logging.h"
+#include "System/String.h"
+
+#endif  //! PLATFORM_H

--- a/gemrb/includes/Platform.h
+++ b/gemrb/includes/Platform.h
@@ -23,6 +23,15 @@
 
 #ifdef HAVE_CONFIG_H
 	#include <config.h>
+#else
+	// we need this fallback for Android and anyone else skipping
+	// cmake, where the proper sizes are checked for
+	#ifndef SIZEOF_INT
+	#define SIZEOF_INT 4
+	#endif
+	#ifndef SIZEOF_LONG_INT
+	#define SIZEOF_LONG_INT 4
+	#endif
 #endif
 
 #include "exports.h"

--- a/gemrb/includes/globals.h
+++ b/gemrb/includes/globals.h
@@ -28,10 +28,6 @@
 #ifndef GLOBALS_H
 #define GLOBALS_H
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "ie_types.h"
 
 #define VERSION_GEMRB "0.8.7-git"
@@ -48,15 +44,14 @@
 #include "RGBAColor.h"
 #include "SClassID.h"
 #include "errors.h"
-#include "win32def.h"
 
 #include "Region.h"
 #include "System/DataStream.h"
 #include "System/String.h"
 
-#ifdef WIN32
-# include <algorithm>
-#else
+#include <algorithm>
+
+#ifndef WIN32
 # include <sys/time.h>
 #endif
 

--- a/gemrb/includes/ie_types.h
+++ b/gemrb/includes/ie_types.h
@@ -32,15 +32,6 @@
 
 namespace GemRB {
 
-// we need this fallback for Android and anyone else skipping
-// cmake, where the proper sizes are checked for
-#ifndef SIZEOF_INT
-#define SIZEOF_INT 4
-#endif
-#ifndef SIZEOF_LONG_INT
-#define SIZEOF_LONG_INT 4
-#endif
-
 typedef unsigned char ieByte;
 typedef signed char ieByteSigned;
 typedef unsigned short ieWord;

--- a/gemrb/includes/ie_types.h
+++ b/gemrb/includes/ie_types.h
@@ -28,9 +28,7 @@
 #ifndef IE_TYPES_H
 #define IE_TYPES_H
 
-#if HAVE_CONFIG_H
-#include <config.h>
-#endif
+#include "Platform.h"
 
 namespace GemRB {
 

--- a/gemrb/includes/iless.h
+++ b/gemrb/includes/iless.h
@@ -19,7 +19,7 @@
 #ifndef ILESS_H
 #define ILESS_H
 
-#include "win32def.h" //for stricmp
+#include "Platform.h" //for stricmp
 
 namespace GemRB {
 

--- a/gemrb/includes/win32def.h
+++ b/gemrb/includes/win32def.h
@@ -24,7 +24,11 @@
 #define WIN32DEF_H
 
 #define WIN32_LEAN_AND_MEAN
+
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
+
 #define UNICODE
 #define _UNICODE
 #define NOGDI

--- a/gemrb/includes/win32def.h
+++ b/gemrb/includes/win32def.h
@@ -18,51 +18,22 @@
  *
  */
 
-/**
- * @file win32def.h
- * Some global definitions, mostly for Un*x vs. MS Windows compatibility
- * @author The GemRB Project
- */
-
+// TODO: move this to platforms/windows
 
 #ifndef WIN32DEF_H
 #define WIN32DEF_H
 
-#include "exports.h"
-
-#include "System/String.h"
-
-#ifdef WIN32
-# define WIN32_LEAN_AND_MEAN
-
-# ifndef NOMINMAX
-# define NOMINMAX
-# endif
-
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #define UNICODE
 #define _UNICODE
-
 #define NOGDI
+#define _USE_MATH_DEFINES
 
-# include <windows.h>
-
-#else //WIN32
-# ifdef HAVE_CONFIG_H
-#  include <config.h>
-# endif
-# include <cstdio>
-# include <cstdlib>
-
-#endif //WIN32
-
-#include "System/VFS.h"
-
-#ifndef M_PI
-#define M_PI    3.14159265358979323846 // pi
-#endif
-#ifndef M_PI_2
-#define M_PI_2  1.57079632679489661923 // pi/2
+#ifdef _DEBUG
+#include <crtdbg.h>
 #endif
 
-#include "System/Logging.h"
+#include <windows.h>
+
 #endif  //! WIN32DEF_H

--- a/gemrb/plugins/2DAImporter/2DAImporter.cpp
+++ b/gemrb/plugins/2DAImporter/2DAImporter.cpp
@@ -20,7 +20,7 @@
 
 #include "2DAImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 #include "System/FileStream.h"

--- a/gemrb/plugins/2DAImporter/2DAImporter.cpp
+++ b/gemrb/plugins/2DAImporter/2DAImporter.cpp
@@ -20,8 +20,6 @@
 
 #include "2DAImporter.h"
 
-#include "Platform.h"
-
 #include "Interface.h"
 #include "System/FileStream.h"
 

--- a/gemrb/plugins/AREImporter/AREImporter.cpp
+++ b/gemrb/plugins/AREImporter/AREImporter.cpp
@@ -20,7 +20,6 @@
 
 #include "AREImporter.h"
 
-#include "Platform.h"
 #include "strrefs.h"
 #include "ie_cursors.h"
 

--- a/gemrb/plugins/AREImporter/AREImporter.cpp
+++ b/gemrb/plugins/AREImporter/AREImporter.cpp
@@ -20,7 +20,7 @@
 
 #include "AREImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 #include "strrefs.h"
 #include "ie_cursors.h"
 

--- a/gemrb/plugins/BAMImporter/BAMImporter.cpp
+++ b/gemrb/plugins/BAMImporter/BAMImporter.cpp
@@ -21,7 +21,7 @@
 
 #include "BAMImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "FileCache.h"
 #include "GameData.h"
@@ -30,11 +30,6 @@
 #include "BAMSprite2D.h"
 #include "Video.h"
 #include "System/FileStream.h"
-
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#undef swab
-#endif
 
 #include "System/swab.h"
 

--- a/gemrb/plugins/BAMImporter/BAMImporter.cpp
+++ b/gemrb/plugins/BAMImporter/BAMImporter.cpp
@@ -21,8 +21,6 @@
 
 #include "BAMImporter.h"
 
-#include "Platform.h"
-
 #include "FileCache.h"
 #include "GameData.h"
 #include "Interface.h"

--- a/gemrb/plugins/BIFImporter/BIFImporter.cpp
+++ b/gemrb/plugins/BIFImporter/BIFImporter.cpp
@@ -20,8 +20,6 @@
 
 #include "BIFImporter.h"
 
-#include "Platform.h"
-
 #include "Compressor.h"
 #include "FileCache.h"
 #include "Interface.h"

--- a/gemrb/plugins/BIFImporter/BIFImporter.cpp
+++ b/gemrb/plugins/BIFImporter/BIFImporter.cpp
@@ -20,7 +20,7 @@
 
 #include "BIFImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Compressor.h"
 #include "FileCache.h"

--- a/gemrb/plugins/BIKPlayer/BIKPlayer.cpp
+++ b/gemrb/plugins/BIKPlayer/BIKPlayer.cpp
@@ -44,10 +44,6 @@
 #include <cassert>
 #include <cstdio>
 
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-
 using namespace GemRB;
 
 static int g_truecolor;

--- a/gemrb/plugins/BIKPlayer/BIKPlayer.h
+++ b/gemrb/plugins/BIKPlayer/BIKPlayer.h
@@ -24,7 +24,7 @@
 #include "MoviePlayer.h"
 
 #include "globals.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 

--- a/gemrb/plugins/BIKPlayer/BIKPlayer.h
+++ b/gemrb/plugins/BIKPlayer/BIKPlayer.h
@@ -24,7 +24,6 @@
 #include "MoviePlayer.h"
 
 #include "globals.h"
-#include "Platform.h"
 
 #include "Interface.h"
 

--- a/gemrb/plugins/BIKPlayer/common.h
+++ b/gemrb/plugins/BIKPlayer/common.h
@@ -23,7 +23,6 @@
 #ifndef AVUTIL_COMMON_H
 #define AVUTIL_COMMON_H
 
-#include "Platform.h"
 #include "globals.h"
 
 #define _USE_MATH_DEFINES

--- a/gemrb/plugins/BIKPlayer/common.h
+++ b/gemrb/plugins/BIKPlayer/common.h
@@ -23,7 +23,7 @@
 #ifndef AVUTIL_COMMON_H
 #define AVUTIL_COMMON_H
 
-#include "win32def.h"
+#include "Platform.h"
 #include "globals.h"
 
 #define _USE_MATH_DEFINES

--- a/gemrb/plugins/BIKPlayer/mem.cpp
+++ b/gemrb/plugins/BIKPlayer/mem.cpp
@@ -23,9 +23,6 @@
  * @file libavutil/mem.c
  * default memory allocator for libavutil
  */
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
 
 #include <limits.h>
 #include <stdlib.h>

--- a/gemrb/plugins/BMPImporter/BMPImporter.cpp
+++ b/gemrb/plugins/BMPImporter/BMPImporter.cpp
@@ -21,7 +21,7 @@
 #include "BMPImporter.h"
 
 #include "RGBAColor.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 #include "Video.h"

--- a/gemrb/plugins/BMPImporter/BMPImporter.cpp
+++ b/gemrb/plugins/BMPImporter/BMPImporter.cpp
@@ -21,7 +21,6 @@
 #include "BMPImporter.h"
 
 #include "RGBAColor.h"
-#include "Platform.h"
 
 #include "Interface.h"
 #include "Video.h"

--- a/gemrb/plugins/CHUImporter/CHUImporter.cpp
+++ b/gemrb/plugins/CHUImporter/CHUImporter.cpp
@@ -21,7 +21,7 @@
 #include "CHUImporter.h"
 
 #include "RGBAColor.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "AnimationFactory.h"
 #include "GameData.h"

--- a/gemrb/plugins/CHUImporter/CHUImporter.cpp
+++ b/gemrb/plugins/CHUImporter/CHUImporter.cpp
@@ -21,7 +21,6 @@
 #include "CHUImporter.h"
 
 #include "RGBAColor.h"
-#include "Platform.h"
 
 #include "AnimationFactory.h"
 #include "GameData.h"

--- a/gemrb/plugins/CREImporter/CREImporter.cpp
+++ b/gemrb/plugins/CREImporter/CREImporter.cpp
@@ -22,7 +22,6 @@
 
 #include "ie_stats.h"
 #include "voodooconst.h"
-#include "Platform.h"
 
 #include "EffectMgr.h"
 #include "GameData.h"

--- a/gemrb/plugins/CREImporter/CREImporter.cpp
+++ b/gemrb/plugins/CREImporter/CREImporter.cpp
@@ -22,7 +22,7 @@
 
 #include "ie_stats.h"
 #include "voodooconst.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "EffectMgr.h"
 #include "GameData.h"

--- a/gemrb/plugins/DLGImporter/DLGImporter.cpp
+++ b/gemrb/plugins/DLGImporter/DLGImporter.cpp
@@ -20,7 +20,7 @@
 
 #include "DLGImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 #include "GameScript/GameScript.h"

--- a/gemrb/plugins/DLGImporter/DLGImporter.cpp
+++ b/gemrb/plugins/DLGImporter/DLGImporter.cpp
@@ -20,8 +20,6 @@
 
 #include "DLGImporter.h"
 
-#include "Platform.h"
-
 #include "Interface.h"
 #include "GameScript/GameScript.h"
 #include "System/FileStream.h"

--- a/gemrb/plugins/DirectoryImporter/DirectoryImporter.cpp
+++ b/gemrb/plugins/DirectoryImporter/DirectoryImporter.cpp
@@ -19,7 +19,6 @@
 #include "DirectoryImporter.h"
 
 #include "globals.h"
-#include "Platform.h"
 
 #include "Interface.h"
 #include "ResourceDesc.h"

--- a/gemrb/plugins/DirectoryImporter/DirectoryImporter.cpp
+++ b/gemrb/plugins/DirectoryImporter/DirectoryImporter.cpp
@@ -19,7 +19,7 @@
 #include "DirectoryImporter.h"
 
 #include "globals.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 #include "ResourceDesc.h"

--- a/gemrb/plugins/EFFImporter/EFFImporter.cpp
+++ b/gemrb/plugins/EFFImporter/EFFImporter.cpp
@@ -20,7 +20,7 @@
 
 #include "EFFImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 

--- a/gemrb/plugins/EFFImporter/EFFImporter.cpp
+++ b/gemrb/plugins/EFFImporter/EFFImporter.cpp
@@ -20,8 +20,6 @@
 
 #include "EFFImporter.h"
 
-#include "Platform.h"
-
 #include "Interface.h"
 
 using namespace GemRB;

--- a/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
+++ b/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
@@ -23,7 +23,7 @@
 #include "overlays.h"
 #include "strrefs.h"
 #include "voodooconst.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Audio.h"
 #include "DisplayMessage.h"

--- a/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
+++ b/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
@@ -23,7 +23,6 @@
 #include "overlays.h"
 #include "strrefs.h"
 #include "voodooconst.h"
-#include "Platform.h"
 
 #include "Audio.h"
 #include "DisplayMessage.h"

--- a/gemrb/plugins/GAMImporter/GAMImporter.cpp
+++ b/gemrb/plugins/GAMImporter/GAMImporter.cpp
@@ -21,7 +21,7 @@
 #include "GAMImporter.h"
 
 #include "globals.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "DataFileMgr.h"
 #include "GameData.h"

--- a/gemrb/plugins/GAMImporter/GAMImporter.cpp
+++ b/gemrb/plugins/GAMImporter/GAMImporter.cpp
@@ -21,7 +21,6 @@
 #include "GAMImporter.h"
 
 #include "globals.h"
-#include "Platform.h"
 
 #include "DataFileMgr.h"
 #include "GameData.h"

--- a/gemrb/plugins/GUIScript/PythonHelpers.h
+++ b/gemrb/plugins/GUIScript/PythonHelpers.h
@@ -22,14 +22,14 @@
 // Python.h needs to be included first.
 #include "GUIScript.h"
 
-#include "win32def.h" // For Logging
-
 #include "Callback.h"
 #include "Holder.h"
 #include "Interface.h"
 
 #include "GUI/Control.h"
 #include "GUI/Window.h"
+
+#include "System/Logging.h"
 
 namespace GemRB {
 

--- a/gemrb/plugins/IDSImporter/IDSImporter.cpp
+++ b/gemrb/plugins/IDSImporter/IDSImporter.cpp
@@ -23,7 +23,6 @@
 #include "IDSImporterDefs.h"
 
 #include "globals.h"
-#include "Platform.h"
 
 #include <cstring>
 

--- a/gemrb/plugins/IDSImporter/IDSImporter.cpp
+++ b/gemrb/plugins/IDSImporter/IDSImporter.cpp
@@ -23,7 +23,7 @@
 #include "IDSImporterDefs.h"
 
 #include "globals.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include <cstring>
 

--- a/gemrb/plugins/INIImporter/INIImporter.cpp
+++ b/gemrb/plugins/INIImporter/INIImporter.cpp
@@ -20,8 +20,6 @@
 
 #include "INIImporter.h"
 
-#include "Platform.h"
-
 #include "Interface.h"
 
 using namespace GemRB;

--- a/gemrb/plugins/INIImporter/INIImporter.cpp
+++ b/gemrb/plugins/INIImporter/INIImporter.cpp
@@ -20,7 +20,7 @@
 
 #include "INIImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 

--- a/gemrb/plugins/ITMImporter/ITMImporter.cpp
+++ b/gemrb/plugins/ITMImporter/ITMImporter.cpp
@@ -20,7 +20,7 @@
 
 #include "ITMImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "EffectMgr.h"
 #include "Interface.h"

--- a/gemrb/plugins/ITMImporter/ITMImporter.cpp
+++ b/gemrb/plugins/ITMImporter/ITMImporter.cpp
@@ -20,8 +20,6 @@
 
 #include "ITMImporter.h"
 
-#include "Platform.h"
-
 #include "EffectMgr.h"
 #include "Interface.h"
 #include "PluginMgr.h"

--- a/gemrb/plugins/IWDOpcodes/IWDOpcodes.cpp
+++ b/gemrb/plugins/IWDOpcodes/IWDOpcodes.cpp
@@ -21,7 +21,7 @@
 #include "ie_feats.h" //cannot avoid declaring these
 #include "opcode_params.h"
 #include "overlays.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Audio.h"  //needs for a playsound call
 #include "DisplayMessage.h"

--- a/gemrb/plugins/IWDOpcodes/IWDOpcodes.cpp
+++ b/gemrb/plugins/IWDOpcodes/IWDOpcodes.cpp
@@ -21,7 +21,6 @@
 #include "ie_feats.h" //cannot avoid declaring these
 #include "opcode_params.h"
 #include "overlays.h"
-#include "Platform.h"
 
 #include "Audio.h"  //needs for a playsound call
 #include "DisplayMessage.h"

--- a/gemrb/plugins/KEYImporter/KEYImporter.cpp
+++ b/gemrb/plugins/KEYImporter/KEYImporter.cpp
@@ -20,7 +20,6 @@
 
 #include "KEYImporter.h"
 
-#include "Platform.h"
 #include "globals.h"
 
 #include "IndexedArchive.h"

--- a/gemrb/plugins/KEYImporter/KEYImporter.cpp
+++ b/gemrb/plugins/KEYImporter/KEYImporter.cpp
@@ -20,7 +20,7 @@
 
 #include "KEYImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 #include "globals.h"
 
 #include "IndexedArchive.h"

--- a/gemrb/plugins/MOSImporter/MOSImporter.cpp
+++ b/gemrb/plugins/MOSImporter/MOSImporter.cpp
@@ -21,7 +21,6 @@
 #include "MOSImporter.h"
 
 #include "RGBAColor.h"
-#include "Platform.h"
 
 #include "FileCache.h"
 #include "Interface.h"

--- a/gemrb/plugins/MOSImporter/MOSImporter.cpp
+++ b/gemrb/plugins/MOSImporter/MOSImporter.cpp
@@ -21,7 +21,7 @@
 #include "MOSImporter.h"
 
 #include "RGBAColor.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "FileCache.h"
 #include "Interface.h"

--- a/gemrb/plugins/MUSImporter/MUSImporter.cpp
+++ b/gemrb/plugins/MUSImporter/MUSImporter.cpp
@@ -20,8 +20,6 @@
 
 #include "MUSImporter.h"
 
-#include "Platform.h"
-
 #include "Audio.h"
 #include "GameData.h" // For ResourceHolder
 #include "Interface.h"

--- a/gemrb/plugins/MUSImporter/MUSImporter.cpp
+++ b/gemrb/plugins/MUSImporter/MUSImporter.cpp
@@ -20,7 +20,7 @@
 
 #include "MUSImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Audio.h"
 #include "GameData.h" // For ResourceHolder

--- a/gemrb/plugins/MVEPlayer/MVEPlayer.h
+++ b/gemrb/plugins/MVEPlayer/MVEPlayer.h
@@ -24,7 +24,7 @@
 #include "MoviePlayer.h"
 
 #include "globals.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 

--- a/gemrb/plugins/MVEPlayer/MVEPlayer.h
+++ b/gemrb/plugins/MVEPlayer/MVEPlayer.h
@@ -24,7 +24,6 @@
 #include "MoviePlayer.h"
 
 #include "globals.h"
-#include "Platform.h"
 
 #include "Interface.h"
 

--- a/gemrb/plugins/MVEPlayer/gstmvedemux.h
+++ b/gemrb/plugins/MVEPlayer/gstmvedemux.h
@@ -22,7 +22,7 @@
 #ifndef __GST_MVE_DEMUX_H__
 #define __GST_MVE_DEMUX_H__
 
-#include "win32def.h"
+#include "Platform.h"
 #include "globals.h"
 
 using namespace GemRB;

--- a/gemrb/plugins/MVEPlayer/gstmvedemux.h
+++ b/gemrb/plugins/MVEPlayer/gstmvedemux.h
@@ -22,7 +22,6 @@
 #ifndef __GST_MVE_DEMUX_H__
 #define __GST_MVE_DEMUX_H__
 
-#include "Platform.h"
 #include "globals.h"
 
 using namespace GemRB;

--- a/gemrb/plugins/MVEPlayer/mve_player.cpp
+++ b/gemrb/plugins/MVEPlayer/mve_player.cpp
@@ -30,10 +30,6 @@
 #include "gstmvedemux.h"
 #include "mve.h"
 
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-
 /* mvevideodec8.cpp */
 extern int ipvideo_decode_frame8 (const GstMveDemuxStream * s,
 	const unsigned char *data, unsigned short len);

--- a/gemrb/plugins/NullSound/NullSound.cpp
+++ b/gemrb/plugins/NullSound/NullSound.cpp
@@ -20,8 +20,6 @@
 
 #include "NullSound.h"
 
-#include "Platform.h"
-
 #include "AmbientMgr.h"
 #include "SoundMgr.h"
 

--- a/gemrb/plugins/NullSound/NullSound.cpp
+++ b/gemrb/plugins/NullSound/NullSound.cpp
@@ -20,7 +20,7 @@
 
 #include "NullSound.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "AmbientMgr.h"
 #include "SoundMgr.h"

--- a/gemrb/plugins/NullSource/NullSource.cpp
+++ b/gemrb/plugins/NullSource/NullSource.cpp
@@ -19,7 +19,6 @@
 #include "NullSource.h"
 
 #include "globals.h"
-#include "Platform.h"
 
 #include "Interface.h"
 #include "ResourceDesc.h"

--- a/gemrb/plugins/NullSource/NullSource.cpp
+++ b/gemrb/plugins/NullSource/NullSource.cpp
@@ -19,7 +19,7 @@
 #include "NullSource.h"
 
 #include "globals.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 #include "ResourceDesc.h"

--- a/gemrb/plugins/OpenALAudio/AmbientMgrAL.h
+++ b/gemrb/plugins/OpenALAudio/AmbientMgrAL.h
@@ -22,6 +22,7 @@
 #define AMBIENTMGRAL_H
 
 #include "AmbientMgr.h"
+#include "Region.h"
 
 #include <atomic>
 #include <condition_variable>

--- a/gemrb/plugins/PLTImporter/PLTImporter.cpp
+++ b/gemrb/plugins/PLTImporter/PLTImporter.cpp
@@ -21,7 +21,6 @@
 #include "PLTImporter.h"
 
 #include "RGBAColor.h"
-#include "Platform.h"
 
 #include "Interface.h"
 #include "Video.h"

--- a/gemrb/plugins/PLTImporter/PLTImporter.cpp
+++ b/gemrb/plugins/PLTImporter/PLTImporter.cpp
@@ -21,7 +21,7 @@
 #include "PLTImporter.h"
 
 #include "RGBAColor.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 #include "Video.h"

--- a/gemrb/plugins/PROImporter/PROImporter.cpp
+++ b/gemrb/plugins/PROImporter/PROImporter.cpp
@@ -20,7 +20,7 @@
 
 #include "PROImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "EffectMgr.h"
 #include "Interface.h"

--- a/gemrb/plugins/PROImporter/PROImporter.cpp
+++ b/gemrb/plugins/PROImporter/PROImporter.cpp
@@ -20,8 +20,6 @@
 
 #include "PROImporter.h"
 
-#include "Platform.h"
-
 #include "EffectMgr.h"
 #include "Interface.h"
 

--- a/gemrb/plugins/PSTOpcodes/PSTOpcodes.cpp
+++ b/gemrb/plugins/PSTOpcodes/PSTOpcodes.cpp
@@ -19,7 +19,6 @@
  */
 
 #include "strrefs.h"
-#include "Platform.h"
 
 #include "EffectQueue.h"
 #include "Game.h"

--- a/gemrb/plugins/PSTOpcodes/PSTOpcodes.cpp
+++ b/gemrb/plugins/PSTOpcodes/PSTOpcodes.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "strrefs.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "EffectQueue.h"
 #include "Game.h"

--- a/gemrb/plugins/SAVImporter/SAVImporter.cpp
+++ b/gemrb/plugins/SAVImporter/SAVImporter.cpp
@@ -18,7 +18,7 @@
 
 #include "SAVImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Compressor.h"
 #include "FileCache.h"

--- a/gemrb/plugins/SAVImporter/SAVImporter.cpp
+++ b/gemrb/plugins/SAVImporter/SAVImporter.cpp
@@ -18,8 +18,6 @@
 
 #include "SAVImporter.h"
 
-#include "Platform.h"
-
 #include "Compressor.h"
 #include "FileCache.h"
 #include "Interface.h"

--- a/gemrb/plugins/SDLAudio/SDLAudio.cpp
+++ b/gemrb/plugins/SDLAudio/SDLAudio.cpp
@@ -20,7 +20,7 @@
 
 #include "SDLAudio.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "AmbientMgr.h"
 #include "GameData.h"

--- a/gemrb/plugins/SDLAudio/SDLAudio.cpp
+++ b/gemrb/plugins/SDLAudio/SDLAudio.cpp
@@ -20,8 +20,6 @@
 
 #include "SDLAudio.h"
 
-#include "Platform.h"
-
 #include "AmbientMgr.h"
 #include "GameData.h"
 #include "Interface.h" // GetMusicMgr()

--- a/gemrb/plugins/SDLVideo/GLSLProgram.cpp
+++ b/gemrb/plugins/SDLVideo/GLSLProgram.cpp
@@ -5,9 +5,6 @@
 #include <cctype>
 #include <sstream>
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
 #include "System/VFS.h" // for PathDelimiter
 
 #include "GLSLProgram.h"

--- a/gemrb/plugins/SDLVideo/SDLVideo.h
+++ b/gemrb/plugins/SDLVideo/SDLVideo.h
@@ -25,7 +25,6 @@
 #include "GamepadControl.h"
 
 #include "GUI/EventMgr.h"
-#include "Platform.h"
 
 #include <vector>
 #include <SDL.h>

--- a/gemrb/plugins/SDLVideo/SDLVideo.h
+++ b/gemrb/plugins/SDLVideo/SDLVideo.h
@@ -25,7 +25,7 @@
 #include "GamepadControl.h"
 
 #include "GUI/EventMgr.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include <vector>
 #include <SDL.h>

--- a/gemrb/plugins/SPLImporter/SPLImporter.cpp
+++ b/gemrb/plugins/SPLImporter/SPLImporter.cpp
@@ -20,8 +20,6 @@
 
 #include "SPLImporter.h"
 
-#include "Platform.h"
-
 #include "EffectMgr.h"
 #include "Interface.h"
 #include "PluginMgr.h"

--- a/gemrb/plugins/SPLImporter/SPLImporter.cpp
+++ b/gemrb/plugins/SPLImporter/SPLImporter.cpp
@@ -20,7 +20,7 @@
 
 #include "SPLImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "EffectMgr.h"
 #include "Interface.h"

--- a/gemrb/plugins/STOImporter/STOImporter.cpp
+++ b/gemrb/plugins/STOImporter/STOImporter.cpp
@@ -20,8 +20,6 @@
 
 #include "STOImporter.h"
 
-#include "Platform.h"
-
 #include "DialogMgr.h"
 #include "GameData.h"
 #include "Interface.h"

--- a/gemrb/plugins/STOImporter/STOImporter.cpp
+++ b/gemrb/plugins/STOImporter/STOImporter.cpp
@@ -20,7 +20,7 @@
 
 #include "STOImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "DialogMgr.h"
 #include "GameData.h"

--- a/gemrb/plugins/TISImporter/TISImporter.cpp
+++ b/gemrb/plugins/TISImporter/TISImporter.cpp
@@ -21,7 +21,6 @@
 #include "TISImporter.h"
 
 #include "RGBAColor.h"
-#include "Platform.h"
 
 #include "Interface.h"
 #include "Sprite2D.h"

--- a/gemrb/plugins/TISImporter/TISImporter.cpp
+++ b/gemrb/plugins/TISImporter/TISImporter.cpp
@@ -21,7 +21,7 @@
 #include "TISImporter.h"
 
 #include "RGBAColor.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Interface.h"
 #include "Sprite2D.h"

--- a/gemrb/plugins/TLKImporter/TLKImporter.cpp
+++ b/gemrb/plugins/TLKImporter/TLKImporter.cpp
@@ -20,8 +20,6 @@
 
 #include "TLKImporter.h"
 
-#include "Platform.h"
-
 #include "Audio.h"
 #include "Calendar.h"
 #include "DialogHandler.h"

--- a/gemrb/plugins/TLKImporter/TLKImporter.cpp
+++ b/gemrb/plugins/TLKImporter/TLKImporter.cpp
@@ -20,7 +20,7 @@
 
 #include "TLKImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "Audio.h"
 #include "Calendar.h"

--- a/gemrb/plugins/WEDImporter/WEDImporter.cpp
+++ b/gemrb/plugins/WEDImporter/WEDImporter.cpp
@@ -20,17 +20,12 @@
 
 #include "WEDImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "GameData.h"
 #include "Interface.h"
 #include "PluginMgr.h"
 #include "TileSetMgr.h"
-
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#undef swab
-#endif
 
 #include "System/swab.h"
 

--- a/gemrb/plugins/WEDImporter/WEDImporter.cpp
+++ b/gemrb/plugins/WEDImporter/WEDImporter.cpp
@@ -20,8 +20,6 @@
 
 #include "WEDImporter.h"
 
-#include "Platform.h"
-
 #include "GameData.h"
 #include "Interface.h"
 #include "PluginMgr.h"

--- a/gemrb/plugins/WMPImporter/WMPImporter.cpp
+++ b/gemrb/plugins/WMPImporter/WMPImporter.cpp
@@ -20,7 +20,7 @@
 
 #include "WMPImporter.h"
 
-#include "win32def.h"
+#include "Platform.h"
 
 #include "GameData.h"
 #include "ImageMgr.h"

--- a/gemrb/plugins/WMPImporter/WMPImporter.cpp
+++ b/gemrb/plugins/WMPImporter/WMPImporter.cpp
@@ -20,8 +20,6 @@
 
 #include "WMPImporter.h"
 
-#include "Platform.h"
-
 #include "GameData.h"
 #include "ImageMgr.h"
 #include "Interface.h"

--- a/gemrb/plugins/ZLibManager/ZLibManager.cpp
+++ b/gemrb/plugins/ZLibManager/ZLibManager.cpp
@@ -21,7 +21,6 @@
 #include "ZLibManager.h"
 
 #include "globals.h"
-#include "Platform.h"
 
 #include <zlib.h>
 

--- a/gemrb/plugins/ZLibManager/ZLibManager.cpp
+++ b/gemrb/plugins/ZLibManager/ZLibManager.cpp
@@ -21,7 +21,7 @@
 #include "ZLibManager.h"
 
 #include "globals.h"
-#include "win32def.h"
+#include "Platform.h"
 
 #include <zlib.h>
 


### PR DESCRIPTION
## Description
trying to unravel the tangled web of includes/dependancies

Provide `Platform.h` as an umbrella file for defining platform specifics which should greatly reduce the `#ifdef` clutter surrounding windows.h or unistd.h

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
