### PR TITLE
GUICG:Fixed faulty stats calculation of min and max values

### DIFF
--- a/gemrb/GUIScripts/bg2/GUICG4.py
+++ b/gemrb/GUIScripts/bg2/GUICG4.py
@@ -49,30 +49,30 @@ def CalcLimits(Abidx):
 	Minimum = 3
 	Maximum = 18
 
-	tmp = Abclasrq.GetValue(KitIndex, Abidx)
-	if tmp!=0 and tmp>Minimum:
-		Minimum = tmp
-
 	Race = Abracerq.GetRowIndex(RaceName)
 	tmp = Abracerq.GetValue(Race, Abidx*2)
-	if tmp!=0 and tmp>Minimum:
+	if tmp != 0:
 		Minimum = tmp
 
 	tmp = Abracerq.GetValue(Race, Abidx*2+1)
-	if tmp!=0 and tmp>Maximum:
+	if tmp != 0:
 		Maximum = tmp
 
+	Add = Abracead.GetValue(Race, Abidx)
 	Race = Abracead.GetRowIndex(RaceName)
 	if Abclsmod:
-		Add = Abracead.GetValue(Race, Abidx) + Abclsmod.GetValue(KitIndex, Abidx)
-	else:
-		Add = Abracead.GetValue(Race, Abidx)
-	Maximum = Maximum + Add
-	Minimum = Minimum + Add
-	if Minimum<1:
-		Minimum=1
-	if Maximum>25:
-		Maximum=25
+		Add += Abclsmod.GetValue(KitIndex, Abidx)
+	Minimum += Add
+	Maximum += Add
+
+	tmp = Abclasrq.GetValue(KitIndex, Abidx)
+	if tmp != 0 and tmp > Minimum:
+		Minimum = tmp
+
+	if Minimum < 1:
+		Minimum = 1
+	if Maximum > 25:
+		Maximum = 25
 
 	return
 

--- a/gemrb/GUIScripts/bg2/GUICG4.py
+++ b/gemrb/GUIScripts/bg2/GUICG4.py
@@ -58,12 +58,16 @@ def CalcLimits(Abidx):
 	if tmp != 0:
 		Maximum = tmp
 
-	Add = Abracead.GetValue(Race, Abidx)
+
 	Race = Abracead.GetRowIndex(RaceName)
-	if Abclsmod:
-		Add += Abclsmod.GetValue(KitIndex, Abidx)
+	Add = Abracead.GetValue(Race, Abidx)
 	Minimum += Add
 	Maximum += Add
+
+	if Abclsmod:
+		tmp = Abclsmod.GetValue(KitIndex, Abidx)
+		Maximum += tmp
+		Add += tmp
 
 	tmp = Abclasrq.GetValue(KitIndex, Abidx)
 	if tmp != 0 and tmp > Minimum:


### PR DESCRIPTION
abracerq.2da values for races should always be treated as base for calculation.
abclasrq.2da should be last thing to to consider as it is required boundary.

## Description
see #431 
It looks like there still might be an issue with Abclsmod it probably shouldn't impact min values, at least it look like it works that way in originals.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
