### PR TITLE
Missing CString header for MSYS2/GCC

### DIFF
--- a/gemrb/core/System/CString.h
+++ b/gemrb/core/System/CString.h
@@ -26,6 +26,7 @@
 #include <cctype>
 #include <cstdarg>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 
 #ifndef WIN32


### PR DESCRIPTION
The only thing that prevents #1523 from building for me.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
