### PR TITLE
Obtain ticks from an std::chrono implementation

### DIFF
--- a/gemrb/core/Animation.cpp
+++ b/gemrb/core/Animation.cpp
@@ -108,7 +108,7 @@ Sprite2D* Animation::LastFrame(void)
 	if (gameAnimation) {
 		starttime = core->GetGame()->Ticks;
 	} else {
-		starttime = GetTickCount();
+		starttime = GetTicks();
 	}
 	Sprite2D* ret;
 	if (playReversed)
@@ -128,7 +128,7 @@ Sprite2D* Animation::NextFrame(void)
 		if (gameAnimation) {
 			starttime = core->GetGame()->Ticks;
 		} else {
-			starttime = GetTickCount();
+			starttime = GetTicks();
 		}
 	}
 	Sprite2D* ret;
@@ -144,7 +144,7 @@ Sprite2D* Animation::NextFrame(void)
 	if (gameAnimation) {
 		time = core->GetGame()->Ticks;
 	} else {
-		time = GetTickCount();
+		time = GetTicks();
 	}
 
 	//it could be that we skip more than one frame in case of slow rendering

--- a/gemrb/core/GUI/Button.cpp
+++ b/gemrb/core/GUI/Button.cpp
@@ -124,7 +124,7 @@ void Button::CloseUpColor()
 	//handle Game at this point
 	unsigned long newtime;
 
-	newtime = GetTickCount();
+	newtime = GetTicks();
 	if (newtime<starttime) {
 		return;
 	}
