### PR TITLE
D3D: Scaling on window resizing

### DIFF
--- a/gemrb/core/GUI/EventMgr.cpp
+++ b/gemrb/core/GUI/EventMgr.cpp
@@ -500,4 +500,11 @@ Event EventMgr::CreateControllerButtonEvent(EventButton btn, bool down)
 	return e;
 }
 
+Event EventMgr::CreateRedrawRequestEvent() {
+	Event e = {};
+	e.type = Event::RedrawRequest;
+
+	return e;
+}
+
 }

--- a/gemrb/core/GUI/EventMgr.h
+++ b/gemrb/core/GUI/EventMgr.h
@@ -165,6 +165,9 @@ struct GEM_EXPORT GestureEvent : public TouchEvent {
 	float dDist;
 };
 
+struct GEM_EXPORT ApplicationEvent : public EventBase {
+};
+
 struct GEM_EXPORT Event {
 	enum EventType {
 		MouseMove = 0,
@@ -183,8 +186,10 @@ struct GEM_EXPORT Event {
 		
 		ControllerAxis,
 		ControllerButtonUp,
-		ControllerButtonDown
+		ControllerButtonDown,
 
+		// Something wants the whole screen to be refreshed (SDL backend, OS, ...)
+		RedrawRequest
 		// leaving off types for unused events
 	};
 
@@ -217,6 +222,9 @@ struct GEM_EXPORT Event {
 		
 		AllControllerMask = ControllerAxisMask | ControllerButtonUpMask | ControllerButtonDownMask,
 
+		RedrawRequestMask = 1 << RedrawRequest,
+		AllApplicationMask = RedrawRequestMask,
+
 		AllEventsMask = 0xffffffffU
 	};
 
@@ -228,6 +236,7 @@ struct GEM_EXPORT Event {
 		KeyboardEvent keyboard;
 		TouchEvent touch;
 		GestureEvent gesture;
+		ApplicationEvent application;
 	};
 
 	TextEvent text; // text is nontrivial so it stands alone (until C++11 is allowed)
@@ -277,6 +286,8 @@ public:
 	
 	static Event CreateControllerAxisEvent(InputAxis axis, int delta, float pct);
 	static Event CreateControllerButtonEvent(EventButton btn, bool down);
+
+	static Event CreateRedrawRequestEvent();
 
 	static bool RegisterHotKeyCallback(EventCallback, KeyboardKey key, short mod = 0);
 	static void UnRegisterHotKeyCallback(EventCallback, KeyboardKey key, short mod = 0);

--- a/gemrb/core/GUI/WindowManager.cpp
+++ b/gemrb/core/GUI/WindowManager.cpp
@@ -369,6 +369,11 @@ Window* WindowManager::NextEventWindow(const Event& event, WindowList::const_ite
 
 bool WindowManager::DispatchEvent(const Event& event)
 {
+	if (event.type == Event::EventType::RedrawRequest) {
+		MarkAllDirty();
+		return true;
+	}
+
 	if (eventMgr.MouseDown() == false && eventMgr.FingerDown() == false) {
 		if (event.type == Event::MouseUp || event.type == Event::TouchUp) {
 			if (trackingWin) {

--- a/gemrb/core/GUI/WindowManager.cpp
+++ b/gemrb/core/GUI/WindowManager.cpp
@@ -76,6 +76,12 @@ WindowManager::WindowManager(Video* vid)
 	// TODO: how do we get notified if the Video driver changes size?
 }
 
+void WindowManager::MarkAllDirty() {
+	for (auto it = windows.begin(); it != windows.end(); ++it) {
+		(*it)->MarkDirty();
+	}
+}
+
 WindowManager::~WindowManager()
 {
 	DestroyWindows(closedWindows);

--- a/gemrb/core/GUI/WindowManager.h
+++ b/gemrb/core/GUI/WindowManager.h
@@ -118,6 +118,7 @@ public:
 
 	Window* MakeWindow(const Region& rgn);
 	void CloseWindow(Window* win);
+	void MarkAllDirty();
 	void DestroyAllWindows();
 
 	bool OrderFront(Window* win);

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -708,8 +708,10 @@ int SDL20VideoDriver::ProcessEvent(const SDL_Event & event)
 			// TODO: must destroy all SDLTextureSprite2D textures
 
 			// fallthough
+		case SDL_APP_DIDENTERFOREGROUND:
 		case SDL_RENDER_TARGETS_RESET:
-			// TODO: must destroy all SDLTextureVideoBuffer textures
+			e = EventMgr::CreateRedrawRequestEvent();
+			EvntManager->DispatchEvent(std::move(e));
 			break;
 		case SDL_WINDOWEVENT://SDL 1.2
 			switch (event.window.event) {


### PR DESCRIPTION
## Description

Some findings:
* `SDL_RENDER_TARGETS_RESET` is exclusively fired for D3D9 (or `direct3d` backend), D3D11 is unaffected at all. Anyway, unlike the removed comment, the [SDL docs imply](https://wiki.libsdl.org/SDL_EventType) that existing textures can be reused. So I think it's the easiest way just to make every window redraw on the next occasion.
* `SDL_RENDER_DEVICE_RESET` is exlusively fired for D3D11 and is not so much related to the issue. From what I read in [MSDN](https://docs.microsoft.com/en-us/windows/uwp/gaming/handling-device-lost-scenarios), it covers some very, very edgy cases that I'd like to ignore here.

See #1317

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
