### PR TITLE
Improving load & save time of heavy save games

### DIFF
--- a/gemrb/core/ArchiveImporter.h
+++ b/gemrb/core/ArchiveImporter.h
@@ -24,6 +24,7 @@
 #include "globals.h"
 
 #include "Plugin.h"
+#include "SaveGameAREExtractor.h"
 
 namespace GemRB {
 
@@ -33,7 +34,7 @@ public:
 	~ArchiveImporter(void) override;
 	virtual int CreateArchive(DataStream *stream) = 0;
 	//decompressing a .sav file similar to CBF
-	virtual int DecompressSaveGame(DataStream *compressed) = 0;
+	virtual int DecompressSaveGame(DataStream *compressed, SaveGameAREExtractor&) = 0;
 	virtual int AddToSaveGame(DataStream *str, DataStream *uncompressed) = 0;
 	virtual int AddToSaveGameCompressed(DataStream *str, DataStream *compressed) = 0;
 };

--- a/gemrb/core/ArchiveImporter.h
+++ b/gemrb/core/ArchiveImporter.h
@@ -35,6 +35,7 @@ public:
 	//decompressing a .sav file similar to CBF
 	virtual int DecompressSaveGame(DataStream *compressed) = 0;
 	virtual int AddToSaveGame(DataStream *str, DataStream *uncompressed) = 0;
+	virtual int AddToSaveGameCompressed(DataStream *str, DataStream *compressed) = 0;
 };
 
 }

--- a/gemrb/core/CMakeLists.txt
+++ b/gemrb/core/CMakeLists.txt
@@ -61,6 +61,7 @@ FILE(GLOB gemrb_core_LIB_SRCS
 	Resource.cpp
 	ResourceDesc.cpp
 	ResourceManager.cpp
+	SaveGameAREExtractor.cpp
 	SaveGameIterator.cpp
 	SaveGameMgr.cpp
 	ScriptEngine.cpp

--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -923,7 +923,13 @@ int Game::LoadMap(const char* ResRef, bool loadscreen)
 		sE->RunFunction("LoadScreen", "StartLoadScreen");
 		sE->RunFunction("LoadScreen", "SetLoadScreen");
 	}
-	DataStream* ds = gamedata->GetResource( ResRef, IE_ARE_CLASS_ID );
+
+	DataStream* ds = nullptr;
+	if (core->saveGameAREExtractor.extractARE(ResRef) != GEM_OK) {
+		goto failedload;
+	}
+
+	ds = gamedata->GetResource( ResRef, IE_ARE_CLASS_ID );
 	if (!ds) {
 		goto failedload;
 	}

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -4513,6 +4513,7 @@ int Interface::CompressSave(const char *folder, bool overrideRunning)
 	PluginHolder<ArchiveImporter> ai = MakePluginHolder<ArchiveImporter>(IE_SAV_CLASS_ID);
 	ai->CreateArchive( &str);
 
+	tick_t startTime = GetTicks();
 	// If we override the savegame we are running to fetch AREs from, it has already dumped
 	// itself as "ares.blb" into the cache folder. Otherwise, just copy directly.
 	if (!overrideRunning && saveGameAREExtractor.copyRetainedAREs(&str) == GEM_ERROR) {
@@ -4550,6 +4551,9 @@ int Interface::CompressSave(const char *folder, bool overrideRunning)
 			dir.Rewind();
 		}
 	}
+
+	tick_t endTime = GetTicks();
+	Log(WARNING, "Core", "%lu ms (compressing SAV file)", endTime - startTime);
 	return GEM_OK;
 }
 

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -43,6 +43,7 @@
 #include "InterfaceConfig.h"
 #include "Resource.h"
 #include "Timer.h"
+#include "SaveGameAREExtractor.h"
 #include "System/VFS.h"
 
 #include <map>
@@ -417,6 +418,7 @@ public:
 	int QuitFlag;
 	int EventFlag;
 	Holder<SaveGame> LoadGameIndex;
