### PR TITLE
Win32Console: fixes building on MSYS2

### DIFF
--- a/platforms/windows/Win32Console.h
+++ b/platforms/windows/Win32Console.h
@@ -22,7 +22,7 @@
 
 #include "System/Logger/Stdio.h"
 
-#include <consoleapi.h>
+#include <windows.h>
 
 namespace GemRB {
 


### PR DESCRIPTION
As mentioned in #1161, I cannot build this with MSYS2 WinAPI headers as there is no discrete `consoleapi.h`. The general `windows.h` does the job, and all the exotic color stuff isn't there anymore anyway.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
