### PR TITLE
Formations ctor crash 

### DIFF
--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -70,7 +70,7 @@ class Formations {
 			return;
 		}
 		auto formationcount = tab->GetRowCount();
-		formations.reserve(formationcount);
+		formations.resize(formationcount);
 		for (unsigned int i = 0; i < formationcount; i++) {
 			for (uint8_t j = 0; j < FORMATIONSIZE; j++) {
 				Point p(tab->QueryFieldSigned<int>(i, j*2), tab->QueryFieldSigned<int>(i, j*2+1));


### PR DESCRIPTION
Would otherwise crash on debug build, at least when running IWD2.

## Description
Was doing reserve instead of resize.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
