### PR TITLE
Sdl ambient

### DIFF
--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -2313,6 +2313,12 @@ int Interface::PlayMovie(const ResRef& movieRef)
 		}
 	}
 
+	//shutting down music and ambients before movie
+	if (music)
+		music->HardEnd();
+	AmbientMgr *ambim = AudioDriver->GetAmbientMgr();
+	if (ambim) ambim->Deactivate();
+
 	ResourceHolder<MoviePlayer> mp = GetResourceHolder<MoviePlayer>(actualMovieRef);
 	if (!mp) {
 		return -1;
@@ -2381,12 +2387,6 @@ int Interface::PlayMovie(const ResRef& movieRef)
 			mp->SetSubtitles(new IESubtitles(font, sttable));
 		}
 	}
-
-	//shutting down music and ambients before movie
-	if (music)
-		music->HardEnd();
-	AmbientMgr *ambim = AudioDriver->GetAmbientMgr();
-	if (ambim) ambim->Deactivate();
 
 	Holder<SoundHandle> sound_override;
 	if (!sound_resref.empty()) {

--- a/gemrb/plugins/SDLAudio/SDLAudio.cpp
+++ b/gemrb/plugins/SDLAudio/SDLAudio.cpp
@@ -506,7 +506,7 @@ int SDLAudio::SetupNewStream(int x, int y, int z,
 
 tick_t SDLAudio::QueueAmbient(int stream, const ResRef& sound)
 {
-	if (stream == 0 || stream > AMBIENT_CHANNELS + 1) {
+	if (stream <= 0 || stream > AMBIENT_CHANNELS) {
 		return -1;
 	}
 

--- a/gemrb/plugins/SDLAudio/SDLAudio.h
+++ b/gemrb/plugins/SDLAudio/SDLAudio.h
@@ -29,8 +29,11 @@
 
 #include <SDL_mixer.h>
 
+#define AMBIENT_CHANNELS 8
 #define MIXER_CHANNELS 16
 #define BUFFER_CACHE_SIZE 100
+#define AUDIO_DISTANCE_ROLLOFF_MOD 1.3
+#define AMBIENT_DISTANCE_ROLLOFF_MOD 5
 
 namespace GemRB {
 
@@ -54,6 +57,13 @@ struct BufferedData {
 	unsigned int size;
 };
 
+struct SDLAudioStream {
+	SDLAudioStream() : free(true), point(false), streamPos(0, 0) { }
+	bool free;
+	bool point;
+	Point streamPos;
+};
+
 struct CacheEntry {
 	Mix_Chunk *chunk;
 	unsigned int Length;
@@ -69,13 +79,13 @@ public:
 	int CreateStream(std::shared_ptr<SoundMgr>) override;
 	bool Play() override;
 	bool Stop() override;
-	bool Pause() override { return true; } /*not implemented*/
-	bool Resume() override { return true; } /*not implemented*/
+	bool Pause() override;
+	bool Resume() override;
 	bool CanPlay() override;
 	void ResetMusics() override;
 	void UpdateListenerPos(const Point&) override;
 	Point GetListenerPos() override;
-	void UpdateVolume(unsigned int) override {}
+	void UpdateVolume(unsigned int flags) override;
 
 	int SetupNewStream(int x, int y, int z, ieWord gain, bool point, int ambientRange) override;
 	tick_t QueueAmbient(int stream, const ResRef& sound) override;
@@ -108,6 +118,7 @@ private:
 
 	std::recursive_mutex MusicMutex;
 	LRUCache buffercache;
+	SDLAudioStream ambientStreams[AMBIENT_CHANNELS];
 };
 
 }


### PR DESCRIPTION
## Description
I had a working ambient sounds support for SDLAudio plugin for quite some time, so I thought that I might as well do a PR with it.
Also had to move music stopping code a bit to make sure that music is stopped after movie sound buffer is queued (movie sound stops otherwise with SDLAudio).


## Checklist

- [*] Commit messages are descriptive and explain the rationale for changes
- [*] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [*] I have tested the proposed changes
- [*] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)