+	SaveGameAREExtractor saveGameAREExtractor;
 	int VersionOverride;
 	unsigned int SlotTypes; //this is the same as the inventory size
 	ResRef GlobalScript;
@@ -663,7 +665,7 @@ public:
 	/** saves the worldmap object to the destination folder */
 	int WriteWorldMap(const char *folder);
 	/** saves the .are and .sto files to the destination folder */
-	int CompressSave(const char *folder);
+	int CompressSave(const char *folder, bool overrideRunning);
 	/** toggles the pause. returns either PAUSE_ON or PAUSE_OFF to reflect the script state after toggling. */
 	PauseSetting TogglePause();
 	/** returns true the passed pause setting was applied. false otherwise. */

--- a/gemrb/core/SaveGameAREExtractor.cpp
+++ b/gemrb/core/SaveGameAREExtractor.cpp
@@ -1,0 +1,188 @@
+/* GemRB - Infinity Engine Emulator
+ * Copyright (C) 2021 The GemRB Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ *
+ */
+#include "Interface.h"
+#include "FileCache.h"
+#include "System/FileStream.h"
+#include "SaveGameAREExtractor.h"
+
+namespace GemRB {
+
+SaveGameAREExtractor::SaveGameAREExtractor(SaveGame *saveGame)
+	: saveGame(saveGame)
+{
+	if (saveGame != nullptr) {
+		saveGame->acquire();
+	}
+}
+
+SaveGameAREExtractor::~SaveGameAREExtractor() {
+	if (saveGame != nullptr) {
+		saveGame->release();
+	}
+}
+
+int32_t SaveGameAREExtractor::copyRetainedAREs(DataStream *destStream, bool trackLocations) {
+	auto saveGameStream = saveGame->GetSave();
+	if (saveGameStream == nullptr) {
+		return GEM_ERROR;
+	}
+
+	if (trackLocations) {
+		newAreLocations.clear();
+	}
+
+	using BufferT = std::array<uint8_t, 4096>;
+	BufferT buffer{};
+	int32_t i = 0;
+
+	size_t relativeLocation = 0;
+	for (auto it = areLocations.cbegin(); it != areLocations.cend(); ++it, ++i) {
+		relativeLocation += 4 + it->first.size() + 1;
+
+		ieDword complen, declen;
+		saveGameStream->Seek(it->second, GEM_STREAM_START);
+		saveGameStream->ReadDword(declen);
+		saveGameStream->ReadDword(complen);
+
+		auto nameLength = it->first.size() + 1;
+		destStream->WriteDword(nameLength);
+		destStream->Write(it->first.c_str(), nameLength);
+		destStream->WriteDword(declen);
+		destStream->WriteDword(complen);
+
+		if (trackLocations) {
+			newAreLocations.emplace(std::make_pair(it->first, relativeLocation));
+			relativeLocation += 8 + complen;
+		}
+
+		BufferT::size_type remaining = complen;
+		while (remaining > 0) {
+			auto copySize = std::min(buffer.size(), remaining);
+			saveGameStream->Read(buffer.data(), copySize);
+			destStream->Write(buffer.data(), copySize);
+			remaining -= copySize;
+		}
+	}
+
+	delete saveGameStream;
+
+	return i;
+}
+
+int32_t SaveGameAREExtractor::createCacheBlob() {
+	if (areLocations.empty()) {
+		return 0;
+	}
+
+	const char *blobFile = "ares.blb";
+	char path[_MAX_PATH];
+	PathJoin(path, core->CachePath, blobFile, nullptr);
+
+	FileStream cacheStream;
+
+	if (!cacheStream.Create(path)) {
+		Log(ERROR, "SaveGameAREExtractor", "Cannot write to cache: %s.", path);
+		return GEM_ERROR;
+	}
+
+	int32_t areEntries = copyRetainedAREs(&cacheStream, true);
+
+	return areEntries;
+}
+
+int32_t SaveGameAREExtractor::extractARE(const char *name) {
+	std::string key{name};
+	StringToLower(key);
+	key.append(".are");
+
+	auto it = areLocations.find(key);
+	if (it != areLocations.cend() && extractByEntry(key, it) != GEM_OK) {
+		return GEM_ERROR;
+	}
+
+	return GEM_OK;
+}
+
+int32_t SaveGameAREExtractor::extractByEntry(const std::string& key, RegistryT::const_iterator it) {
+	auto saveGameStream = saveGame->GetSave();
+	if (saveGameStream == nullptr) {
+		return GEM_ERROR;
+	}
+
+	ieDword complen, declen;
+	saveGameStream->Seek(it->second, GEM_STREAM_START);
+	saveGameStream->ReadDword(declen);
+	saveGameStream->ReadDword(complen);
+
+	DataStream* cached = CacheCompressedStream(saveGameStream, key.c_str(), complen, true);
+
+	int32_t returnValue = GEM_OK;
+	if (cached != nullptr) {
+		delete cached;
+	} else {
+		returnValue = GEM_ERROR;
+	}
+
+	delete saveGameStream;
+	areLocations.erase(it);
+
+	return returnValue;
+}
+
+bool SaveGameAREExtractor::isRunningSaveGame(const SaveGame& otherGame) {
+	if (saveGame == nullptr) {
+		return false;
+	}
+
+	return saveGame->GetSaveID() == otherGame.GetSaveID();
+}
+
+void SaveGameAREExtractor::registerLocation(const char *name, unsigned long pos) {
+	std::string key{name};
+	StringToLower(key);
+
+	areLocations.emplace(std::make_pair(std::move(key), pos));
+}
+
+void SaveGameAREExtractor::changeSaveGame(SaveGame *saveGame) {
+	if (this->saveGame != nullptr) {
+		this->saveGame->release();
+	}
+
+	this->saveGame = saveGame;
+	if (this->saveGame != nullptr) {
+		this->saveGame->acquire();
+	}
+
+	areLocations.clear();
+	newAreLocations.clear();
+}
+
+void SaveGameAREExtractor::updateSaveGame(size_t offset) {
+	if (saveGame == nullptr) {
+		return;
+	}
+
+	areLocations = std::move(newAreLocations);
+
+	for (auto it = areLocations.begin(); it != areLocations.end(); ++it) {
+		it->second += offset;
+	}
+}
+
+}

