### PR TITLE
Stats overflow crashes fix

### DIFF
--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -4277,6 +4277,7 @@ ieDword Interface::TranslateStat(const char *stat_name)
 	ieDword stat = sym->GetValue(StringView(stat_name));
 	if (stat==(ieDword) ~0) {
 		Log(WARNING, "Core", "Cannot translate symbol: {}", stat_name);
+		stat = 0; // dont let the overflow happen
 	}
 	return stat;
 }

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -7088,10 +7088,15 @@ void Actor::ModifyDamage(Scriptable *hitter, int &damage, int &resisted, int dam
 				damage -= resisted;
 			} else {
 				int resistance = (signed)GetSafeStat(it->second.resist_stat);
-				// avoid buggy data
-				if ((unsigned)abs(resistance) > maximum_values[it->second.resist_stat]) {
-					resistance = 0;
-					Log(DEBUG, "ModifyDamage", "Ignoring bad damage resistance value ({}).", resistance);
+				// sanity check
+				if (it->second.resist_stat <= MAX_STATS) {
+					// avoid buggy data
+					if ((unsigned)abs(resistance) > maximum_values[it->second.resist_stat]) {
+						resistance = 0;
+						Log(DEBUG, "ModifyDamage", "Ignoring bad damage resistance value ({}).", resistance);
+					}
+				} else {
+					Log(ERROR, "resist_stat overflow: ", "{}", it->second.resist_stat);
 				}
 				resisted += (int) (damage * resistance/100.0);
 				damage -= resisted;


### PR DESCRIPTION
## Description
<!-- Describe the overall purpose of this pull request (PR). If applicable also add bug references and screenshots.-->
Using the linux build (Ubuntu 22.04.1 LTS x86_64, package from the default repository), I had multiple crashes during combat, which I tracked down to be caused by an overflow: the resist_stat of RESISTPOISON was read as -1, which is then cast to a signed integer, causing a massive overflow in the Actor::stats_t maximum_values table when checking.

I don't know neither the games or the data file formats enough to figure out what causes this wrong read, but it seems IDSImporter::GetValue(StringView txt) should maybe be changed to not return an int anymore (that would mean changing the GemRB::IDSImporter::Pair struct, but I don't know the implications to that).
It also seems the RESISTPOISON is the only one having a wrong value, when I logged them all.

Maybe this is a bug in the original game, no idea.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