@@ -750,7 +750,7 @@ void Button::SetHorizontalOverlay(double clip, const Color &/*src*/, const Color
 		// (see Draw)
 		SourceRGB=src;
 		DestRGB=dest;
-		starttime = GetTickCount();
+		starttime = GetTicks();
 		starttime += 40;
 #else
 		SourceRGB = DestRGB = dest;

--- a/gemrb/core/GUI/EventMgr.cpp
+++ b/gemrb/core/GUI/EventMgr.cpp
@@ -262,7 +262,7 @@ void EventMgr::MouseDown(unsigned short x, unsigned short y, unsigned short Butt
 	Control *ctrl;
 	unsigned long thisTime;
 
-	thisTime = GetTickCount();
+	thisTime = GetTicks();
 	if (ClickMatch(x, y, thisTime)) {
 		Button |= GEM_MB_DOUBLECLICK;
 		dc_x = 0;

--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -339,7 +339,7 @@ void GameControl::DrawTargetReticle(Point p, int size, bool animate, bool flash,
 	if (animate) {
 		// generates "step" from sequence 3 2 1 0 1 2 3 4
 		// updated each 1/15 sec
-		++step = tp_steps [(GetTickCount() >> 6) & 7];
+		++step = tp_steps [(GetTicks() >> 6) & 7];
 	} else {
 		step = 3;
 	}

--- a/gemrb/core/GUI/TextArea.cpp
+++ b/gemrb/core/GUI/TextArea.cpp
@@ -112,7 +112,7 @@ void TextArea::DrawInternal(Region& clip)
 			ScrollToY(TextYPos); // reset animation values
 		} else {
 			// update animation for this next draw cycle
-			unsigned long curTime = GetTickCount();
+			unsigned long curTime = GetTicks();
 			if (animationEnd.time > curTime) {
 				//double animProgress = curTime / animationEnd;
 				int deltaY = animationEnd.y - animationBegin.y;
@@ -426,7 +426,7 @@ void TextArea::ScrollToY(int y, Control* sender, ieDword duration)
 	if  (duration) {
 		// HACK: notice the values arent clamped here.
 		// this is sort of a hack we allow for chapter text so it can begin and end out of sight
-		unsigned long startTime = GetTickCount();
+		unsigned long startTime = GetTicks();
 		animationBegin = AnimationPoint(TextYPos, startTime);
 		animationEnd = AnimationPoint(y, startTime + duration);
 		return;

--- a/gemrb/core/GlobalTimer.cpp
+++ b/gemrb/core/GlobalTimer.cpp
@@ -65,7 +65,7 @@ void GlobalTimer::Freeze()
 
 	UpdateAnimations(true);
 
-	thisTime = GetTickCount();
+	thisTime = GetTicks();
 	advance = thisTime - startTime;
 	if ( advance < interval) {
 		return;
@@ -165,7 +165,7 @@ bool GlobalTimer::Update()
 
 	UpdateAnimations(false);
 
-	thisTime = GetTickCount();
+	thisTime = GetTicks();
 
 	if (!startTime) {
 		startTime = thisTime;
@@ -275,7 +275,7 @@ void GlobalTimer::AddAnimation(ControlAnimation* ctlanim, unsigned long time)
 	AnimationRef* anim;
 	unsigned long thisTime;
 
-	thisTime = GetTickCount();
+	thisTime = GetTicks();
 	time += thisTime;
 
 	// if there are no free animation reference objects,
@@ -319,7 +319,7 @@ void GlobalTimer::RemoveAnimation(ControlAnimation* ctlanim)
 void GlobalTimer::UpdateAnimations(bool paused)
 {
 	unsigned long thisTime;
-	thisTime = GetTickCount();
+	thisTime = GetTicks();
 	while (animations.begin() + first_animation != animations.end()) {
 		AnimationRef* anim = animations[first_animation];
 		if (anim->ctlanim == NULL) {

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -991,7 +991,7 @@ void Interface::Main()
 	wchar_t fpsstring[20] = {L"???.??? fps"};
 
 	unsigned long frame = 0, time, timebase;
-	timebase = GetTickCount();
+	timebase = GetTicks();
 	double frames;
 	Palette* palette = new Palette( ColorWhite, ColorBlack );
 	do {
@@ -1010,7 +1010,7 @@ void Interface::Main()
 		DrawWindows(true);
 		if (DrawFPS) {
 			frame++;
-			time = GetTickCount();
+			time = GetTicks();
 			if (time - timebase > 1000) {
 				frames = ( frame * 1000.0 / ( time - timebase ) );
 				timebase = time;

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -4935,7 +4935,7 @@ void Actor::PlayWalkSound()
 	ieDword thisTime;
 	ieResRef Sound;
 
-	thisTime = GetTickCount();
+	thisTime = GetTicks();
 	if (thisTime<nextWalk) return;
 	int cnt = anims->GetWalkSoundCount();
 	if (!cnt) return;
@@ -8620,7 +8620,7 @@ void Actor::Draw(const Region &screen)
 	}
 
 	if (remainingTalkSoundTime > 0) {
-		unsigned int currentTick = GetTickCount();
+		unsigned int currentTick = GetTicks();
 		unsigned int diffTime = currentTick - lastTalkTimeCheckAt;
 		lastTalkTimeCheckAt = currentTick;
 
@@ -11442,7 +11442,7 @@ const char *Actor::GetKitName(ieDword kitID) const
 
 void Actor::SetAnimatedTalking (unsigned int length) {
 	remainingTalkSoundTime = std::max(remainingTalkSoundTime, length);
-	lastTalkTimeCheckAt = GetTickCount();
+	lastTalkTimeCheckAt = GetTicks();
 }
 
 bool Actor::HasPlayerClass() const

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -1764,7 +1764,7 @@ void Selectable::DrawCircle(const Region &vp)
 		//doing a time dependent flashing of colors
 		//if it is too fast, increase the 6 to 7
 		unsigned long step;
-		step = GetTickCount();
+		step = GetTicks();
 		step = tp_steps [(step >> 7) & 7]*2;
 		mix.a = overColor.a;
 		mix.r = (overColor.r*step+selectedColor.r*(8-step))/8;

--- a/gemrb/includes/globals.h
+++ b/gemrb/includes/globals.h
@@ -50,10 +50,7 @@
 #include "System/String.h"
 
 #include <algorithm>
-
-#ifndef WIN32
-# include <sys/time.h>
-#endif
+#include <chrono>
 
 namespace GemRB {
 
@@ -203,14 +200,11 @@ GEM_EXPORT void CopyResRef(ieResRef d, const ieResRef s);
 
 #define SCHEDULE_MASK(time) (1 << core->Time.GetHour(time - core->Time.hour_size/2))
 
-#ifndef WIN32
-inline unsigned long GetTickCount()
+inline unsigned long GetTicks()
 {
-	struct timeval tv;
-	gettimeofday(&tv, NULL);
-	return (tv.tv_usec/1000) + (tv.tv_sec*1000);
+	using namespace std::chrono;
+	return duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
 }
-#endif
 
 inline bool valid_number(const char* string, long& val)
 {

--- a/gemrb/plugins/BIKPlayer/BIKPlayer.cpp
+++ b/gemrb/plugins/BIKPlayer/BIKPlayer.cpp
@@ -240,19 +240,10 @@ int BIKPlayer::Play()
 
 //this code could be in the movieplayer parent class
 void static get_current_time(long &sec, long &usec) {
-#ifdef _WIN32
-	DWORD time;
-	time = GetTickCount();
+	auto time = GetTicks();
 
 	sec = time / 1000;
 	usec = (time % 1000) * 1000;
-#else
-	struct timeval tv;
-	gettimeofday(&tv, NULL);
-
-	sec = tv.tv_sec;
-	usec = tv.tv_usec;
-#endif
 }
 
 void BIKPlayer::timer_start()

--- a/gemrb/plugins/MVEPlayer/mve_player.cpp
+++ b/gemrb/plugins/MVEPlayer/mve_player.cpp
@@ -166,11 +166,11 @@ bool MVEPlayer::process_chunk() {
 	while (chunk_offset < chunk_size) {
 		chunk_offset += 4;
 		if (!request_data(4)) return false;
-		
+
 		unsigned int segment_size = GST_READ_UINT16_LE(buffer);
 		unsigned char segment_type = buffer[2];
 		unsigned char segment_version = buffer[3];
-		
+
 		chunk_offset += segment_size;
 		if (!process_segment(segment_size, segment_type, segment_version)) return false;
 	}
@@ -242,19 +242,10 @@ bool MVEPlayer::process_segment(unsigned short len, unsigned char type, unsigned
  */
 
 static void get_current_time(long &sec, long &usec) {
-#ifdef _WIN32
-	DWORD time;
-	time = GetTickCount();
+	auto time = GetTicks();
 
 	sec = time / 1000;
 	usec = (time % 1000) * 1000;
-#else
-	struct timeval tv;
-	gettimeofday(&tv, NULL);
-
-	sec = tv.tv_sec;
-	usec = tv.tv_usec;
-#endif
 }
 
 void MVEPlayer::timer_start() {

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -405,7 +405,7 @@ int SDL20VideoDriver::PollEvents()
 {
 	if (ignoreNextFingerUp <= 0
 		&& firstFingerDownTime
-		&& GetTickCount() - firstFingerDownTime >= TOUCH_RC_NUM_TICKS) {
+		&& GetTicks() - firstFingerDownTime >= TOUCH_RC_NUM_TICKS) {
 		// enough time has passed to transform firstTouch into a right click event
 
 		// store the finger coordinates before calling ProcessFirstTouch (they get cleared)
@@ -624,7 +624,7 @@ int SDL20VideoDriver::ProcessEvent(const SDL_Event & event)
 				}
 				// do not send a mouseDown event. we delay firstTouch until we know more about the context.
 				firstFingerDown = event.tfinger;
-				firstFingerDownTime = GetTickCount();
+				firstFingerDownTime = GetTicks();
 				// ensure we get the coords for the actual first finger
 				if (finger0) {
 					firstFingerDown.x = ScaleCoordinateHorizontal(finger0->x);

--- a/gemrb/plugins/SDLVideo/SDLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDLVideo.cpp
@@ -66,7 +66,7 @@ SDLVideoDriver::SDLVideoDriver(void)
 	lastTime = 0;
 	backBuf=NULL;
 	extra=NULL;
-	lastMouseDownTime = lastMouseMoveTime = GetTickCount();
+	lastMouseDownTime = lastMouseMoveTime = GetTicks();
 	subtitlestrref = 0;
 	subtitletext = NULL;
 	disp = tmpBuf =  NULL;
@@ -103,12 +103,12 @@ int SDLVideoDriver::Init(void)
 int SDLVideoDriver::SwapBuffers(void)
 {
 	unsigned long time;
-	time = GetTickCount();
+	time = GetTicks();
 	if (( time - lastTime ) < 33) {
 #ifndef NOFPSLIMIT
 		SDL_Delay( 33 - (time - lastTime) );
 #endif
-		time = GetTickCount();
+		time = GetTicks();
 	}
 	lastTime = time;
 
@@ -130,7 +130,7 @@ int SDLVideoDriver::SwapBuffers(void)
 		unsigned int delay = core->TooltipDelay;
 		// The multiplication by 10 is there since the last, disabling slider position is the eleventh
 		if (!core->ConsolePopped && (delay<TOOLTIP_DELAY_FACTOR*10) ) {
-			unsigned long time = GetTickCount();
+			unsigned long time = GetTicks();
 			/** Display tooltip if mouse is idle */
 			if (( time - lastMouseMoveTime ) > delay) {
 				if (EvntManager)
@@ -1590,7 +1590,7 @@ void SDLVideoDriver::SetFadePercent(int percent)
 
 void SDLVideoDriver::MouseMovement(int x, int y)
 {
-	lastMouseMoveTime = GetTickCount();
+	lastMouseMoveTime = GetTicks();
 	if (MouseFlags&MOUSE_DISABLED)
 		return;
 	CursorPos.x = x; // - mouseAdjustX[CursorIndex];


### PR DESCRIPTION
See #1215

I even found a good example that makes the difference at the same FPS indication:

before:
![fps2](https://user-images.githubusercontent.com/238558/113457381-e73eb980-940f-11eb-9359-5fac0ec430f8.gif)
after:
![fps](https://user-images.githubusercontent.com/238558/113457375-e60d8c80-940f-11eb-860d-12ba86e3897c.gif)


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
