### PR TITLE
GUILOAD: soft-killing the playlist after load screen

### DIFF
--- a/gemrb/GUIScripts/GUILOAD.py
+++ b/gemrb/GUIScripts/GUILOAD.py
@@ -162,6 +162,7 @@ def LoadGamePress (btn):
 		LoadScreen.StartLoadScreen ()
 		# it will close windows, including the loadscreen
 		GemRB.EnterGame ()
+		GemRB.SoftEndPL ()
 	return
 
 def GetQuickLoadSlot():


### PR DESCRIPTION
## Description
See #1715. This way the menu music is playing while seeing the load screen, but hands over to the map playlist, or none.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
