### PR TITLE
PST: Clock setup fixes

### DIFF
--- a/gemrb/GUIScripts/pst/Clock.py
+++ b/gemrb/GUIScripts/pst/Clock.py
@@ -19,6 +19,7 @@
 
 import GemRB
 import GUICommon
+import Clock
 from GUIDefines import *
 
 def CreateClockButton(Button):
@@ -27,7 +28,7 @@ def CreateClockButton(Button):
 	Button.SetFlags (IE_GUI_BUTTON_PICTURE | IE_GUI_BUTTON_ANIMATED, OP_SET)
 	Button.SetEvent(IE_GUI_BUTTON_ON_PRESS, lambda: GemRB.GamePause (2, 0))
 	Button.SetEvent(IE_GUI_MOUSE_ENTER_BUTTON, Clock.UpdateClock)
-	Clock.SetPSTGamedaysAndHourToken ()
+	SetPSTGamedaysAndHourToken ()
 	Button.SetTooltip (GemRB.GetString(65027))
 	
 	UpdateClock()


### PR DESCRIPTION
## Description
I've seen Python errors on `Clock` being missing/wrong, resulting in an unusable clock button.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
