### PR TITLE
Pausing on accessing the menu

### DIFF
--- a/gemrb/GUIScripts/GUIMG.py
+++ b/gemrb/GUIScripts/GUIMG.py
@@ -210,11 +210,11 @@ def MageSelectionChanged (oldwin):
 	else:
 		OpenMageWindow (ToggleSpellWindow.Args)
 
-ToggleMageWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIMG", GUICommonWindows.ToggleWindow, InitMageWindow, MageSelectionChanged)
-OpenMageWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIMG", GUICommonWindows.OpenWindowOnce, InitMageWindow, MageSelectionChanged)
+ToggleMageWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIMG", GUICommonWindows.ToggleWindow, InitMageWindow, MageSelectionChanged, GUICommonWindows.DefaultWinPos, True)
+OpenMageWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIMG", GUICommonWindows.OpenWindowOnce, InitMageWindow, MageSelectionChanged, GUICommonWindows.DefaultWinPos, True)
 
-ToggleSorcererWindow = GUICommonWindows.CreateTopWinLoader(8, "GUIMG", GUICommonWindows.ToggleWindow, InitMageWindow, MageSelectionChanged)
-OpenSorcererWindow = GUICommonWindows.CreateTopWinLoader(8, "GUIMG", GUICommonWindows.OpenWindowOnce, InitMageWindow, MageSelectionChanged)
+ToggleSorcererWindow = GUICommonWindows.CreateTopWinLoader(8, "GUIMG", GUICommonWindows.ToggleWindow, InitMageWindow, MageSelectionChanged, GUICommonWindows.DefaultWinPos, True)
+OpenSorcererWindow = GUICommonWindows.CreateTopWinLoader(8, "GUIMG", GUICommonWindows.OpenWindowOnce, InitMageWindow, MageSelectionChanged, GUICommonWindows.DefaultWinPos, True)
 
 def MagePrevLevelPress ():
 	global MageSpellLevel

--- a/gemrb/GUIScripts/GUIOPT.py
+++ b/gemrb/GUIScripts/GUIOPT.py
@@ -108,8 +108,8 @@ def InitOptionsWindow (Window):
 
 	return
 
-ToggleOptionsWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIOPT", GUICommonWindows.ToggleWindow, InitOptionsWindow)
-OpenOptionsWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIOPT", GUICommonWindows.OpenWindowOnce, InitOptionsWindow)
+ToggleOptionsWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIOPT", GUICommonWindows.ToggleWindow, InitOptionsWindow, None, GUICommonWindows.DefaultWinPos, True)
+OpenOptionsWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIOPT", GUICommonWindows.OpenWindowOnce, InitOptionsWindow, None, GUICommonWindows.DefaultWinPos, True)
 
 def TrySavingConfiguration():
 	if not GemRB.SaveConfig():

--- a/gemrb/GUIScripts/GUIPR.py
+++ b/gemrb/GUIScripts/GUIPR.py
@@ -163,8 +163,8 @@ def UpdatePriestWindow (Window):
 	Window.Focus()
 	return
 
-TogglePriestWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIPR", GUICommonWindows.ToggleWindow, InitPriestWindow, UpdatePriestWindow)
-OpenPriestWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIPR", GUICommonWindows.OpenWindowOnce, InitPriestWindow, UpdatePriestWindow)
+TogglePriestWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIPR", GUICommonWindows.ToggleWindow, InitPriestWindow, UpdatePriestWindow, GUICommonWindows.DefaultWinPos, True)
+OpenPriestWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIPR", GUICommonWindows.OpenWindowOnce, InitPriestWindow, UpdatePriestWindow, GUICommonWindows.DefaultWinPos, True)
 
 def PriestPrevLevelPress ():
 	global PriestSpellLevel

--- a/gemrb/GUIScripts/bg2/GUIINV.py
+++ b/gemrb/GUIScripts/bg2/GUIINV.py
@@ -121,8 +121,8 @@ def UpdateInventoryWindow (Window = None):
 		InventoryCommon.UpdateSlot (pc, i)
 	return
 
-ToggleInventoryWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIINV", GUICommonWindows.ToggleWindow, InitInventoryWindow, UpdateInventoryWindow)
-OpenInventoryWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIINV", GUICommonWindows.OpenWindowOnce, InitInventoryWindow, UpdateInventoryWindow)
+ToggleInventoryWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIINV", GUICommonWindows.ToggleWindow, InitInventoryWindow, UpdateInventoryWindow, GUICommonWindows.DefaultWinPos, True)
+OpenInventoryWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIINV", GUICommonWindows.OpenWindowOnce, InitInventoryWindow, UpdateInventoryWindow, GUICommonWindows.DefaultWinPos, True)
 
 InventoryCommon.UpdateInventoryWindow = UpdateInventoryWindow
 

--- a/gemrb/GUIScripts/bg2/GUIJRNL.py
+++ b/gemrb/GUIScripts/bg2/GUIJRNL.py
@@ -175,8 +175,8 @@ def UpdateLogWindow (JournalWindow):
 		Text.Append (JournalTitle + GemRB.GetString(15980) + JournalText)
 	return
 
-ToggleJournalWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIJRNL", GUICommonWindows.ToggleWindow, InitJournalWindow, UpdateLogWindow)
-OpenJournalWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIJRNL", GUICommonWindows.OpenWindowOnce, InitJournalWindow, UpdateLogWindow)
+ToggleJournalWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIJRNL", GUICommonWindows.ToggleWindow, InitJournalWindow, UpdateLogWindow, GUICommonWindows.DefaultWinPos, True)
+OpenJournalWindow = GUICommonWindows.CreateTopWinLoader(2, "GUIJRNL", GUICommonWindows.OpenWindowOnce, InitJournalWindow, UpdateLogWindow, GUICommonWindows.DefaultWinPos, True)
 
 ###################################################
 def PrevChapterPress ():


### PR DESCRIPTION
Added pause when opening:

- Options
- Inventory
- Character Record
- Priest Spells
- Mage Spells
- Sorcerer Spells
- Journal

This is only applying to BG2. Missing what the others do.

## Description
Fixing bug #1678 

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [X] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
