### PR TITLE
Add DAMAGE_INNOCENT_REP flag

### DIFF
--- a/demo/data/gemrb.ini
+++ b/demo/data/gemrb.ini
@@ -137,3 +137,4 @@ StealIsAttack = 1
 StrrefSaveGame = 0
 TeamMovement = 0
 UpperButtonText = 1
+DamageInnocentRep = 1

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -1767,7 +1767,8 @@ static const char* const game_flags[GF_COUNT + 1]={
 		"Happiness",          //80GF_HAPPINESS
 		"EfficientORTrigger", //81GF_EFFICIENT_OR
 		"LayeredWaterTiles",  //82GF_LAYERED_WATER_TILES
-		"ClearingActionOverride", // GF_CLEARING_ACTIONOVERRIDE
+		"ClearingActionOverride", //83GF_CLEARING_ACTIONOVERRIDE
+		"DamageInnocentRep",  //84GF_DAMAGE_INNOCENT_REP
 		NULL                  //for our own safety, this marks the end of the pole
 };
 

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -4256,10 +4256,12 @@ int Actor::Damage(int damage, int damagetype, Scriptable *hitter, int modtype, i
 	}
 
 	// also apply reputation damage if we hurt (but not killed) an innocent
-	if (Modified[IE_CLASS] == CLASS_INNOCENT && !core->InCutSceneMode()) {
-		if (act && act->GetStat(IE_EA) <= EA_CONTROLLABLE) {
-			core->GetGame()->SetReputation(core->GetGame()->Reputation + gamedata->GetReputationMod(1));
-		}
+	if (core->HasFeature(GF_DAMAGE_INNOCENT_REP) &&
+			Modified[IE_CLASS] == CLASS_INNOCENT &&
+			!core->InCutSceneMode() &&
+			act && act->GetStat(IE_EA) <= EA_CONTROLLABLE) {
+
+		core->GetGame()->SetReputation(core->GetGame()->Reputation + gamedata->GetReputationMod(1));
 	}
 
 	int chp = (signed) BaseStats[IE_HITPOINTS];

--- a/gemrb/docs/en/gemrb_ini.txt
+++ b/gemrb/docs/en/gemrb_ini.txt
@@ -598,3 +598,8 @@ This option is 1 for original PST.
 UpperButtonText = <bool>
 - - - - - - - - - - - - -
 Set to 1 if button labels should be converted to upper-case (e.g. BG2)
+
+DamageInnocentRep = <bool>
+- - - - - - - - - - - - -
+Set to 1 if damaging INNOCENT characters should result in a reputation hit.
+Killing INNOCENT characters is not affected by this flag.

--- a/gemrb/includes/globals.h
+++ b/gemrb/includes/globals.h
@@ -138,7 +138,8 @@ enum GameFeatureFlags : uint32_t {
 	GF_HAPPINESS,                   	// all except pst and iwd2
 	GF_EFFICIENT_OR,                	// does the OR trigger shortcircuit on success or not? Only in iwd2
 	GF_LAYERED_WATER_TILES,				// TileOverlay for water has an extra half transparent layer (all but BG1)
-	GF_CLEARING_ACTIONOVERRIDE, // bg2, not iwd2
+	GF_CLEARING_ACTIONOVERRIDE,         // bg2, not iwd2
+	GF_DAMAGE_INNOCENT_REP,             // not bg1
 
 	GF_COUNT // sentinal count
 };

--- a/gemrb/unhardcoded/bg1/gemrb.ini
+++ b/gemrb/unhardcoded/bg1/gemrb.ini
@@ -153,3 +153,4 @@ StrrefSaveGame = 0
 TeamMovement = 0
 UpperButtonText = 0
 ZeroTimerIsValid = 0
+DamageInnocentRep = 0

--- a/gemrb/unhardcoded/bg2/gemrb.ini
+++ b/gemrb/unhardcoded/bg2/gemrb.ini
@@ -154,3 +154,4 @@ StrrefSaveGame = 0
 TeamMovement = 0
 UpperButtonText = 1
 ZeroTimerIsValid = 0
+DamageInnocentRep = 1

--- a/gemrb/unhardcoded/iwd/gemrb.ini
+++ b/gemrb/unhardcoded/iwd/gemrb.ini
@@ -154,3 +154,4 @@ StrrefSaveGame = 0
 TeamMovement = 0
 UpperButtonText = 0
 ZeroTimerIsValid = 1
+DamageInnocentRep = 1

--- a/gemrb/unhardcoded/iwd2/gemrb.ini
+++ b/gemrb/unhardcoded/iwd2/gemrb.ini
@@ -155,3 +155,4 @@ StrrefSaveGame = 1
 TeamMovement = 0
 UpperButtonText = 0
 ZeroTimerIsValid = 1
+DamageInnocentRep = 1

--- a/gemrb/unhardcoded/pst/gemrb.ini
+++ b/gemrb/unhardcoded/pst/gemrb.ini
@@ -152,3 +152,4 @@ StrrefSaveGame = 0
 TeamMovement = 1
 UpperButtonText = 0
 ZeroTimerIsValid = 0
+DamageInnocentRep = 1


### PR DESCRIPTION
Controls whether damaging innocents affects the player reputation.
Off for BG1 only.

Fixes #1603
