### PR TITLE
BIFImporter: wrong delete operator

### DIFF
--- a/gemrb/plugins/BIFImporter/BIFImporter.cpp
+++ b/gemrb/plugins/BIFImporter/BIFImporter.cpp
@@ -189,8 +189,8 @@ int BIFImporter::ReadBIF()
 	fentries = new FileEntry[fentcount];
 	tentries = new TileEntry[tentcount];
 	if (!fentries || !tentries) {
-		delete fentries;
-		delete tentries;
+		delete[] fentries;
+		delete[] tentries;
 		return GEM_ERROR;
 	}
 


### PR DESCRIPTION
## Description
There is a mismatching `delete`-operator in use. Interestingly, GCC started to complain about this only today.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