--- a/gemrb/core/SaveGameAREExtractor.h
+++ b/gemrb/core/SaveGameAREExtractor.h
@@ -1,0 +1,66 @@
+/* GemRB - Infinity Engine Emulator
+ * Copyright (C) 2021 The GemRB Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ *
+ */
+
+#ifndef SAVE_GAME_ARE_EXTRACTOR_H
+#define SAVE_GAME_ARE_EXTRACTOR_H
+
+#include <unordered_map>
+#include <string>
+
+#include "exports.h"
+#include "System/String.h"
+#include "SaveGame.h"
+
+namespace GemRB {
+
+/**
+ * This thing knows the currently loaded game, and SAVImporter already told
+ * us where to find what ARE files. So we can extract them only when required.
+ */
+class GEM_EXPORT SaveGameAREExtractor {
+	private:
+		using RegistryT = std::unordered_map<std::string, unsigned long>;
+
+		SaveGame *saveGame;
+		RegistryT areLocations;
+		RegistryT newAreLocations;
+
+	public:
+		SaveGameAREExtractor(SaveGame *saveGame = nullptr);
+		SaveGameAREExtractor(const SaveGameAREExtractor&) = delete;
+		SaveGameAREExtractor(SaveGameAREExtractor&&) = delete;
+		~SaveGameAREExtractor();
+		SaveGameAREExtractor& operator=(const SaveGameAREExtractor&) = delete;
+		SaveGameAREExtractor& operator=(SaveGameAREExtractor&&) = delete;
+
+		void changeSaveGame(SaveGame*);
+		int32_t copyRetainedAREs(DataStream*, bool trackLocations = false);
+		int32_t createCacheBlob();
+		int32_t extractARE(const char*);
+		bool isRunningSaveGame(const SaveGame&);
+		void registerLocation(const char*, unsigned long);
+		void registerNewLocation(const char*, unsigned long);
+		void updateSaveGame(size_t offset);
+
+	private:
+		int32_t extractByEntry(const std::string&, RegistryT::const_iterator);
+};
+
+}
+
+#endif

