### PR TITLE
Change if subtitles option is disable will not show the pc text on the chat log

### DIFF
--- a/gemrb/core/GameScript/GSUtils.cpp
+++ b/gemrb/core/GameScript/GSUtils.cpp
@@ -435,6 +435,9 @@ void DisplayStringCore(Scriptable* const Sender, int Strref, int flags)
 	unsigned int channel = SFX_CHAN_DIALOG;
 
 	Log(MESSAGE, "GameScript", "Displaying string on: %s", Sender->GetScriptName() );
+	// Check if subtitles are not enabled
+	ieDword charactersubtitles = 0;
+	core->GetDictionary()->Lookup("Subtitles", charactersubtitles);
 	if (flags & DS_CONST) {
 		if (Sender->Type!=ST_ACTOR) {
 			Log(ERROR, "GameScript", "Verbal constant not supported for non actors!");
@@ -459,8 +462,6 @@ void DisplayStringCore(Scriptable* const Sender, int Strref, int flags)
 		Strref = tmp;
 
 		//display the verbal constants in the console
-		ieDword charactersubtitles = 0;
-		core->GetDictionary()->Lookup("Subtitles", charactersubtitles);
 		if (charactersubtitles) {
 			flags |= DS_CONSOLE;
 		}
@@ -471,12 +472,6 @@ void DisplayStringCore(Scriptable* const Sender, int Strref, int flags)
 			channel = SFX_CHAN_MONSTER;
 		}
 	}
-	// Check if subtitles are not enabled
-	ieDword charactersubtitles = 0;
-	core->GetDictionary()->Lookup("Subtitles", charactersubtitles);
-	//if (!charactersubtitles) {
-	//	flags &= ~DS_CONSOLE;
-	//}
 	// PST does not echo verbal constants in the console, their strings
 	// actually contain development related identifying comments
 	// thus the console flag is unset.

--- a/gemrb/core/GameScript/GSUtils.cpp
+++ b/gemrb/core/GameScript/GSUtils.cpp
@@ -485,6 +485,11 @@ void DisplayStringCore(Scriptable* const Sender, int Strref, int flags)
 			strlcpy(Sound, sb.Sound, sizeof(Sound));
 		}
 		if (sb.text) {
+			ieDword charactersubtitles = 0;
+			core->GetDictionary()->Lookup("Subtitles", charactersubtitles);
+			if (!charactersubtitles) {
+				flags &= ~DS_CONSOLE;
+			}
 			if (flags & DS_CONSOLE) {
 				//can't play the sound here, we have to delay action
 				//and for that, we have to know how long the text takes

--- a/gemrb/core/GameScript/GSUtils.cpp
+++ b/gemrb/core/GameScript/GSUtils.cpp
@@ -471,11 +471,16 @@ void DisplayStringCore(Scriptable* const Sender, int Strref, int flags)
 			channel = SFX_CHAN_MONSTER;
 		}
 	}
-
+	// Check if subtitles are not enabled
+	ieDword charactersubtitles = 0;
+	core->GetDictionary()->Lookup("Subtitles", charactersubtitles);
+	//if (!charactersubtitles) {
+	//	flags &= ~DS_CONSOLE;
+	//}
 	// PST does not echo verbal constants in the console, their strings
 	// actually contain development related identifying comments
 	// thus the console flag is unset.
-	if (core->HasFeature(GF_ONSCREEN_TEXT)) {
+	if (core->HasFeature(GF_ONSCREEN_TEXT) || !charactersubtitles) {
 		flags &= ~DS_CONSOLE;
 	}
 
@@ -485,11 +490,6 @@ void DisplayStringCore(Scriptable* const Sender, int Strref, int flags)
 			strlcpy(Sound, sb.Sound, sizeof(Sound));
 		}
 		if (sb.text) {
-			ieDword charactersubtitles = 0;
-			core->GetDictionary()->Lookup("Subtitles", charactersubtitles);
-			if (!charactersubtitles) {
-				flags &= ~DS_CONSOLE;
-			}
 			if (flags & DS_CONSOLE) {
 				//can't play the sound here, we have to delay action
 				//and for that, we have to know how long the text takes


### PR DESCRIPTION
## Description
This will fix the option of enabling and disabling subtitles on the chat log. Issue #1420

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [X] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
