### PR TITLE
Actor: fix displaying consecutive saving throws

### DIFF
--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -3203,7 +3203,7 @@ bool Actor::GetSavingThrow(ieDword type, int modifier, const Effect *fx)
 		static ieDword prevType = -1;
 		static int prevRoll = -1;
 		static const Actor *prevActor = nullptr;
-		if (core->HasFeedback(FT_COMBAT) && prevType != type && prevActor != this && prevRoll != ret) {
+		if (core->HasFeedback(FT_COMBAT) && (prevType != type || prevActor != this || prevRoll != ret)) {
 			// "Save Vs Death" in all games except pst: "Save Vs. Death:"
 			String msg = core->GetString(DisplayMessage::GetStringReference(STR_SAVE_SPELL + type));
 			msg += L" " + fmt::to_wstring(ret);


### PR DESCRIPTION
A simple typo, the code was supposed to block repetitive messages from similar effects, but due to using && instead of ||, it often ended up blocking many subsequent unrelated saving throw reports.

So basically a boolean logic derp.  Without the fix, I would only see ST messages once every few minutes if at all.