### PR TITLE
SDL: fixes alpha channel in shader for grey mode

### DIFF
--- a/gemrb/plugins/SDLVideo/Shaders/BlitRGBA.glsl
+++ b/gemrb/plugins/SDLVideo/Shaders/BlitRGBA.glsl
@@ -21,7 +21,7 @@ void main() {
 
 	if (u_greyMode == 1) {
 		float grey = (color.r + color.g + color.b)*0.333333;
-		gl_FragColor = vec4(grey, grey, grey, color.a);
+		gl_FragColor = vec4(grey, grey, grey, gl_FragColor.a);
 	} else if (u_greyMode == 2) {
 		float grey = (color.r + color.g + color.b)*0.333333;
 		gl_FragColor = vec4(grey + (21.0/256.0), grey, max(0.0, grey - (32.0/256.0)), gl_FragColor.a);


### PR DESCRIPTION
Probably a leftover of the very last shader code merge, other color branch was correct already. Looks good now:

![bg2_ts_ok](https://user-images.githubusercontent.com/238558/201560018-98dc6b6e-c1b2-4612-b4bc-c84ec0f4f619.jpg)

Fixes #1712.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
