### PR TITLE
Fix calls to Scriptable::As through null pointers.

### DIFF
--- a/gemrb/core/Core.cpp
+++ b/gemrb/core/Core.cpp
@@ -272,7 +272,7 @@ bool WithinPersonalRange(const Scriptable *actor, const Point &dest, int distanc
 int EARelation(const Scriptable* Owner, const Actor* target)
 {
 	ieDword eao = EA_ENEMY;
-	const Actor* actor = Owner->As<const Actor>();
+	const Actor* actor = Scriptable::As<const Actor>(Owner);
 	if (actor) {
 		eao = actor->GetStat(IE_EA);
 	}

--- a/gemrb/core/DialogHandler.cpp
+++ b/gemrb/core/DialogHandler.cpp
@@ -196,7 +196,7 @@ void DialogHandler::EndDialog(bool try_to_break)
 	}
 
 	Actor *tmp = GetSpeaker();
-	Actor *target = GetTarget()->As<Actor>();
+	Actor *target = Scriptable::As<Actor>(GetTarget());
 	speakerID = 0;
 	targetID = 0;
 	originalTargetID = 0;

--- a/gemrb/core/EffectQueue.cpp
+++ b/gemrb/core/EffectQueue.cpp
@@ -480,7 +480,7 @@ int EffectQueue::AddEffect(Effect* fx, Scriptable* self, Actor* pretarget, const
 	const Map *map;
 	int flg;
 	ieDword spec = 0;
-	Actor *st = self->As<Actor>();
+	Actor *st = Scriptable::As<Actor>(self);
 	// HACK: 00p2229.baf in ar1006 does this silly thing, crashing later
 	if (!st && self && (self->Type==ST_CONTAINER) && (fx->Target == FX_TARGET_SELF)) {
 		fx->Target = FX_TARGET_PRESET;
@@ -1024,7 +1024,7 @@ static int check_resistance(Actor* actor, Effect* fx)
 	if (!actor) return -1;
 
 	const Scriptable *cob = GetCasterObject();
-	const Actor* caster = cob->As<const Actor>();
+	const Actor* caster = Scriptable::As<const Actor>(cob);
 	
 	const auto& globals = Globals::Get();
 
@@ -1146,7 +1146,7 @@ int EffectQueue::ApplyEffect(Actor* target, Effect* fx, ieDword first_apply, ieD
 		if (target) fx->SetPosition(target->Pos);
 
 		//gemrb specific, stat based chance
-		const Actor* OwnerActor = Owner->As<Actor>();
+		const Actor* OwnerActor = Scriptable::As<Actor>(Owner);
 		if (fx->ProbabilityRangeMin == 100 && OwnerActor) {
 			fx->ProbabilityRangeMin = 0;
 			fx->ProbabilityRangeMax = static_cast<ieWord>(OwnerActor->GetSafeStat(fx->ProbabilityRangeMax));
@@ -1356,7 +1356,7 @@ void EffectQueue::RemoveAllEffects(const ResRef &removed)
 		fx.TimingMode = FX_DURATION_JUST_EXPIRED;
 	}
 
-	Actor* OwnerActor = Owner->As<Actor>();
+	Actor* OwnerActor = Scriptable::As<Actor>(Owner);
 	if (!OwnerActor) return;
 
 	// we didn't catch effects that don't persist — they still need to be undone
@@ -2306,7 +2306,7 @@ bool EffectQueue::CheckIWDTargeting(Scriptable* Owner, Actor* target, ieDword va
 		case STI_AREATYPE:
 			return DiffCore((ieDword) target->GetCurrentArea()->AreaType, val, rel);
 		case STI_MORAL_ALIGNMENT:
-			OwnerActor = Owner->As<Actor>();
+			OwnerActor = Scriptable::As<Actor>(Owner);
 			if (OwnerActor) {
 				return DiffCore(OwnerActor->GetStat(IE_ALIGNMENT) & AL_GE_MASK, STAT_GET(IE_ALIGNMENT) & AL_GE_MASK, rel);
 			} else {

--- a/gemrb/core/Spell.cpp
+++ b/gemrb/core/Spell.cpp
@@ -150,7 +150,7 @@ EffectQueue Spell::GetEffectBlock(Scriptable *self, const Point &pos, int block_
 	std::vector<Effect>* features;
 	size_t count;
 	const auto& tables = SpellTables::Get();
-	Actor *caster = self->As<Actor>();
+	Actor *caster = Scriptable::As<Actor>(self);
 
 	//iwd2 has this hack
 	if (block_index>=0) {
@@ -265,7 +265,7 @@ unsigned int Spell::GetCastingDistance(Scriptable *Sender) const
 {
 	int level = 0;
 	unsigned int limit = VOODOO_VISUAL_RANGE;
-	Actor* actor = Sender->As<Actor>();
+	Actor* actor = Scriptable::As<Actor>(Sender);
 	if (actor) {
 		level = actor->GetCasterLevel(SpellType);
 		limit = actor->GetStat(IE_VISUALRANGE);

--- a/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
+++ b/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
@@ -1170,7 +1170,7 @@ int fx_set_charmed_state (Scriptable* Owner, Actor* target, Effect* fx)
 
 		Scriptable *caster = GetCasterObject();
 		if (!caster) caster = Owner;
-		const Actor* casterActor = caster->As<const Actor>();
+		const Actor* casterActor = Scriptable::As<const Actor>(caster);
 		if (casterActor) {
 			casterenemy = casterActor->GetStat(IE_EA) > EA_GOODCUTOFF; //or evilcutoff?
 		} else {
@@ -3488,7 +3488,7 @@ int fx_turn_undead (Scriptable* Owner, Actor* target, Effect* fx)
 	if (fx->Parameter1) {
 		target->Turn(Owner, fx->Parameter1);
 	} else {
-		const Actor* actor = Owner->As<const Actor>();
+		const Actor* actor = Scriptable::As<const Actor>(Owner);
 		if (!actor) {
 			return FX_NOT_APPLIED;
 		}
@@ -6735,7 +6735,7 @@ int fx_set_area_effect (Scriptable* Owner, Actor* target, Effect* fx)
 		return FX_NOT_APPLIED;
 	}
 
-	const Actor* caster = Owner->As<const Actor>();
+	const Actor* caster = Scriptable::As<const Actor>(Owner);
 	if (caster) {
 		skill = caster->GetStat(IE_SETTRAPS);
 		roll = target->LuckyRoll(1,100,0,LR_NEGATIVE);
@@ -6857,7 +6857,7 @@ int fx_create_spell_sequencer(Scriptable* /*Owner*/, Actor* target, Effect* fx)
 int fx_activate_spell_sequencer(Scriptable* Owner, Actor* target, Effect* fx)
 {
 	// print("fx_activate_spell_sequencer(%2d): Resource: %s", fx->Opcode, fx->Resource);
-	Actor* actor = Owner->As<Actor>();
+	Actor* actor = Scriptable::As<Actor>(Owner);
 	if (!actor) {
 		return FX_NOT_APPLIED;
 	}


### PR DESCRIPTION
Calling a non-static member function on a null pointer is undefined
behavior. Added non-null checks at affected call sites.

## Description
There are multiple places in the code where Scriptable::As is called on a pointer that can be null. This can cause crashes on some platforms, which I have experienced (I can add a separate bug report with details if it's necessary).

From this discussion (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99074) it seems that versions of GCC from 8 up to 11 are affected.

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [X] I have tested the proposed changes
- [X] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
