### PR TITLE
CString: fixing RTrim 

### DIFF
--- a/gemrb/core/Strings/CString.h
+++ b/gemrb/core/Strings/CString.h
@@ -111,10 +111,11 @@ public:
 	
 	// remove trailing spaces
 	uint8_t RTrim() {
-		int8_t len = CStrLen();
-		int8_t i = len;
-		for (; i - 1 >= 0; --i) {
-			if (std::isspace(str[i])) str[i] = '\0';
+		uint8_t len = CStrLen();
+		uint8_t i = 0;
+		for (; i < len; ++i) {
+			uint8_t idx = len - i - 1;
+			if (std::isspace(str[idx])) str[idx] = '\0';
 			else break;
 		}
 


### PR DESCRIPTION
The implementation has problems: First index is oob, and what if the string length is > 127. See #1555

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
