### PR TITLE
Fixes for Windows

### DIFF
--- a/gemrb/core/ScriptEngine.h
+++ b/gemrb/core/ScriptEngine.h
@@ -54,7 +54,7 @@ public:
 };
 
 template <class T>
-class GEM_EXPORT ScriptingRef : public ScriptingRefBase {
+class ScriptingRef : public ScriptingRefBase {
 private:
 	T* ref;
 public:

--- a/gemrb/core/System/VFS.h
+++ b/gemrb/core/System/VFS.h
@@ -45,7 +45,8 @@ namespace GemRB {
 
 #ifdef WIN32
 
-#define ResolveFilePath(p)
+// prevents warnings of unused `p`
+#define ResolveFilePath(p) (void)p
 
 #else  // ! WIN32
 


### PR DESCRIPTION
## Description
Two things addressed:

* The initial problem of #1636 
* Errors for unused variables on uses of `ResolveFilePath` on Windows & GCC.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
