### PR TITLE
1663 Keys in bags are not visible to scripts

### DIFF
--- a/gemrb/core/GameScript/GSUtils.cpp
+++ b/gemrb/core/GameScript/GSUtils.cpp
@@ -411,12 +411,7 @@ bool RemoveItemOfStore(const ResRef& storename, const ResRef& itemname)
 		Log(ERROR, "GameScript", "Store cannot be opened!");
 		return false;
 	}
-
-	//RemoveItem doesn't use trigger, and hopefully this will always run on bags (with no triggers)
-	unsigned int idx = store->FindItem(itemname, false);
-	if (idx == (unsigned int) -1) return false;
-	STOItem *si = store->GetItem(idx, false);
-	store->RemoveItem(si);
+	store->RemoveItemByName(itemname);
 	//store changed, save it
 	gamedata->SaveStore(store);
 	return true;

--- a/gemrb/core/GameScript/GSUtils.cpp
+++ b/gemrb/core/GameScript/GSUtils.cpp
@@ -404,7 +404,7 @@ bool HasItemCore(const Inventory *inventory, const ResRef& itemname, ieDword fla
 	return false;
 }
 
-bool RemoveItemOfStore(const ResRef& storename, const ResRef& itemname)
+bool RemoveStoreItem(const ResRef& storename, const ResRef& itemname)
 {
 	Store* store = gamedata->GetStore(storename);
 	if (!store) {

--- a/gemrb/core/GameScript/GSUtils.cpp
+++ b/gemrb/core/GameScript/GSUtils.cpp
@@ -404,6 +404,24 @@ bool HasItemCore(const Inventory *inventory, const ResRef& itemname, ieDword fla
 	return false;
 }
 
+bool RemoveItemOfStore(const ResRef& storename, const ResRef& itemname)
+{
+	Store* store = gamedata->GetStore(storename);
+	if (!store) {
+		Log(ERROR, "GameScript", "Store cannot be opened!");
+		return false;
+	}
+
+	//RemoveItem doesn't use trigger, and hopefully this will always run on bags (with no triggers)
+	unsigned int idx = store->FindItem(itemname, false);
+	if (idx == (unsigned int) -1) return false;
+	STOItem *si = store->GetItem(idx, false);
+	store->RemoveItem(si);
+	//store changed, save it
+	gamedata->SaveStore(store);
+	return true;
+}
+
 //finds and takes an item from a container in the given inventory
 static bool GetItemContainer(CREItem &itemslot2, const Inventory *inventory, const ResRef& itemname, int count)
 {

--- a/gemrb/core/GameScript/GSUtils.h
+++ b/gemrb/core/GameScript/GSUtils.h
@@ -69,6 +69,7 @@ GEM_EXPORT int GetReaction(const Actor *target, const Scriptable *Sender);
 GEM_EXPORT int GetHappiness(const Scriptable *Sender, int reputation);
 int GetHPPercent(const Scriptable *Sender);
 bool StoreHasItemCore(const ResRef& storename, const ResRef& itemname);
+bool RemoveItemOfStore(const ResRef& storename, const ResRef& itemname);
 bool HasItemCore(const Inventory *inventory, const ResRef& itemname, ieDword flags);
 void ClickCore(Scriptable *Sender, const MouseEvent& me, int speed);
 void PlaySequenceCore(Scriptable *Sender, const Action *parameters, Animation::index_t value);

--- a/gemrb/core/GameScript/GSUtils.h
+++ b/gemrb/core/GameScript/GSUtils.h
@@ -69,7 +69,7 @@ GEM_EXPORT int GetReaction(const Actor *target, const Scriptable *Sender);
 GEM_EXPORT int GetHappiness(const Scriptable *Sender, int reputation);
 int GetHPPercent(const Scriptable *Sender);
 bool StoreHasItemCore(const ResRef& storename, const ResRef& itemname);
-bool RemoveItemOfStore(const ResRef& storename, const ResRef& itemname);
+bool RemoveStoreItem(const ResRef& storename, const ResRef& itemname);
 bool HasItemCore(const Inventory *inventory, const ResRef& itemname, ieDword flags);
 void ClickCore(Scriptable *Sender, const MouseEvent& me, int speed);
 void PlaySequenceCore(Scriptable *Sender, const Action *parameters, Animation::index_t value);

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -1820,14 +1820,13 @@ bool Highlightable::TryUnlock(Actor *actor, bool removekey) const {
 		for (int idx = 0; idx < game->GetPartySize(false); idx++) {
 			Actor *pc = game->FindPC(idx + 1);
 			if (!pc) continue;
-
-			if (pc->inventory.HasItem(KeyResRef,0)) {
+			if (HasItemCore(&pc->inventory, KeyResRef, 0)) {
 				haskey = pc;
 				break;
 			}
 		}
 	// actor is not in party, check only actor
-	} else if (actor->inventory.HasItem(KeyResRef, 0)) {
+	} else if (HasItemCore(&actor->inventory, KeyResRef, 0)) {
 		haskey = actor;
 	}
 
@@ -1837,7 +1836,24 @@ bool Highlightable::TryUnlock(Actor *actor, bool removekey) const {
 
 	if (removekey) {
 		CREItem *item = NULL;
-		haskey->inventory.RemoveItem(KeyResRef,0,&item);
+		int result = haskey->inventory.RemoveItem(KeyResRef,0,&item);
+		if (result == -1) {
+			int i= haskey->inventory.GetSlotCount();
+			while (i--) {
+				//maybe we could speed this up if we mark bag items with a flags bit
+				const CREItem *itemslot = haskey->inventory.GetSlotItem(i);
+				if (!itemslot)
+					continue;
+				const Item *itemStore = gamedata->GetItem(itemslot->ItemResRef);
+				if (!itemStore)
+					continue;
+				if (core->CanUseItemType(SLOT_BAG, itemStore)) {
+					//the store is the same as the item's name
+					RemoveItemOfStore(itemslot->ItemResRef, KeyResRef);
+				}
+				gamedata->FreeItem(itemStore, itemslot->ItemResRef);
+			}
+		}
 		//the item should always be existing!!!
 		delete item;
 	}

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -1849,7 +1849,7 @@ bool Highlightable::TryUnlock(Actor *actor, bool removekey) const {
 					continue;
 				if (core->CanUseItemType(SLOT_BAG, itemStore)) {
 					//the store is the same as the item's name
-					RemoveItemOfStore(itemslot->ItemResRef, KeyResRef);
+					RemoveStoreItem(itemslot->ItemResRef, KeyResRef);
 				}
 				gamedata->FreeItem(itemStore, itemslot->ItemResRef);
 			}

--- a/gemrb/core/Store.cpp
+++ b/gemrb/core/Store.cpp
@@ -339,12 +339,12 @@ void Store::RemoveItem(const STOItem *itm)
 	}
 }
 
-void Store::RemoveItemByName(const ResRef &itemname)
+void Store::RemoveItemByName(const ResRef &itemName)
 {
-	unsigned int idx = this->FindItem(itemname, false);
+	unsigned int idx = FindItem(itemName, false);
 	if (idx == (unsigned int) -1) return;
-	STOItem *si = this->GetItem(idx, false);
-	this->RemoveItem(si);
+	const STOItem *si = GetItem(idx, false);
+	RemoveItem(si);
 }
 
 ieDword Store::GetOwnerID() const

--- a/gemrb/core/Store.cpp
+++ b/gemrb/core/Store.cpp
@@ -339,6 +339,14 @@ void Store::RemoveItem(const STOItem *itm)
 	}
 }
 
+void Store::RemoveItemByName(const ResRef &itemname)
+{
+	unsigned int idx = this->FindItem(itemname, false);
+	if (idx == (unsigned int) -1) return;
+	STOItem *si = this->GetItem(idx, false);
+	this->RemoveItem(si);
+}
+
 ieDword Store::GetOwnerID() const
 {
 	return StoreOwnerID;

--- a/gemrb/core/Store.h
+++ b/gemrb/core/Store.h
@@ -181,7 +181,7 @@ public: //queries
 	/** Adds a new item to the store (selling) */
 	void AddItem(CREItem* item);
 	void RemoveItem(const STOItem *itm);
-	void RemoveItemByName(const ResRef &itemname);
+	void RemoveItemByName(const ResRef &itemName);
 	/** Returns index of item */
 	unsigned int FindItem(const ResRef &item, bool usetrigger) const;
 	const char *GetOwner() const;

--- a/gemrb/core/Store.h
+++ b/gemrb/core/Store.h
@@ -181,6 +181,7 @@ public: //queries
 	/** Adds a new item to the store (selling) */
 	void AddItem(CREItem* item);
 	void RemoveItem(const STOItem *itm);
+	void RemoveItemByName(const ResRef &itemname);
 	/** Returns index of item */
 	unsigned int FindItem(const ResRef &item, bool usetrigger) const;
 	const char *GetOwner() const;


### PR DESCRIPTION
## Description
This is for fixing this bug #1663

Change logic in Highlightable::TryUnlock to search on the Bags also.
The remove logic was also changed so if not removed from the inventory then it will search in all the bags.

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [X] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
