### PR TITLE
Fixing the logging header for Windows

### DIFF
--- a/gemrb/core/Logging/Logging.h
+++ b/gemrb/core/Logging/Logging.h
@@ -42,7 +42,7 @@ GEM_EXPORT void LogMsg(Logger::LogMessage&& msg);
 
 /// Log an error and exit.
 template<typename... ARGS> [[noreturn]]
-GEM_EXPORT void error(const char* owner, const char* format, ARGS&&... args)
+void error(const char* owner, const char* format, ARGS&&... args)
 {
 	auto formattedMsg = fmt::format(format, std::forward<ARGS>(args)...);
 	LogMsg(Logger::LogMessage(FATAL, owner, formattedMsg, LIGHT_RED));
@@ -51,7 +51,7 @@ GEM_EXPORT void error(const char* owner, const char* format, ARGS&&... args)
 }
 
 template<typename... ARGS>
-GEM_EXPORT void Log(log_level level, const char* owner, const char* message, ARGS&&... args)
+void Log(log_level level, const char* owner, const char* message, ARGS&&... args)
 {
 	auto formattedMsg = fmt::format(message, std::forward<ARGS>(args)...);
 	LogMsg(Logger::LogMessage(level, owner, formattedMsg, WHITE));


### PR DESCRIPTION
Having `GEM_EXPORT` with the now-template definitions misdefines some linking expectations, resulting in:

```
D:/Sources/gemrb/gemrb/core/Logging/Logging.h:45:17: error: function 'void GemRB::error(const char*, const char*, ARGS&& ...)' definition is marked dllimport
   45 | GEM_EXPORT void error(const char* owner, const char* format, ARGS&&... args)
      |                 ^~~~~
D:/Sources/gemrb/gemrb/core/Logging/Logging.h:54:17: error: function 'void GemRB::Log(GemRB::log_level, const char*, const char*, ARGS&& ...)' definition is marked dllimport
   54 | GEM_EXPORT void Log(log_level level, const char* owner, const char* message, ARGS&&... args)
      |                 ^~~
```

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
