### PR TITLE
appveyor: try not building the whole thing twice

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -86,7 +86,9 @@ before_build:
     $replace = "define VERSION_GEMRB `"$git_version`""
     (Get-Content $file) -replace $find, $replace | Set-Content $file
 build_script:
-- cmd: cmake --build . -j 2
+- ps: |-
+    pushd c:\projects\gemrb
+    cmake --build . -j 2 --config Release
 after_build:
 - ps: |-
     pushd c:\projects\gemrb

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,6 +29,12 @@ install:
       nuget install secure-file -ExcludeVersion
       choco -r install openssh
       secure-file\tools\secure-file -decrypt testing\id_travissfbot.av.enc -secret $env:SF_ACC
+
+      # chmod 400 ...
+      $path = ".\testing\id_travissfbot.av"
+      icacls.exe $path /reset
+      icacls.exe $path /GRANT:R "$($env:USERNAME):(R)"
+      icacls.exe $path /inheritance:r
     }
 
     vcpkg install zlib:x86-windows


### PR DESCRIPTION
It's clear from the log the install phase does a rebuild, taking another 9 minutes, instead of just copying the files.

EDIT: eh, it looks like SF doesn't like our ssh set up any more either.