### PR TITLE
Fixes issue where portrait would not refresh on level up.

### DIFF
--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -1366,6 +1366,7 @@ static void pcf_xp(Actor *actor, ieDword /*oldValue*/, ieDword /*newValue*/)
 		if (NeedsLevelUp == 1) {
 			displaymsg->DisplayConstantStringName(STR_LEVELUP, DMC_WHITE, actor);
 			actor->GotLUFeedback = true;
+			core->SetEventFlag(EF_PORTRAIT);
 		}
 	}
 }


### PR DESCRIPTION
## Description
<!-- Describe the overall purpose of this pull request (PR). If applicable also add bug references and screenshots.-->
This should fix issue #1462 where portraits were not automatically refreshing when a character leveled up.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
