### PR TITLE
BG2: fix scrolls cast on other actors instead of protagonist

### DIFF
--- a/gemrb/core/GameScript/GameScript.h
+++ b/gemrb/core/GameScript/GameScript.h
@@ -1555,7 +1555,7 @@ public: //Script Functions
 };
 
 GEM_EXPORT Action* GenerateAction(std::string String);
-Action *GenerateActionDirect(std::string string, const Scriptable *object);
+GEM_EXPORT Action *GenerateActionDirect(std::string string, const Scriptable *object);
 GEM_EXPORT Trigger* GenerateTrigger(std::string string);
 
 void InitializeIEScript();

--- a/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
+++ b/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
@@ -4660,14 +4660,8 @@ int fx_cast_spell (Scriptable* Owner, Actor* target, Effect* fx)
 	if (fx->Parameter2 == 0 || target->Type == ST_CONTAINER) {
 		// no deplete, no interrupt, caster or provided level
 		// ForceSpell doesn't have a RES variant, so there's more work
-		std::string tmp;
-		if (target == Owner) {
-			// charname has no scriptname ...
-			tmp = fmt::format("ForceSpell(Myself,{})", ResolveSpellNumber(fx->Resource));
-		} else {
-			tmp = fmt::format("ForceSpell(\"{}\",{})", target->GetScriptName(), ResolveSpellNumber(fx->Resource));
-		}
-		Action *forceSpellAction = GenerateAction(std::move(tmp));
+		std::string tmp = fmt::format("ForceSpell([-1],{})", ResolveSpellNumber(fx->Resource));
+		Action *forceSpellAction = GenerateActionDirect(std::move(tmp), target);
 		if (fx->Parameter1 != 0) {
 			// override casting level
 			forceSpellAction->int1Parameter = fx->Parameter1;


### PR DESCRIPTION
The old code for `Spell:Cast` effect (which scrolls use) created a `ForceSpell()` action with the target's script name (unless casting on self), but the protagonist has the script name "none" (there was even a comment about that!), so usually the spell would be cast on some other actor with the same name instead.  Really, this extends to any creature with a non-unique script name.

Anyway, now the code uses `GenerateActionDirect()` instead, which takes an actor and directly substitutes its actor ID, and this solves the problem.