### PR TITLE
Added hpinit.2da support

### DIFF
--- a/gemrb/GUIScripts/pst/NewLife.py
+++ b/gemrb/GUIScripts/pst/NewLife.py
@@ -251,13 +251,11 @@ def AcceptPress():
 	#don't add con bonus, it will be calculated by the game
 	#interestingly enough, the game adds only one level's con bonus
 	Table = GemRB.LoadTable ("hpinit")
-	x = Table.GetValue (Stats[4]-1, 0)
+	x = Table.GetValue (str(Stats[4]), "HP")
 
 	print("Setting max hp to: ", x)
 	GemRB.SetPlayerStat(1, IE_MAXHITPOINTS, x)
-	#adding the remaining constitution bonus to the current hp
-	#if Con>14:
-	#	x = x+(Con-14)*3
+	
 	x = x + 100 #ensures the player starts at max hp when con > 14
 	print("Setting current hp to: ", x)
 	GemRB.SetPlayerStat(1, IE_HITPOINTS, x)

--- a/gemrb/GUIScripts/pst/NewLife.py
+++ b/gemrb/GUIScripts/pst/NewLife.py
@@ -252,13 +252,9 @@ def AcceptPress():
 	#interestingly enough, the game adds only one level's con bonus
 	Table = GemRB.LoadTable ("hpinit")
 	x = Table.GetValue (str(Stats[4]), "HP")
-
-	print("Setting max hp to: ", x)
-	GemRB.SetPlayerStat(1, IE_MAXHITPOINTS, x)
 	
-	x = x + 100 #ensures the player starts at max hp when con > 14
-	print("Setting current hp to: ", x)
-	GemRB.SetPlayerStat(1, IE_HITPOINTS, x)
+	GemRB.SetPlayerStat(1, IE_MAXHITPOINTS, x)
+	GemRB.SetPlayerStat(1, IE_HITPOINTS, x + 100) # x + 100 ensures the player starts at max hp when con > 14
 
 	GemRB.FillPlayerInfo(1) #does all the rest
 	#LETS PLAY!!

--- a/gemrb/GUIScripts/pst/NewLife.py
+++ b/gemrb/GUIScripts/pst/NewLife.py
@@ -250,17 +250,15 @@ def AcceptPress():
 
 	#don't add con bonus, it will be calculated by the game
 	#interestingly enough, the game adds only one level's con bonus
-	Con = Stats[4]
-	if Con > 14:
-		x = 30
-	else:
-		x = 20 + (Con-9)*2
+	Table = GemRB.LoadTable ("hpinit")
+	x = Table.GetValue (Stats[4]-1, 0)
 
 	print("Setting max hp to: ", x)
 	GemRB.SetPlayerStat(1, IE_MAXHITPOINTS, x)
 	#adding the remaining constitution bonus to the current hp
 	#if Con>14:
 	#	x = x+(Con-14)*3
+	x = x + 100 #ensures the player starts at max hp when con > 14
 	print("Setting current hp to: ", x)
 	GemRB.SetPlayerStat(1, IE_HITPOINTS, x)
 


### PR DESCRIPTION
… would not start at max hp when con >14

## Description
<!-- Describe the overall purpose of this pull request (PR). If applicable also add bug references and screenshots.-->
Added hpinit.2da support to NewLife.py (issue #935). Fixed issue where the player would not start at max hp when con >14.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
