### PR TITLE
Map: fix for crash in MarkVisited

### DIFF
--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -2054,7 +2054,7 @@ void Map::MarkVisited(const Actor *actor) const
 {
 	if (actor->InParty && core->HasFeature(GF_AREA_VISITED_VAR)) {
 		ieVariable key;
-		size_t len = key.SNPrintF("%s_visited", scriptName);
+		size_t len = key.SNPrintF("%s_visited", scriptName.CString());
 		if (len > sizeof(key)) {
 			Log(ERROR, "Map", "Area {} has a too long script name for generating _visited globals!", scriptName);
 		}


### PR DESCRIPTION
## Description
Happens only on `-O2` and above for me, not sure what unopt stuff ends up doing here instead:
```
74      ../sysdeps/x86_64/multiarch/strlen-avx2.S: No such file or directory.
(gdb) bt
#0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:74
#1  0x00007ffff717fe68 in __vfprintf_internal (s=s@entry=0x7fffffffce70, format=format@entry=0x5555558d49f8 %s_visited, ap=ap@entry=0x7fffffffcff0, mode_flags=mode_flags@entry=2) at vfprintf-internal.c:1647
#2  0x00007ffff719141a in __vsnprintf_internal (string=string@entry=0x7fffffffd100 , maxlen=<optimized out>, maxlen@entry=33, format=format@entry=0x5555558d49f8 %s_visited, args=args@entry=0x7fffffffcff0, mode_flags=mode_flags@entry=2) at vsnprintf.c:114
#3  0x00007ffff723c7a2 in ___vsnprintf_chk (s=s@entry=0x7fffffffd100 , maxlen=maxlen@entry=33, flag=flag@entry=1, slen=slen@entry=18446744073709551615, format=format@entry=0x5555558d49f8 %s_visited, ap=ap@entry=0x7fffffffcff0) at vsnprintf_chk.c:34
#4  0x000055555568afb4 in vsnprintf (__ap=0x7fffffffcff0, __fmt=<optimized out>, __n=33, __s=0x7fffffffd100 ) at /usr/include/x86_64-linux-gnu/bits/stdio2.h:85
#5  GemRB::FixedSizeString<32ul, &strncasecmp>::SNPrintF(char const*, ...) (this=this@entry=0x7fffffffd100, format=format@entry=0x5555558d49f8 %s_visited) at /mnt/shared/Sources/gemrb/gemrb/core/Strings/CString.h:148
#6  0x00005555556f86fc in GemRB::Map::MarkVisited(GemRB::Actor const*) const (actor=<optimized out>, this=0x5555576dd8a0) at /mnt/shared/Sources/gemrb/gemrb/core/Map.cpp:2057
#7  GemRB::Map::MarkVisited(GemRB::Actor const*) const (this=0x5555576dd8a0, actor=<optimized out>) at /mnt/shared/Sources/gemrb/gemrb/core/Map.cpp:2053
#8  0x00005555556f87c6 in GemRB::Map::InitActors() (this=this@entry=0x5555576dd8a0) at /mnt/shared/Sources/gemrb/gemrb/core/Map.cpp:2049
#9  0x000055555565420b in GemRB::Game::LoadMap(GemRB::FixedSizeString<8ul, &strncasecmp> const&, bool) (this=0x5555566c7d30, resRef=..., loadscreen=<optimized out>) at /mnt/shared/Sources/gemrb/gemrb/core/Game.cpp:862
#10 0x0000555555654bb8 in GemRB::Game::GetMap(GemRB::FixedSizeString<8ul, &strncasecmp> const&, bool) (this=this@entry=0x5555566c7d30, areaname=..., change=change@entry=true) at /mnt/shared/Sources/gemrb/gemrb/core/Game.cpp:683
#11 0x0000555555612907 in GemRB::GameControl::ChangeMap(GemRB::Actor const*, bool) (this=this@entry=0x5555568abc60, pc=0x555556ad02e0, forced=forced@entry=true) at /mnt/shared/Sources/gemrb/gemrb/core/GUI/GameControl.cpp:2494
#12 0x00005555556c4bc2 in GemRB::Interface::HandleFlags() (this=this@entry=0x555555aa8f40) at /mnt/shared/Sources/gemrb/gemrb/core/Interface.cpp:487
#13 0x00005555556c7a08 in GemRB::Interface::Main() (this=0x555555aa8f40) at /mnt/shared/Sources/gemrb/gemrb/core/Interface.cpp:632
#14 0x00005555555a13a5 in main(int, char**) (argc=<optimized out>, argv=0x7fffffffde08) at /mnt/shared/Sources/gemrb/gemrb/GemRB.cpp:73
```


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
