### PR TITLE
SDL sprite copy fix

### DIFF
--- a/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.cpp
+++ b/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.cpp
@@ -291,6 +291,11 @@ SDLTextureSprite2D::~SDLTextureSprite2D() noexcept
 	SDL_DestroyTexture(texture);
 }
 
+SDLTextureSprite2D::SDLTextureSprite2D(const SDLTextureSprite2D& other) noexcept
+	: SDLSurfaceSprite2D(other), texFormat(other.texFormat), texture(nullptr),
+	staleTexture(false)
+{}
+
 Holder<Sprite2D> SDLTextureSprite2D::copy() const
 {
 	return Holder<Sprite2D>(new SDLTextureSprite2D(*this));

--- a/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.h
+++ b/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.h
@@ -84,6 +84,7 @@ class SDLTextureSprite2D : public SDLSurfaceSprite2D {
 	
 	void Invalidate() const noexcept override;
 public:
+	SDLTextureSprite2D(const SDLTextureSprite2D&) noexcept;
 	SDLTextureSprite2D(const Region&, void* pixels, const PixelFormat& fmt) noexcept;
 	SDLTextureSprite2D(const Region&, const PixelFormat& fmt) noexcept;
 	~SDLTextureSprite2D() noexcept;


### PR DESCRIPTION
The default copy ctor is bad for us.

See #1536

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
