### PR TITLE
A number of spell immunity fixes

### DIFF
--- a/gemrb/core/EffectQueue.cpp
+++ b/gemrb/core/EffectQueue.cpp
@@ -1031,11 +1031,11 @@ static int check_resistance(Actor* actor, Effect* fx)
 
 	//opcode immunity
 	// TODO: research, maybe the whole check_resistance should be skipped on caster != actor (selfapplication)
-	if (caster != actor && actor->fxqueue.HasEffectWithParam(fx_opcode_immunity_ref, fx->Opcode)) {
+	if (actor->fxqueue.HasEffectWithParam(fx_opcode_immunity_ref, fx->Opcode)) {
 		Log(MESSAGE, "EffectQueue", "{} is immune to effect: {}", fmt::WideToChar{actor->GetName()}, globals.Opcodes[fx->Opcode].Name);
 		return FX_NOT_APPLIED;
 	}
-	if (caster != actor && actor->fxqueue.HasEffectWithParam(fx_opcode_immunity2_ref, fx->Opcode)) {
+	if (actor->fxqueue.HasEffectWithParam(fx_opcode_immunity2_ref, fx->Opcode)) {
 		Log(MESSAGE, "EffectQueue", "{} is immune2 to effect: {}", fmt::WideToChar{actor->GetName()}, globals.Opcodes[fx->Opcode].Name);
 		// totlm's spin166 should be wholly blocked by spwi210, but only blocks its third effect, so make it fatal
 		return FX_ABORT;

--- a/gemrb/core/EffectQueue.cpp
+++ b/gemrb/core/EffectQueue.cpp
@@ -1041,10 +1041,13 @@ static int check_resistance(Actor* actor, Effect* fx)
 		return FX_ABORT;
 	}
 
-	//not resistable (but check saves - for chromatic orb instakill)
-	// bg2 sequencer trigger spells have bad resistance set, so ignore them
-	if (fx->Resistance == FX_CAN_RESIST_CAN_DISPEL && signed(fx->Opcode) != EffectQueue::ResolveEffect(fx_activate_spell_sequencer_ref)) {
-		return check_magic_res(actor, fx, caster);
+	// check magic resistance if applicable
+	// (note that no MR roll does not preclude saving throws -- see e.g. chromatic orb instakill)
+	if (fx->Resistance == FX_CAN_RESIST_CAN_DISPEL && check_magic_res(actor, fx, caster) == FX_NOT_APPLIED) {
+		// bg2 sequencer trigger spells have bad resistance set, so ignore them
+		if (signed(fx->Opcode) != EffectQueue::ResolveEffect(fx_activate_spell_sequencer_ref)) {
+			return FX_NOT_APPLIED;
+		}
 	}
 
 	if (globals.pstflags && (actor->GetSafeStat(IE_STATE_ID) & STATE_ANTIMAGIC)) {

--- a/gemrb/core/EffectQueue.cpp
+++ b/gemrb/core/EffectQueue.cpp
@@ -173,6 +173,7 @@ static EffectRef fx_spell_immunity_ref = { "Protection:Spell", -1 }; //bg2
 static EffectRef fx_spell_immunity2_ref = { "Protection:Spell2", -1 };//iwd
 static EffectRef fx_school_immunity_ref = { "Protection:School", -1 };
 static EffectRef fx_secondary_type_immunity_ref = { "Protection:SecondaryType", -1 };
+static EffectRef fx_projectile_immunity_ref = { "Protection:Projectile", -1 };
 
 //decrementing immunity effects
 static EffectRef fx_level_immunity_dec_ref = { "Protection:SpellLevelDec", -1 };
@@ -830,6 +831,11 @@ static int check_type(Actor *actor, const Effect& fx)
 			}
 			return 0;
 		}
+	}
+
+	if (actor->fxqueue.HasEffectWithParam(fx_projectile_immunity_ref, fx.Projectile)) {
+		Log(DEBUG, "EffectQueue", "Resisted by projectile");
+		return 0;
 	}
 
 	//primary type immunity (school)

--- a/gemrb/core/EffectQueue.cpp
+++ b/gemrb/core/EffectQueue.cpp
@@ -1732,7 +1732,7 @@ const Effect *EffectQueue::HasEffectWithParamPair(EffectRef &effect_reference, i
 	return HasOpcodeWithParamPair(effect_reference.opcode, param1, param2);
 }
 
-//this could be used for stoneskins and mirror images as well
+//decreases all eligible effects at once!  returns false if all spent already
 bool EffectQueue::DecreaseParam1OfEffect(ieDword opcode, ieDword amount)
 {
 	bool found = false;

--- a/gemrb/core/EffectQueue.cpp
+++ b/gemrb/core/EffectQueue.cpp
@@ -1591,7 +1591,7 @@ void EffectQueue::RemoveLevelEffects(ieDword level, ieDword Flags, ieDword match
 			continue;
 		}
 
-		if (removed != fx.SourceRef) {
+		if (removed && removed != fx.SourceRef) {
 			continue;
 		}
 		if (Flags & RL_MATCHSCHOOL && fx.PrimaryType != match) {

--- a/gemrb/core/EffectQueue.cpp
+++ b/gemrb/core/EffectQueue.cpp
@@ -808,6 +808,8 @@ static int check_type(Actor *actor, const Effect& fx)
 	Actor *caster = core->GetGame()->GetActorByGlobalID(fx.CasterID);
 	// Cannot resist own spells!  This even applies to bounced hostile spells, but notably excludes source immunity.
 	bool self = (caster == actor);
+	// MagicAttack: these spells pierce most generic magical defences (because they need to be able to dispel them).
+	bool pierce = (fx.SecondaryType == 4);
 
 	//spell level immunity
 	if (fx.Power && actor->fxqueue.HasEffectWithParamPair(fx_level_immunity_ref, fx.Power, 0) && !self) {
@@ -831,7 +833,7 @@ static int check_type(Actor *actor, const Effect& fx)
 	}
 
 	//primary type immunity (school)
-	if (fx.PrimaryType && !self) {
+	if (fx.PrimaryType && !self && !pierce) {
 		if (actor->fxqueue.HasEffectWithParam(fx_school_immunity_ref, fx.PrimaryType)) {
 			Log(DEBUG, "EffectQueue", "Resisted by school/primary type");
 			return 0;
@@ -848,7 +850,7 @@ static int check_type(Actor *actor, const Effect& fx)
 
 	//decrementing immunity checks
 	//decrementing level immunity
-	if (fx.Power && fx.Resistance != FX_NO_RESIST_BYPASS_BOUNCE && !self) {
+	if (fx.Power && fx.Resistance != FX_NO_RESIST_BYPASS_BOUNCE && !self && !pierce) {
 		efx = const_cast<Effect*>(actor->fxqueue.HasEffectWithParam(fx_level_immunity_dec_ref, fx.Power));
 		if (efx && DecreaseEffect(efx)) {
 			Log(DEBUG, "EffectQueue", "Resisted by level immunity (decrementing)");
@@ -865,7 +867,7 @@ static int check_type(Actor *actor, const Effect& fx)
 		}
 	}
 	//decrementing primary type immunity (school)
-	if (fx.PrimaryType && !self) {
+	if (fx.PrimaryType && !self && !pierce) {
 		efx = const_cast<Effect*>(actor->fxqueue.HasEffectWithParam(fx_school_immunity_dec_ref, fx.PrimaryType));
 		if (efx && DecreaseEffect(efx)) {
 			Log(DEBUG, "EffectQueue", "Resisted by school immunity (decrementing)");
@@ -887,7 +889,7 @@ static int check_type(Actor *actor, const Effect& fx)
 	//if the spelltrap effect already absorbed enough levels
 	//but still didn't get removed, it will absorb levels it shouldn't
 	//it will also absorb multiple spells in a single round
-	if (fx.Power && fx.Resistance != FX_NO_RESIST_BYPASS_BOUNCE && !self) {
+	if (fx.Power && fx.Resistance != FX_NO_RESIST_BYPASS_BOUNCE && !self && !pierce) {
 		efx = const_cast<Effect*>(actor->fxqueue.HasEffectWithParamPair(fx_spelltrap, 0, fx.Power));
 		if( efx) {
 			//storing the absorbed spell level
@@ -926,7 +928,7 @@ static int check_type(Actor *actor, const Effect& fx)
 		return -1;
 	}
 
-	if (fx.PrimaryType && (bounce & BNC_SCHOOL)) {
+	if (fx.PrimaryType && (bounce & BNC_SCHOOL) && !pierce) {
 		if (actor->fxqueue.HasEffectWithParam(fx_school_bounce_ref, fx.PrimaryType)) {
 			Log(DEBUG, "EffectQueue", "Bounced by school");
 			return -1;
@@ -942,7 +944,7 @@ static int check_type(Actor *actor, const Effect& fx)
 	//decrementing bounce checks
 
 	//level decrementing bounce check
-	if (fx.Power && bounce & BNC_LEVEL_DEC) {
+	if (fx.Power && bounce & BNC_LEVEL_DEC && !pierce) {
 		efx = const_cast<Effect*>(actor->fxqueue.HasEffectWithParamPair(fx_level_bounce_dec_ref, 0, fx.Power));
 		if (efx && DecreaseEffect(efx)) {
 			Log(DEBUG, "EffectQueue", "Bounced by level (decrementing)");
@@ -958,7 +960,7 @@ static int check_type(Actor *actor, const Effect& fx)
 		}
 	}
 
-	if (fx.PrimaryType && (bounce & BNC_SCHOOL_DEC)) {
+	if (fx.PrimaryType && (bounce & BNC_SCHOOL_DEC) && !pierce) {
 		efx = const_cast<Effect*>(actor->fxqueue.HasEffectWithParam(fx_school_bounce_dec_ref, fx.PrimaryType));
 		if (efx && DecreaseEffect(efx)) {
 			Log(DEBUG, "EffectQueue", "Bounced by school (decrementing)");

--- a/gemrb/core/EffectQueue.h
+++ b/gemrb/core/EffectQueue.h
@@ -314,7 +314,7 @@ public:
 	const Effect *HasEffectWithPower(EffectRef &effect_reference, ieDword power) const;
 	const Effect *HasSource(const ResRef &source) const;
 	const Effect *HasEffectWithSource(EffectRef &effect_reference, const ResRef &source) const;
-	void DecreaseParam1OfEffect(EffectRef &effect_reference, ieDword amount);
+	bool DecreaseParam1OfEffect(EffectRef &effect_reference, ieDword amount);
 	int DecreaseParam3OfEffect(EffectRef &effect_reference, ieDword amount, ieDword param2);
 	int BonusForParam2(EffectRef &effect_reference, ieDword param2) const;
 	int MaxParam1(EffectRef &effect_reference, bool positive) const;
@@ -359,7 +359,7 @@ private:
 	const Effect *HasOpcodeWithResource(ieDword opcode, const ResRef &resource) const;
 	const Effect *HasOpcodeWithPower(ieDword opcode, ieDword power) const;
 	const Effect *HasOpcodeWithSource(ieDword opcode, const ResRef &source) const;
-	void DecreaseParam1OfEffect(ieDword opcode, ieDword amount);
+	bool DecreaseParam1OfEffect(ieDword opcode, ieDword amount);
 	int DecreaseParam3OfEffect(ieDword opcode, ieDword amount, ieDword param2);
 	int BonusForParam2(ieDword opcode, ieDword param2) const;
 	int MaxParam1(ieDword opcode, bool positive) const;


### PR DESCRIPTION
Hello again!  Here are some fixes for the spell protection effects, which didn't work properly for quite a while now.  I'll elaborate on the six commit points:

1. "Magic attack" spells such as Pierce Magic now correctly ignore most spell protections they're supposed to remove.  (`check_type()`, `bool pierce`)

Spells with the secondary type 4, which include spell protection strippers (and also Breach), ignore some protective effects, although not all.  [Here's a handy chart.](https://docs.google.com/spreadsheets/d/1y7r2Z3FfZk74NdAVHuZuiNmWh14y1tAytNrsFMSY7zc)  As you can see, they go through decrementing level immunity (Spell Turning), school immunity (Spell Immunity), decrementing level bounce (Spell Turning), and spell trap, although not generic level immunity (Spell Thrust (technically level 4) and Globe of Invulnerability, and see also note on Breach) or secondary type immunity (Spell Shield).  I haven't actually tested some of the more obscure effects, though, so I'm not 100% sure I got everything right, though.  Also the chart mentions e.g. Spell Trap absorbing lower-level type 4 spells (but only some of them!), which I'm not even sure how to implement properly.

2. Spell protections now make an exception for self-cast spells.   (`check_type()`, `bool self`)

Spells cast on oneself, including bounced spells, are even more exempt from protections, probably for convenience reasons.  See [this wiki article](https://baldursgate.fandom.com/wiki/Spell_Turning#Gameplay) about bounced spells and immunities.  I think they only can be blocked by source immunity (e.g. BG2Fixpack's implementation of Sunfire gives the caster 3 second immunity to itself).

3. Implemented projectile immunity.  The old code didn't work properly.  (`check_type()`, `fx_projectile_immunity_ref`)

Neither the damage nor added effects were blocked, now they do.  I remember seeing some nonfunctional code when I first wrote this fix, but now I can't find it!

4. Spell Deflection and similar limited level immunity effects are now correctly removed after reaching their limit.  (`DecreaseParam1OfEffect()`)

Just like Spell Trap, (Minor) Spell Deflection and Turning create an effect per each level, and an absorbed spell should decrease all of them at once.  I also made the decrease function return false if the effects are already spend (they don't disappear immediately, which caused them to overperform, even in IE).

5. Fixed effects that allow MR not checking saving throws.  (`check_resistance()`)

A typo: if MR is allowed, unconditional `return` was issued, skipping the saving throw code.

6. Spells that dispel other spell effects now work correctly.  (`RemoveLevelEffects()`)

Another typo: source ref was compared with `removed` variable which wasn't initialized before the comparison.