### PR TITLE
Faster GLSL uniforms lookup

### DIFF
--- a/gemrb/plugins/SDLVideo/GLSLProgram.cpp
+++ b/gemrb/plugins/SDLVideo/GLSLProgram.cpp
@@ -175,13 +175,15 @@ bool GLSLProgram::buildProgram(std::string vertexSource, const std::string& frag
 	return program != 0;
 }
 
-GLint GLSLProgram::getUniformLocation(std::string uniformName)
+GLint GLSLProgram::getUniformLocation(const std::string& uniformName) const
 {
-	if (uniforms.find(uniformName) == uniforms.end()) {
+	const auto it = uniforms.find(uniformName);
+	if (it == uniforms.end()) {
 		GLSLProgram::errMessage = "GLSLProgram error: Invalid uniform location";
 		return -1;
 	}
-	return uniforms.at(uniformName);
+
+	return it->second;
 }
 
 const std::string GLSLProgram::GetLastError()

--- a/gemrb/plugins/SDLVideo/GLSLProgram.h
+++ b/gemrb/plugins/SDLVideo/GLSLProgram.h
@@ -32,7 +32,7 @@ namespace GemRB
 		std::map<std::string, GLint> uniforms;
 		bool buildProgram(std::string vertexSource, const std::string& fragmentSource);
 		GLuint buildShader(GLenum type, std::string source) const;
-		GLint getUniformLocation(std::string uniformName);
+		GLint getUniformLocation(const std::string& uniformName) const;
 		bool storeUniformLocation(std::string uniformName);
 	};
 }


### PR DESCRIPTION
I found some oddly bad looking, and unnecessary slow code that's on the hot path when repopulating GLSL uniform variables.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
