### PR TITLE
Actor: fix weapon attacks polluting aura

### DIFF
--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -9222,7 +9222,9 @@ bool Actor::UseItem(ieDword slot, ieDword header, const Scriptable* target, ieDw
 	}
 	ChargeItem(slot, header, item, itm, flags&UI_SILENT, !(flags&UI_NOCHARGE));
 
-	AuraCooldown = core->Time.attack_round_size;
+	if (!(flags&UI_NOAURA)) {
+		AuraCooldown = core->Time.attack_round_size;
+	}
 	ResetCommentTime();
 	if (!pro) {
 		return false;


### PR DESCRIPTION
Prevent actions that don't require aura themselves (e.g. weapon attacks) from setting it on a cooldown.  Allows combining attacks with spells.

So basically, as per the original game, if you can cast a spell then shoot an arrow, you should also be able to shoot an arrow then cast a spell (or attack then drink a potion etc.)  Current master forbids the latter, seems to be unintentional though.