### PR TITLE
Map: pack lightmap/heightmap/materialmap/searchmap

### DIFF
--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -647,14 +647,6 @@ void GameControl::DrawSelf(Region screen, const Region& /*clip*/)
 		}
 	}
 
-	// Draw lightmap
-	if (DebugFlags & DEBUG_SHOW_LIGHTMAP) {
-		Holder<Sprite2D> spr = area->LightMap;
-		video->BlitSprite(spr, Point());
-		Region point(gameMousePos.x / 16, gameMousePos.y / 12, 2, 2);
-		video->DrawRect(point, ColorRed);
-	}
-
 	if (core->HasFeature(GF_ONSCREEN_TEXT) && DisplayText) {
 		core->GetTextFont()->Print(screen, *DisplayText, IE_FONT_ALIGN_CENTER | IE_FONT_ALIGN_MIDDLE, {core->InfoTextColor, ColorBlack});
 		if (!(DialogueFlags & DF_FREEZE_SCRIPTS)) {
@@ -1086,12 +1078,34 @@ bool GameControl::OnKeyRelease(const KeyboardEvent& Key, unsigned short Mod)
 					flagIdx = flagIdx % flagCnt;
 				}
 				break;
-			case '6': //show the lightmap
-				DebugFlags ^= DEBUG_SHOW_LIGHTMAP;
-				Log(MESSAGE, "GameControl", "Show lightmap %s", DebugFlags & DEBUG_SHOW_LIGHTMAP ? "ON" : "OFF");
+			case '6': //toggle between lightmap/heightmap/material/search
+				{
+					constexpr int flagCnt = 5;
+					static uint32_t flags[flagCnt]{
+						0,
+						DEBUG_SHOW_SEARCHMAP,
+						DEBUG_SHOW_MATERIALMAP,
+						DEBUG_SHOW_HEIGHTMAP,
+						DEBUG_SHOW_LIGHTMAP,
+					};
+					constexpr uint32_t mask = (DEBUG_SHOW_LIGHTMAP | DEBUG_SHOW_HEIGHTMAP
+											   | DEBUG_SHOW_MATERIALMAP | DEBUG_SHOW_SEARCHMAP);
+					
+					static uint32_t flagIdx = 0;
+					DebugFlags &= ~mask;
+					DebugFlags |= flags[flagIdx++];
+					flagIdx = flagIdx % flagCnt;
+					
+					if (DebugFlags & mask) {
+						// fog interferese with debugging the map
+						// you can manually reenable with ctrl+7
+						DebugFlags |= DEBUG_SHOW_FOG_ALL;
+					} else {
+						DebugFlags &= ~DEBUG_SHOW_FOG_ALL;
+					}
+				}
 				break;
 			case '7': //toggles fog of war
-			case '8': // searchmap debugging
 				{
 					constexpr int flagCnt = 4;
 					static uint32_t fogFlags[flagCnt]{
@@ -1103,12 +1117,6 @@ bool GameControl::OnKeyRelease(const KeyboardEvent& Key, unsigned short Mod)
 					static uint32_t flagIdx = 0;
 					
 					DebugFlags &= ~DEBUG_SHOW_FOG_ALL;
-					if (Key.character == '8') {
-						DebugFlags ^= DEBUG_SHOW_SEARCHMAP;
-						flagIdx = (DebugFlags & DEBUG_SHOW_SEARCHMAP) ? 1 : 0;
-						Log(MESSAGE, "GameControl", "Show searchmap %s", DebugFlags & DEBUG_SHOW_SEARCHMAP ? "ON" : "OFF");
-					}
-					
 					DebugFlags |= fogFlags[flagIdx++];
 					flagIdx = flagIdx % flagCnt;
 				}

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -286,9 +286,6 @@ tileProps(std::move(props))
 {
 	ExploredBitmap.fill(0);
 	VisibleBitmap.fill(0);
-
-	mapSize.w = TMap->XCellCount * 4;
-	mapSize.h = (TMap->YCellCount * 64 + 63) / 12;
 	
 	area=this;
 	queue[PR_SCRIPT] = NULL;
@@ -803,6 +800,11 @@ Size Map::FogMapSize() const
 	constexpr int CELL_RATIO = 2;
 	const int largefog = Explore::Get().LargeFog;
 	return Size(TMap->XCellCount * CELL_RATIO + largefog, TMap->YCellCount * CELL_RATIO + largefog);
+}
+
+Size Map::PropsSize() const noexcept
+{
+	return tileProps->Frame.size;
 }
 
 bool Map::FogTileUncovered(const Point &p, const Bitmap* mask) const
@@ -2432,7 +2434,7 @@ void Map::PlayAreaSong(int SongType, bool restart, bool hard) const
 int Map::GetHeight(const Point &p) const
 {
 	Point tilePos = Map::ConvertCoordToTile(p);
-	if (mapSize.PointInside(tilePos)) {
+	if (PropsSize().PointInside(tilePos)) {
 		// Heightmaps are greyscale images where the top of the world is white and the bottom is black.
 		// this covers the range -7 – +7
 		// since the image is grey we can use any channel for the mapping
@@ -2448,7 +2450,7 @@ int Map::GetHeight(const Point &p) const
 Color Map::GetLighting(const Point &p) const
 {
 	Point tilePos = Map::ConvertCoordToTile(p);
-	if (mapSize.PointInside(tilePos)) {
+	if (PropsSize().PointInside(tilePos)) {
 		uint8_t val = tileProps->GetPixel(tilePos).a;
 		return tileProps->GetPalette()->col[val];
 	}
@@ -2458,7 +2460,7 @@ Color Map::GetLighting(const Point &p) const
 PathMapFlags Map::QuerySearchMap(const Point &p) const
 {
 	// p is already in search map coords
-	if (mapSize.PointInside(p)) {
+	if (PropsSize().PointInside(p)) {
 		return PathMapFlags(tileProps->GetPixel(p).r);
 	}
 	return PathMapFlags::IMPASSABLE;
@@ -2940,6 +2942,9 @@ bool Map::AdjustPositionX(Point &goal, int radiusx, int radiusy, int size) const
 	if (goal.x > radiusx)
 		minx = goal.x - radiusx;
 	int maxx = goal.x + radiusx + 1;
+	
+	const Size& mapSize = PropsSize();
+	
 	if (maxx > mapSize.w)
 		maxx = mapSize.w;
 
@@ -2968,6 +2973,8 @@ bool Map::AdjustPositionY(Point &goal, int radiusx, int radiusy, int size) const
 	if (goal.y > radiusy)
 		miny = goal.y - radiusy;
 	int maxy = goal.y + radiusy + 1;
+	
+	const Size& mapSize = PropsSize();
 	if (maxy > mapSize.h)
 		maxy = mapSize.h;
 	for (int scany = miny; scany < maxy; scany++) {
@@ -2999,6 +3006,8 @@ void Map::AdjustPositionNavmap(NavmapPoint &goal, int radiusx, int radiusy) cons
 
 void Map::AdjustPosition(SearchmapPoint &goal, int radiusx, int radiusy, int size) const
 {
+	const Size& mapSize = PropsSize();
+
 	if (goal.x > mapSize.w) {
 		goal.x = mapSize.w;
 	}
@@ -3057,6 +3066,7 @@ int Map::WhichEdge(const Point &s) const
 		return -1;
 	}
 	// FIXME: is this backwards?
+	const Size& mapSize = PropsSize();
 	tileP.x *= mapSize.h;
 	tileP.y *= mapSize.w;
 	if (tileP.x > tileP.y) { //north or east
@@ -3410,6 +3420,8 @@ void Map::BlockSearchMap(const Point &Pos, unsigned int size, PathMapFlags value
 	int ppy = Pos.y/12;
 	unsigned int r=(size-1)*(size-1)+1;
 	uint32_t* SrchMap = (uint32_t*)tileProps->LockSprite();
+	const Size& mapSize = PropsSize();
+
 	auto readSrchMap = [&](int pos) -> PathMapFlags {
 		if (pos < 0 || pos > mapSize.Area()) {
 			return PathMapFlags::IMPASSABLE;
@@ -4031,7 +4043,7 @@ PathMapFlags Map::GetInternalSearchMap(const Point& p) const
 	// TODO: the subtle difference betweenm GetInternalSearchMap and QuerySearchMap
 	// is that this returns PathMapFlags::UNMARKED instead of PathMapFlags::IMPASSABLE
 	// for out of bounds points. I dont know if that is an important distiction
-	if (!mapSize.PointInside(p)) {
+	if (!PropsSize().PointInside(p)) {
 		return PathMapFlags::UNMARKED;
 	}
 	return QuerySearchMap(p);
@@ -4039,6 +4051,7 @@ PathMapFlags Map::GetInternalSearchMap(const Point& p) const
 
 void Map::SetInternalSearchMap(const Point& p, PathMapFlags value)
 {
+	const Size& mapSize = PropsSize();
 	if (!mapSize.PointInside(p)) {
 		return;
 	}

--- a/gemrb/core/Map.h
+++ b/gemrb/core/Map.h
@@ -390,7 +390,6 @@ private:
 	// the assigned palette is the palette for the lightmap
 	Holder<Sprite2D> tileProps;
 
-	Size mapSize;
 	std::list<AreaAnimation> animations;
 	std::vector< Actor*> actors;
 	std::vector<WallPolygonGroup> wallGroups;
@@ -654,6 +653,8 @@ private:
 	void DrawPortal(const InfoPoint *ip, int enable);
 	void DrawHighlightables(const Region& viewport) const;
 	void DrawFogOfWar(const Bitmap* explored_mask, const Bitmap* visible_mask, const Region& viewport);
+	
+	Size PropsSize() const noexcept;
 	Size FogMapSize() const;
 	bool FogTileUncovered(const Point &p, const Bitmap*) const;
 	Point ConvertPointToFog(const Point &p) const;

--- a/gemrb/core/PathFinder.cpp
+++ b/gemrb/core/PathFinder.cpp
@@ -154,6 +154,7 @@ PathNode *Map::RandomWalk(const Point &s, int size, int radius, const Actor *cal
 	PathNode *step = new PathNode;
 	step->x = p.x;
 	step->y = p.y;
+	const Size& mapSize = PropsSize();
 	step->x = Clamp<unsigned int>(step->x, 1u, (mapSize.w - 1) * 16);
 	step->y = Clamp<unsigned int>(step->y, 1u, (mapSize.h - 1) * 12);
 	step->Parent = nullptr;
@@ -236,6 +237,8 @@ PathNode *Map::GetLine(const Point &start, const Point &dest, int Speed, int Ori
 		if (p.x < 0 || p.y < 0) {
 			return Return;
 		}
+		
+		const Size& mapSize = PropsSize();
 		if (p.x > mapSize.w * 16 || p.y > mapSize.h * 12) {
 			return Return;
 		}
@@ -274,6 +277,7 @@ PathNode *Map::GetLine(const Point &p, int steps, unsigned int orient) const
 	PathNode *step = new PathNode;
 	step->x = p.x + steps * SEARCHMAP_SQUARE_DIAGONAL * dxRand[orient];
 	step->y = p.y + steps * SEARCHMAP_SQUARE_DIAGONAL * dyRand[orient];
+	const Size& mapSize = PropsSize();
 	step->x = Clamp<unsigned int>(step->x, 1u, (mapSize.w - 1) * 16);
 	step->y = Clamp<unsigned int>(step->y, 1u, (mapSize.h - 1) * 12);
 	step->orient = GetOrient(Point(step->x, step->y), p);
@@ -305,6 +309,7 @@ PathNode *Map::FindPath(const Point &s, const Point &d, unsigned int size, unsig
 	if (smptDest == smptSource) return nullptr;
 
 	// Initialize data structures
+	const Size& mapSize = PropsSize();
 	FibonacciHeap<PQNode> open;
 	std::vector<bool> isClosed(mapSize.Area(), false);
 	std::vector<NavmapPoint> parents(mapSize.Area(), Point(0, 0));

--- a/gemrb/core/Projectile.cpp
+++ b/gemrb/core/Projectile.cpp
@@ -1718,7 +1718,7 @@ void Projectile::DrawTravel(const Region& viewport)
 
 	//Area tint
 	if (TFlags&PTF_TINT) {
-		tint = area->LightMap->GetPixel(Map::ConvertCoordToTile(Pos));
+		tint = area->GetLighting(Pos);
 		tint.a = 255;
 		flag |= BlitFlags::COLOR_MOD;
 	}

--- a/gemrb/plugins/AREImporter/AREImporter.cpp
+++ b/gemrb/plugins/AREImporter/AREImporter.cpp
@@ -329,13 +329,9 @@ bool AREImporter::ChangeMap(Map *map, bool day_or_night)
 	// Small map for MapControl
 	ResourceHolder<ImageMgr> sm = GetResourceHolder<ImageMgr>(TmpResRef);
 
-	// night small map is *optional*!
-	if (!sm) {
-		//fall back to day minimap
-		sm = GetResourceHolder<ImageMgr>(map->WEDResRef);
-	}
-	
 	if (sm) {
+		// night small map is *optional*!
+		// keep the exising map if this one is null
 		map->SmallMap = sm->GetSprite2D();
 	}
 	


### PR DESCRIPTION
into a single 32bit sprite. This will give great cache locality for everything we need to lookup in a given frame.
if we want we could add a way to dump it to a file for even better debugging

add enhanced DebugOverlay capable of displaying all maps

## Description
<!-- Describe the overall purpose of this pull request (PR). If applicable also add bug references and screenshots.-->


## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
