### PR TITLE
CString: Substring assertion fix

### DIFF
--- a/gemrb/core/Strings/CString.h
+++ b/gemrb/core/Strings/CString.h
@@ -224,7 +224,7 @@ public:
 
 	template<size_type N> FixedSizeString<N, CMP> SubStr(size_type pos) {
 		static_assert(N <= LEN, "Substring must not exceed the original length.");
-		assert(pos + LEN <= N);
+		assert(static_cast<size_type>(pos + N) <= LEN);
 		return FixedSizeString<N, CMP>{CString() + pos};
 	}
 };


### PR DESCRIPTION
## Description

I was looking at the problem below (happens on some enemy encounters in IWD2), and that assertion made no sense in what it was supposed to do: prevent overrunning the original string's memory.

That `static_cast` prevents a warning, as GCC otherwise complains about comparing different signs which I do not understand by looking at all the unsigned the types, so ...

```
(gdb) bt
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140737316622912) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=140737316622912) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140737316622912, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007ffff70ae476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007ffff70947f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007ffff709471b in __assert_fail_base (fmt=0x7ffff7249150 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0x555555997186 "pos + LEN <= N", file=0x555555992390 "/mnt/shared/Sources/gemrb/gemrb/core/Strings/CString.h", line=227, function=<optimized out>)
    at ./assert/assert.c:92
#6  0x00007ffff70a5e96 in __GI___assert_fail
    (assertion=0x555555997186 "pos + LEN <= N", file=0x555555992390 "/mnt/shared/Sources/gemrb/gemrb/core/Strings/CString.h", line=227, function=0x555555997060 "GemRB::FixedSizeString<N, CMP> GemRB::FixedSizeString<LEN, CMP>::SubStr(GemRB::FixedSizeString<LEN, CMP>::size_type) [with unsigned char N = 4; long unsigned int LEN = 64; int (* CMP)(const char*, con"...) at ./assert/assert.c:101
#7  0x00005555556dd4de in GemRB::FixedSizeString<64ul, &strncasecmp>::SubStr<(unsigned char)4>(unsigned char) (this=0x55555eab5d34, pos=4 '\004') at /mnt/shared/Sources/gemrb/gemrb/core/Strings/CString.h:227
#8  0x00005555556d51a5 in GemRB::GameScript::MarkSpellAndObject(GemRB::Scriptable*, GemRB::Action*) (Sender=0x55555e9e26b0, parameters=0x55555eab5cf0) at /mnt/shared/Sources/gemrb/gemrb/core/GameScript/Actions.cpp:5363
#9  0x00005555556f3758 in GemRB::GameScript::ExecuteAction(GemRB::Scriptable*, GemRB::Action*) (Sender=0x55555e9e26b0, aC=0x55555eab5cf0) at /mnt/shared/Sources/gemrb/gemrb/core/GameScript/GameScript.cpp:2465
#10 0x0000555555839dce in GemRB::Scriptable::AddAction(GemRB::Action*) (this=0x55555e9e26b0, aC=0x55555eab5cf0) at /mnt/shared/Sources/gemrb/gemrb/core/Scriptable/Scriptable.cpp:420
#11 0x00005555556f3170 in GemRB::Response::Execute(GemRB::Scriptable*) (this=0x55555eab5cb0, Sender=0x55555e9e26b0) at /mnt/shared/Sources/gemrb/gemrb/core/GameScript/GameScript.cpp:2374
#12 0x00005555556f3079 in GemRB::ResponseSet::Execute(GemRB::Scriptable*) (this=0x55555eab5c80, Sender=0x55555e9e26b0) at /mnt/shared/Sources/gemrb/gemrb/core/GameScript/GameScript.cpp:2355
#13 0x00005555556f20a8 in GemRB::GameScript::Update(bool*, bool*) (this=0x55555eb76380, continuing=0x7fffffffd7ed, done=0x7fffffffd7ee) at /mnt/shared/Sources/gemrb/gemrb/core/GameScript/GameScript.cpp:2069
#14 0x0000555555839b4a in GemRB::Scriptable::ExecuteScript(int) (this=0x55555e9e26b0, scriptCount=8) at /mnt/shared/Sources/gemrb/gemrb/core/Scriptable/Scriptable.cpp:371
#15 0x0000555555839878 in GemRB::Scriptable::TickScripting() (this=0x55555e9e26b0) at /mnt/shared/Sources/gemrb/gemrb/core/Scriptable/Scriptable.cpp:316
#16 0x0000555555839623 in GemRB::Scriptable::Update() (this=0x55555e9e26b0) at /mnt/shared/Sources/gemrb/gemrb/core/Scriptable/Scriptable.cpp:257
#17 0x0000555555770e01 in GemRB::Map::UpdateScripts() (this=0x55555e957110) at /mnt/shared/Sources/gemrb/gemrb/core/Map.cpp:731
#18 0x0000555555692eb1 in GemRB::Game::UpdateScripts() (this=0x55555806cee0) at /mnt/shared/Sources/gemrb/gemrb/core/Game.cpp:1477
#19 0x000055555572c403 in GemRB::Interface::GameLoop() (this=0x555555c42360) at /mnt/shared/Sources/gemrb/gemrb/core/Interface.cpp:2183
#20 0x00005555557236d8 in GemRB::Interface::Main() (this=0x555555c42360) at /mnt/shared/Sources/gemrb/gemrb/core/Interface.cpp:643
#21 0x0000555555590cbd in main(int, char**) (argc=1, argv=0x7fffffffdd08) at /mnt/shared/Sources/gemrb/gemrb/GemRB.cpp:66
(gdb) f 8
#8  0x00005555556d51a5 in GemRB::GameScript::MarkSpellAndObject (Sender=0x55555e9e26b0, parameters=0x55555eab5cf0) at /mnt/shared/Sources/gemrb/gemrb/core/GameScript/Actions.cpp:5363
5363                    auto spl = parameters->string0Parameter.SubStr<4>(pos * 4);
(gdb) p parameters->string0Parameter
$1 = {str = "24202104", '\000' <repeats 56 times>}
(gdb) p pos
$2 = 1
```

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
