### PR TITLE
Replace some uses of size_t

### DIFF
--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -550,7 +550,7 @@ bool Interface::ReadDamageTypeTable() {
 
 	DamageInfoStruct di;
 	for (TableMgr::index_t i = 0; i < tm->GetRowCount(); i++) {
-		di.strref = DisplayMessage::GetStringReference(tm->QueryFieldUnsigned<size_t>(i, 0));
+		di.strref = DisplayMessage::GetStringReference(tm->QueryFieldUnsigned<uint16_t>(i, 0));
 		di.resist_stat = TranslateStat(tm->QueryField(i, 1).c_str());
 		di.value = strtounsigned<unsigned int>(tm->QueryField(i, 2).c_str(), nullptr, 16);
 		di.iwd_mod_type = tm->QueryFieldSigned<int>(i, 3);
@@ -2962,7 +2962,7 @@ bool Interface::InitItemTypes()
 
 	//itemtype data stores (armor failure and critical damage multipliers), critical range
 	itemtypedata.reserve(ItemTypes);
-	for (size_t i = 0; i < ItemTypes; i++) {
+	for (TableMgr::index_t i = 0; i < ItemTypes; i++) {
 		itemtypedata.emplace_back(4);
 		//default values in case itemdata is missing (it is needed only for iwd2)
 		if (slotmatrix[i] & SLOT_WEAPON) {
@@ -2977,8 +2977,8 @@ bool Interface::InitItemTypes()
 		TableMgr::index_t armcount = af->GetRowCount();
 		TableMgr::index_t colcount = af->GetColumnCount();
 		for (TableMgr::index_t i = 0; i < armcount; i++) {
-			size_t itemtype = af->QueryFieldUnsigned<size_t>(i, 0);
-			if (itemtype<ItemTypes) {
+			uint16_t itemtype = af->QueryFieldUnsigned<uint16_t>(i, 0);
+			if (itemtype < ItemTypes) {
 				// we don't need the itemtype column, since it is equal to the position
 				for (TableMgr::index_t j = 0; j < colcount - 1; ++j) {
 					itemtypedata[itemtype][j] = af->QueryFieldSigned<int>(i, j+1);
@@ -3116,7 +3116,7 @@ const ResRef& Interface::QuerySlotResRef(unsigned int idx) const
 
 int Interface::GetArmorFailure(unsigned int itemtype) const
 {
-	if (itemtype>=(unsigned int) ItemTypes) {
+	if (itemtype >= ItemTypes) {
 		return 0;
 	}
 	if (slotmatrix[itemtype]&SLOT_ARMOUR) return itemtypedata[itemtype][IDT_FAILURE];
@@ -3125,7 +3125,7 @@ int Interface::GetArmorFailure(unsigned int itemtype) const
 
 int Interface::GetShieldFailure(unsigned int itemtype) const
 {
-	if (itemtype>=(unsigned int) ItemTypes) {
+	if (itemtype >= ItemTypes) {
 		return 0;
 	}
 	if (slotmatrix[itemtype]&SLOT_SHIELD) return itemtypedata[itemtype][IDT_FAILURE];
@@ -3134,7 +3134,7 @@ int Interface::GetShieldFailure(unsigned int itemtype) const
 
 int Interface::GetArmorPenalty(unsigned int itemtype) const
 {
-	if (itemtype>=(unsigned int) ItemTypes) {
+	if (itemtype >= ItemTypes) {
 		return 0;
 	}
 	if (slotmatrix[itemtype]&SLOT_ARMOUR) return itemtypedata[itemtype][IDT_SKILLPENALTY];
@@ -3143,7 +3143,7 @@ int Interface::GetArmorPenalty(unsigned int itemtype) const
 
 int Interface::GetShieldPenalty(unsigned int itemtype) const
 {
-	if (itemtype>=(unsigned int) ItemTypes) {
+	if (itemtype >= ItemTypes) {
 		return 0;
 	}
 	if (slotmatrix[itemtype]&SLOT_SHIELD) return itemtypedata[itemtype][IDT_SKILLPENALTY];
@@ -3152,7 +3152,7 @@ int Interface::GetShieldPenalty(unsigned int itemtype) const
 
 int Interface::GetCriticalMultiplier(unsigned int itemtype) const
 {
-	if (itemtype>=(unsigned int) ItemTypes) {
+	if (itemtype >= ItemTypes) {
 		return 2;
 	}
 	if (slotmatrix[itemtype]&SLOT_WEAPON) return itemtypedata[itemtype][IDT_CRITMULTI];
@@ -3161,7 +3161,7 @@ int Interface::GetCriticalMultiplier(unsigned int itemtype) const
 
 int Interface::GetCriticalRange(unsigned int itemtype) const
 {
-	if (itemtype>=(unsigned int) ItemTypes) {
+	if (itemtype >= ItemTypes) {
 		return 20;
 	}
 	if (slotmatrix[itemtype]&SLOT_WEAPON) return itemtypedata[itemtype][IDT_CRITRANGE];
@@ -3192,7 +3192,7 @@ int Interface::CanUseItemType(int slottype, const Item *item, const Actor *actor
 		}
 	}
 
-	if ( (unsigned int) item->ItemType>=(unsigned int) ItemTypes) {
+	if (item->ItemType >= ItemTypes) {
 		//invalid itemtype
 		if (feedback) displaymsg->DisplayConstantString(STR_WRONGITEMTYPE, DMC_WHITE);
 		return 0;

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -404,7 +404,7 @@ private:
 	ieDword* slotmatrix = nullptr; // itemtype vs slottype
 	std::vector<std::vector<int> > itemtypedata; //armor failure, critical multiplier, critical range
 	std::vector<SlotType> slotTypes;
-	size_t ItemTypes = 0;
+	TableMgr::index_t ItemTypes = 0;
 
 	// Currently dragged item or NULL
 	std::unique_ptr<ItemDragOp> DraggedItem;

--- a/gemrb/core/TableMgr.h
+++ b/gemrb/core/TableMgr.h
@@ -45,7 +45,7 @@ class DataStream;
 class GEM_EXPORT TableMgr : public Plugin {
 public:
 	static constexpr TypeID ID = { "Table" };
-	using index_t = size_t;
+	using index_t = uint32_t;
 	static constexpr index_t npos = -1;
 	using key_t = StringView;
 

--- a/gemrb/plugins/2DAImporter/2DAImporter.cpp
+++ b/gemrb/plugins/2DAImporter/2DAImporter.cpp
@@ -102,7 +102,9 @@ bool p2DAImporter::Open(DataStream* str)
 			row++;
 		}
 	}
+
 	delete str;
+	assert(rows.size() < std::numeric_limits<index_t>::max());
 	return true;
 }
 


### PR DESCRIPTION
## Description
See #1616, there were two errors and I noticed a bunch of stuff around it that could be type-wired and cleaned with `uint32_t` at the end.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