--- a/gemrb/plugins/SAVImporter/SAVImporter.cpp
+++ b/gemrb/plugins/SAVImporter/SAVImporter.cpp
@@ -115,6 +115,21 @@ int SAVImporter::AddToSaveGame(DataStream *str, DataStream *uncompressed)
 	return GEM_OK;
 }
 
+int SAVImporter::AddToSaveGameCompressed(DataStream *str, DataStream *compressed) {
+	using BufferT = std::array<uint8_t, 4096>;
+	BufferT buffer{};
+
+	BufferT::size_type remaining = compressed->Size();
+	while (remaining > 0) {
+		auto copySize = std::min(buffer.size(), remaining);
+		compressed->Read(buffer.data(), copySize);
+		str->Write(buffer.data(), copySize);
+		remaining -= copySize;
+	}
+
+	return GEM_OK;
+}
+
 #include "plugindef.h"
 
 GEMRB_PLUGIN(0xCDF132C, "SAV File Importer")

--- a/gemrb/plugins/SAVImporter/SAVImporter.cpp
+++ b/gemrb/plugins/SAVImporter/SAVImporter.cpp
@@ -44,6 +44,8 @@ int SAVImporter::DecompressSaveGame(DataStream *compressed, SaveGameAREExtractor
 	int Current;
 	int percent, last_percent = 20;
 	if (!All) return GEM_ERROR;
+
+	tick_t startTime = GetTicks();
 	do {
 		ieDword fnlen, complen, declen;
 		compressed->ReadDword(fnlen);
@@ -80,6 +82,9 @@ int SAVImporter::DecompressSaveGame(DataStream *compressed, SaveGameAREExtractor
 		}
 	}
 	while(Current);
+
+	tick_t endTime = GetTicks();
+	Log(WARNING, "Core", "%lu ms (extracting the SAV)", endTime - startTime);
 	return GEM_OK;
 }
 

--- a/gemrb/plugins/SAVImporter/SAVImporter.h
+++ b/gemrb/plugins/SAVImporter/SAVImporter.h
@@ -35,6 +35,7 @@ public:
 	~SAVImporter(void) override;
 	int DecompressSaveGame(DataStream *compressed) override;
 	int AddToSaveGame(DataStream *str, DataStream *uncompressed) override;
+	int AddToSaveGameCompressed(DataStream *str, DataStream *compressed) override;
 	int CreateArchive(DataStream *compressed) override;
 };
 

--- a/gemrb/plugins/SAVImporter/SAVImporter.h
+++ b/gemrb/plugins/SAVImporter/SAVImporter.h
@@ -33,7 +33,7 @@ class SAVImporter : public ArchiveImporter {
 public:
 	SAVImporter(void);
 	~SAVImporter(void) override;
-	int DecompressSaveGame(DataStream *compressed) override;
+	int DecompressSaveGame(DataStream *compressed, SaveGameAREExtractor&) override;
 	int AddToSaveGame(DataStream *str, DataStream *uncompressed) override;
 	int AddToSaveGameCompressed(DataStream *str, DataStream *compressed) override;
 	int CreateArchive(DataStream *compressed) override;


### PR DESCRIPTION
## Description
I noticed that save games of later stages in the game take notably longer: Every ARE is extracted into the cache onto the disk. Yet, we don't need all these ARE files right now, and given the progress, some of them never again.

BG1 spills around 260 ARE files into the cache folder, other games a little less for me.

Why not extract only when we really need it? On my very fast NVMe this _only_ saves half a second (and a lot of console entries), but surely some more on HDDs or RPIs -- unfortunately no test hardware at hand right now.

Feel free to discuss first, but I considered this an avoidable practice.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
