### PR TITLE
Don't stop movement after setting a new path

### DIFF
--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -771,9 +771,8 @@ void Map::UpdateScripts()
 			Actor* nearActor = GetActorInRadius(actor->Pos, GA_NO_DEAD|GA_NO_UNSCHEDULED, actor->GetAnims()->GetCircleSize());
 			if (nearActor && nearActor != actor) {
 				actor->NewPath();
-			} else {
-				DoStepForActor(actor, time);
 			}
+			DoStepForActor(actor, time);
 		} else {
 			DoStepForActor(actor, time);
 		}


### PR DESCRIPTION
## Description
Prevents actors from stopping after setting a new path (they we're stopping in place with walking active animation).

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
