### PR TITLE
Data stream cleanup

### DIFF
--- a/gemrb/core/Projectile.cpp
+++ b/gemrb/core/Projectile.cpp
@@ -1313,8 +1313,8 @@ void Projectile::SpawnFragment(Point &dest)
 //		}
 		pro->SetCaster(Caster, Level);
 		if (pro->ExtFlags&PEF_RANDOM) {
-			dest.x+=core->Roll(1,Extension->TileX, -Extension->TileX/2);
-			dest.y+=core->Roll(1,Extension->TileY, -Extension->TileY/2);
+			dest.x += core->Roll(1,Extension->tileCoord.x, -Extension->tileCoord.x / 2);
+			dest.y += core->Roll(1,Extension->tileCoord.y, -Extension->tileCoord.y / 2);
 		}
 		area->AddProjectile(pro, dest, dest);
 	}
@@ -1392,8 +1392,8 @@ void Projectile::DrawExplosion(const Region& vp)
 		if (apflags&APF_TILED) {
 			int radius = Extension->ExplosionRadius;
 
-			for (int i = -radius; i < radius; i += Extension->TileX) {
-				for (int j = -radius; j < radius; j += Extension->TileY) {
+			for (int i = -radius; i < radius; i += Extension->tileCoord.x) {
+				for (int j = -radius; j < radius; j += Extension->tileCoord.y) {
 					if (i*i+j*j<radius*radius) {
 						Point p(Pos.x+i, Pos.y+j);
 						SpawnFragment(p);

--- a/gemrb/core/Projectile.h
+++ b/gemrb/core/Projectile.h
@@ -194,8 +194,7 @@ struct ProjectileExtension : Held<ProjectileExtension>
 	//used for target or HD counting
 	ieWord DiceCount;
 	ieWord DiceSize;
-	ieWord TileX;
-	ieWord TileY;
+	Point tileCoord;
 };
 
 class GEM_EXPORT Projectile

--- a/gemrb/core/Streams/DataStream.cpp
+++ b/gemrb/core/Streams/DataStream.cpp
@@ -121,10 +121,14 @@ strret_t DataStream::ReadSize(class Size& s)
 	return ret;
 }
 
-strret_t DataStream::ReadRegion(Region& r)
+strret_t DataStream::ReadRegion(Region& r, bool asPoints)
 {
 	strret_t ret = ReadPoint(r.origin);
 	ret += ReadSize(r.size);
+	if (asPoints) { // size is really the "max" coord
+		r.w -= r.x;
+		r.h -= r.y;
+	}
 	return ret;
 }
 

--- a/gemrb/core/Streams/DataStream.cpp
+++ b/gemrb/core/Streams/DataStream.cpp
@@ -101,16 +101,16 @@ strret_t DataStream::WriteFilling(strpos_t len)
 strret_t DataStream::ReadPoint(Point &p)
 {
 	// in the data files Points are 16bit per coord as opposed to our 32ish
-	strret_t ret = ReadScalar<int, ieWord>(p.x);
-	ret += ReadScalar<int, ieWord>(p.y);
+	strret_t ret = ReadScalar<int, ieWordSigned>(p.x);
+	ret += ReadScalar<int, ieWordSigned>(p.y);
 	return ret;
 }
 
 strret_t DataStream::WritePoint(const Point &p)
 {
 	// in the data files Points are 16bit per coord as opposed to our 32ish
-	strret_t ret = WriteScalar<int, ieWord>(p.x);
-	ret += WriteScalar<int, ieWord>(p.y);
+	strret_t ret = WriteScalar<int, ieWordSigned>(p.x);
+	ret += WriteScalar<int, ieWordSigned>(p.y);
 	return ret;
 }
 

--- a/gemrb/core/Streams/DataStream.cpp
+++ b/gemrb/core/Streams/DataStream.cpp
@@ -114,12 +114,17 @@ strret_t DataStream::WritePoint(const Point &p)
 	return ret;
 }
 
+strret_t DataStream::ReadSize(class Size& s)
+{
+	strret_t ret = ReadScalar<int, ieWord>(s.w);
+	ret += ReadScalar<int, ieWord>(s.h);
+	return ret;
+}
+
 strret_t DataStream::ReadRegion(Region& r)
 {
-	strret_t ret = ReadScalar<int, ieWord>(r.x);
-	ret += ReadScalar<int, ieWord>(r.y);
-	ret += ReadScalar<int, ieWord>(r.w);
-	ret += ReadScalar<int, ieWord>(r.h);
+	strret_t ret = ReadPoint(r.origin);
+	ret += ReadSize(r.size);
 	return ret;
 }
 

--- a/gemrb/core/Streams/DataStream.h
+++ b/gemrb/core/Streams/DataStream.h
@@ -169,6 +169,7 @@ public:
 
 	strret_t ReadPoint(Point&);
 	strret_t WritePoint(const Point&);
+	strret_t ReadSize(class Size&);
 	strret_t ReadRegion(Region&);
 	
 	virtual stroff_t Seek(stroff_t pos, strpos_t startpos) = 0;

--- a/gemrb/core/Streams/DataStream.h
+++ b/gemrb/core/Streams/DataStream.h
@@ -170,7 +170,7 @@ public:
 	strret_t ReadPoint(Point&);
 	strret_t WritePoint(const Point&);
 	strret_t ReadSize(class Size&);
-	strret_t ReadRegion(Region&);
+	strret_t ReadRegion(Region&, bool asPoints = false);
 	
 	virtual stroff_t Seek(stroff_t pos, strpos_t startpos) = 0;
 	strpos_t Remains() const;

--- a/gemrb/plugins/AREImporter/AREImporter.cpp
+++ b/gemrb/plugins/AREImporter/AREImporter.cpp
@@ -643,14 +643,7 @@ Map* AREImporter::GetMap(const ResRef& resRef, bool day_or_night)
 		str->ReadWord(Type);
 		Region bbox;
 		ieWord tmp;
-		str->ReadWord(tmp);
-		bbox.x = tmp;
-		str->ReadWord(tmp);
-		bbox.y = tmp;
-		str->ReadWord(tmp);
-		bbox.w = tmp - bbox.x;
-		str->ReadWord(tmp);
-		bbox.h = tmp - bbox.y;
+		str->ReadRegion(bbox, true);
 		str->ReadWord(VertexCount);
 		str->ReadDword(FirstVertex);
 		ieDword tmp2;
@@ -804,15 +797,7 @@ Map* AREImporter::GetMap(const ResRef& resRef, bool day_or_night)
 		str->ReadWord(TrapDetected);
 		str->ReadPoint(launchPos);
 		Region bbox;
-		ieWord tmp;
-		str->ReadWord(tmp);
-		bbox.x = tmp;
-		str->ReadWord(tmp);
-		bbox.y = tmp;
-		str->ReadWord(tmp);
-		bbox.w = tmp - bbox.x;
-		str->ReadWord(tmp);
-		bbox.h = tmp - bbox.y;
+		str->ReadRegion(bbox, true);
 		str->ReadDword(ItemIndex);
 		str->ReadDword(ItemCount);
 		str->ReadResRef( Script );
@@ -891,7 +876,6 @@ Map* AREImporter::GetMap(const ResRef& resRef, bool day_or_night)
 		ieWord OpenImpededCount, ClosedImpededCount;
 		ieVariable LongName, LinkedInfo;
 		ResRef ShortName;
-		ieWord minX, maxX, minY, maxY;
 		ieDword cursor;
 		ResRef KeyResRef;
 		ResRef script0;
@@ -916,22 +900,8 @@ Map* AREImporter::GetMap(const ResRef& resRef, bool day_or_night)
 		str->ReadWord(OpenVerticesCount);
 		str->ReadWord(ClosedVerticesCount);
 		str->ReadDword(ClosedFirstVertex);
-		str->ReadWord(minX);
-		str->ReadWord(minY);
-		str->ReadWord(maxX);
-		str->ReadWord(maxY);
-		BBOpen.x = minX;
-		BBOpen.y = minY;
-		BBOpen.w = maxX - minX;
-		BBOpen.h = maxY - minY;
-		str->ReadWord(minX);
-		str->ReadWord(minY);
-		str->ReadWord(maxX);
-		str->ReadWord(maxY);
-		BBClosed.x = minX;
-		BBClosed.y = minY;
-		BBClosed.w = maxX - minX;
-		BBClosed.h = maxY - minY;
+		str->ReadRegion(BBOpen, true);
+		str->ReadRegion(BBClosed, true);
 		str->ReadDword(OpenFirstImpeded);
 		str->ReadWord(OpenImpededCount);
 		str->ReadWord(ClosedImpededCount);
@@ -953,14 +923,8 @@ Map* AREImporter::GetMap(const ResRef& resRef, bool day_or_night)
 		str->ReadDword(DiscoveryDiff);
 		str->ReadDword(LockRemoval);
 		Point toOpen[2];
-		str->ReadWord(minX);
-		toOpen[0].x = minX;
-		str->ReadWord(minY);
-		toOpen[0].y = minY;
-		str->ReadWord(maxX);
-		toOpen[1].x = maxX;
-		str->ReadWord(maxY);
-		toOpen[1].y = maxY;
+		str->ReadPoint(toOpen[0]);
+		str->ReadPoint(toOpen[1]);
 		str->ReadStrRef(OpenStrRef);
 		if (core->HasFeature(GF_AUTOMAP_INI) ) {
 			char tmp[25];
@@ -983,10 +947,7 @@ Map* AREImporter::GetMap(const ResRef& resRef, bool day_or_night)
 		if (OpenVerticesCount) {
 			std::vector<Point> points(OpenVerticesCount);
 			for (int x = 0; x < OpenVerticesCount; x++) {
-				str->ReadWord(minX);
-				points[x].x = minX;
-				str->ReadWord(minY);
-				points[x].y = minY;
+				str->ReadPoint(points[x]);
 			}
 			open = std::make_shared<Gem_Polygon>(std::move(points), &BBOpen );
 		}
@@ -998,10 +959,7 @@ Map* AREImporter::GetMap(const ResRef& resRef, bool day_or_night)
 		if (ClosedVerticesCount) {
 			std::vector<Point> points(ClosedVerticesCount);
 			for (int x = 0; x < ClosedVerticesCount; x++) {
-				str->ReadWord(minX);
-				points[x].x = minX;
-				str->ReadWord(minY);
-				points[x].y = minY;
+				str->ReadPoint(points[x]);
 			}
 			closed = std::make_shared<Gem_Polygon>(std::move(points), &BBClosed);
 		}

--- a/gemrb/plugins/BAMImporter/BAMImporter.cpp
+++ b/gemrb/plugins/BAMImporter/BAMImporter.cpp
@@ -61,16 +61,10 @@ bool BAMImporter::Import(DataStream* str)
 	
 	DataStart = str->Size();
 	for (auto& frame : frames) {
-		ieWord w, h;
-		ieWordSigned x , y;
-		str->ReadScalar(w);
-		frame.bounds.w = w;
-		str->ReadScalar(h);
-		frame.bounds.h = h;
-		str->ReadScalar(x);
-		frame.bounds.x = x;
-		str->ReadScalar(y);
-		frame.bounds.y = y;
+		// ReadRegion is ordered x,y,w,h
+		// for some reason these rects are w,h,x,y
+		str->ReadSize(frame.bounds.size);
+		str->ReadPoint(frame.bounds.origin);
 		ieDword offset;
 		str->ReadScalar(offset);
 		frame.RLE = (offset & 0x80000000) == 0;

--- a/gemrb/plugins/BMPWriter/BMPWriter.cpp
+++ b/gemrb/plugins/BMPWriter/BMPWriter.cpp
@@ -13,9 +13,6 @@ using namespace GemRB;
 
 void BMPWriter::PutImage(DataStream *output, Holder<Sprite2D> spr)
 {
-	ieDword tmpDword;
-	ieWord tmpWord;
-
 	// FIXME
 	ieDword Width = spr->Frame.w;
 	ieDword Height = spr->Frame.h;
@@ -27,27 +24,15 @@ void BMPWriter::PutImage(DataStream *output, Holder<Sprite2D> spr)
 
 	//always save in truecolor (24 bit), no palette
 	output->Write( filling, 2);
-	tmpDword = fullsize+BMP_HEADER_SIZE;  // FileSize
-	output->WriteDword(tmpDword);
-	tmpDword = 0;
-	output->WriteDword(tmpDword);       // ??
-	tmpDword = BMP_HEADER_SIZE;           // DataOffset
-	output->WriteDword(tmpDword);
-	tmpDword = 40;                        // Size
-	output->WriteDword(tmpDword);
+	output->WriteDword(fullsize + BMP_HEADER_SIZE); // FileSize
+	output->WriteDword(0);       // ??
+	output->WriteDword(BMP_HEADER_SIZE); // DataOffset
+	output->WriteDword(40);  // Size
 	output->WriteDword(Width);
 	output->WriteDword(Height);
-	tmpWord = 1;                          // Planes
-	output->WriteWord(tmpWord);
-	tmpWord = 24; //24 bits               // BitCount
-	output->WriteWord(tmpWord);
-	tmpDword = 0;                         // Compression
-	output->WriteDword(tmpDword);
-	output->WriteDword(tmpDword);       // ImageSize
-	output->WriteDword(tmpDword);
-	output->WriteDword(tmpDword);
-	output->WriteDword(tmpDword);
-	output->WriteDword(tmpDword);
+	output->WriteWord(1); // Planes
+	output->WriteWord(24); // BitCount
+	output->WriteFilling(24); // Compression
 
 	auto it = spr->GetIterator(IPixelIterator::Direction::Forward, IPixelIterator::Direction::Reverse);
 	for (unsigned int y=0;y<Height;y++) {

--- a/gemrb/plugins/GAMImporter/GAMImporter.cpp
+++ b/gemrb/plugins/GAMImporter/GAMImporter.cpp
@@ -277,30 +277,20 @@ Game* GAMImporter::LoadGame(Game *newGame, int ver_override)
 	}
 
 	if (SavedLocCount && SavedLocOffset) {
-		ieWord PosX, PosY;
-
 		str->Seek( SavedLocOffset, GEM_STREAM_START );
 		for (unsigned int i = 0; i < SavedLocCount; i++) {
 			GAMLocationEntry *gle = newGame->GetSavedLocationEntry(i);
 			str->ReadResRef( gle->AreaResRef );
-			str->ReadWord(PosX);
-			str->ReadWord(PosY);
-			gle->Pos.x=PosX;
-			gle->Pos.y=PosY;
+			str->ReadPoint(gle->Pos);
 		}
 	}
 
 	if (PPLocCount && PPLocOffset) {
-		ieWord PosX, PosY;
-
 		str->Seek( PPLocOffset, GEM_STREAM_START );
 		for (unsigned int i = 0; i < PPLocCount; i++) {
 			GAMLocationEntry *gle = newGame->GetPlaneLocationEntry(i);
 			str->ReadResRef( gle->AreaResRef );
-			str->ReadWord(PosX);
-			str->ReadWord(PosY);
-			gle->Pos.x=PosX;
-			gle->Pos.y=PosY;
+			str->ReadPoint(gle->Pos);
 		}
 	}
 	return newGame;

--- a/gemrb/plugins/GAMImporter/GAMImporter.cpp
+++ b/gemrb/plugins/GAMImporter/GAMImporter.cpp
@@ -704,14 +704,11 @@ int GAMImporter::PutJournals(DataStream *stream, const Game *game) const
 //only in ToB (and iwd2)
 int GAMImporter::PutSavedLocations(DataStream *stream, Game *game) const
 {
-	ieWord tmpWord;
-	ieDword filling = 0;
-
 	//iwd2 has a single 0 dword here (at the end of the file)
 	//it could be a hacked out saved location list (inherited from SoA)
 	//if the field is missing, original engine cannot load this saved game
 	if (game->version==GAM_VER_IWD2) {
-		stream->WriteDword(filling);
+		stream->WriteDword(0);
 		return 0;
 	}
 
@@ -719,26 +716,18 @@ int GAMImporter::PutSavedLocations(DataStream *stream, Game *game) const
 			const GAMLocationEntry *j = game->GetSavedLocationEntry(i);
 
 			stream->WriteResRef(j->AreaResRef);
-			tmpWord = j->Pos.x;
-			stream->WriteWord(tmpWord);
-			tmpWord = j->Pos.y;
-			stream->WriteWord(tmpWord);
+			stream->WritePoint(j->Pos);
 	}
 	return 0;
 }
 
 int GAMImporter::PutPlaneLocations(DataStream *stream, Game *game) const
 {
-	ieWord tmpWord;
-
 	for (unsigned int i=0;i<PPLocCount;i++) {
 			const GAMLocationEntry *j = game->GetPlaneLocationEntry(i);
 
 			stream->WriteResRef(j->AreaResRef);
-			tmpWord = j->Pos.x;
-			stream->WriteWord(tmpWord);
-			tmpWord = j->Pos.y;
-			stream->WriteWord(tmpWord);
+			stream->WritePoint(j->Pos);
 	}
 	return 0;
 }
@@ -893,18 +882,13 @@ int GAMImporter::PutHeader(DataStream *stream, const Game *game) const
 
 int GAMImporter::PutActor(DataStream* stream, const Actor* ac, ieDword CRESize, ieDword CREOffset, ieDword GAMVersion) const
 {
-	ieDword tmpDword;
-	ieWord tmpWord;
-
 	if (ac->Selected) {
-		tmpWord=1;
+		stream->WriteWord(1);
 	} else {
-		tmpWord=0;
+		stream->WriteWord(0);
 	}
 
-	stream->WriteWord(tmpWord);
-	tmpWord = ac->InParty-1;
-	stream->WriteWord(tmpWord);
+	stream->WriteWord(ac->InParty - 1);
 
 	stream->WriteDword(CREOffset);
 	stream->WriteDword(CRESize);
@@ -912,22 +896,14 @@ int GAMImporter::PutActor(DataStream* stream, const Actor* ac, ieDword CRESize, 
 	//BG1 doesn't even like the * in there, zero fill
 	//seems to be accepted by all
 	stream->WriteFilling(8);
-	tmpDword = ac->GetOrientation();
-	stream->WriteDword(tmpDword);
+	stream->WriteDword(ac->GetOrientation());
 	stream->WriteResRefUC(ac->Area);
-	tmpWord = ac->Pos.x;
-	stream->WriteWord(tmpWord);
-	tmpWord = ac->Pos.y;
-	stream->WriteWord(tmpWord);
+	stream->WritePoint(ac->Pos);
 	//no viewport, we cheat
-	tmpWord = ac->Pos.x - core->config.Width / 2;
-	stream->WriteWord(tmpWord);
-	tmpWord = ac->Pos.y - core->config.Height / 2;
-	stream->WriteWord(tmpWord);
-	tmpWord = (ieWord) ac->Modal.State;
-	stream->WriteWord(tmpWord);
-	tmpWord = ac->PCStats->Happiness;
-	stream->WriteWord(tmpWord);
+	stream->WriteWord(ac->Pos.x - core->config.Width / 2);
+	stream->WriteWord(ac->Pos.y - core->config.Height / 2);
+	stream->WriteWord(ac->Modal.State);
+	stream->WriteWord(ac->PCStats->Happiness);
 	//interact counters
 	for (unsigned int& interact : ac->PCStats->Interact) {
 		stream->WriteDword(interact);
@@ -1016,8 +992,7 @@ int GAMImporter::PutActor(DataStream* stream, const Actor* ac, ieDword CRESize, 
 			}
 		}
 		for (int i = 0; i < MAX_QSLOTS; i++) {
-			tmpDword = ac->PCStats->QSlots[i+3];
-			stream->WriteDword(tmpDword);
+			stream->WriteDword(ac->PCStats->QSlots[i+3]);
 		}
 	}
 

--- a/gemrb/plugins/GAMImporter/GAMImporter.cpp
+++ b/gemrb/plugins/GAMImporter/GAMImporter.cpp
@@ -316,10 +316,8 @@ struct PCStruct {
 	ResRef CREResRef;
 	ieDword  Orientation;
 	ResRef Area;
-	ieWord   XPos;
-	ieWord   YPos;
-	ieWord   ViewXPos;
-	ieWord   ViewYPos;
+	Point Pos;
+	Point   ViewPos;
 	ieWord   ModalState;
 	ieWordSigned   Happiness;
 	ieDword  Interact[MAX_INTERACT];
@@ -347,10 +345,8 @@ Actor* GAMImporter::GetActor(const std::shared_ptr<ActorMgr>& aM, bool is_in_par
 	str->ReadResRef( pcInfo.CREResRef );
 	str->ReadDword(pcInfo.Orientation);
 	str->ReadResRef( pcInfo.Area );
-	str->ReadWord(pcInfo.XPos);
-	str->ReadWord(pcInfo.YPos);
-	str->ReadWord(pcInfo.ViewXPos);
-	str->ReadWord(pcInfo.ViewYPos);
+	str->ReadPoint(pcInfo.Pos);
+	str->ReadPoint(pcInfo.ViewPos);
 	str->ReadWord(pcInfo.ModalState); //see Modal.ids
 	str->ReadScalar<ieWordSigned>(pcInfo.Happiness);
 	for (unsigned int& interact : pcInfo.Interact) {
@@ -512,8 +508,7 @@ Actor* GAMImporter::GetActor(const std::shared_ptr<ActorMgr>& aM, bool is_in_par
 	memcpy(ps->QuickItemSlots, pcInfo.QuickItemSlot, MAX_QUICKITEMSLOT*sizeof(ieWord) );
 	memcpy(ps->QuickItemHeaders, pcInfo.QuickItemHeader, MAX_QUICKITEMSLOT*sizeof(ieWord) );
 	actor->ReinitQuickSlots();
-	actor->Destination.x = actor->Pos.x = pcInfo.XPos;
-	actor->Destination.y = actor->Pos.y = pcInfo.YPos;
+	actor->Destination = actor->Pos = pcInfo.Pos;
 	actor->Area = pcInfo.Area;
 	actor->SetOrientation(ClampToOrientation(pcInfo.Orientation), false);
 	actor->TalkCount = pcInfo.TalkCount;

--- a/gemrb/plugins/MOSImporter/MOSImporter.cpp
+++ b/gemrb/plugins/MOSImporter/MOSImporter.cpp
@@ -41,11 +41,7 @@ bool MOSImporter::Import(DataStream* str)
 	if (strncmp( Signature, "MOS V1  ", 8 ) != 0) {
 		return false;
 	}
-	ieWord tmp;
-	str->ReadWord(tmp);
-	size.w = tmp;
-	str->ReadWord(tmp);
-	size.h = tmp;
+	str->ReadSize(size);
 	str->ReadWord(Cols);
 	str->ReadWord(Rows);
 	str->ReadDword(BlockSize);

--- a/gemrb/plugins/PROImporter/PROImporter.cpp
+++ b/gemrb/plugins/PROImporter/PROImporter.cpp
@@ -110,7 +110,6 @@ Projectile* PROImporter::GetProjectile(Projectile *s)
 
 Holder<ProjectileExtension> PROImporter::GetAreaExtension()
 {
-	ieWord tmp;
 	Holder<ProjectileExtension> e = MakeHolder<ProjectileExtension>();
 
 	str->ReadDword(e->AFlags);
@@ -128,17 +127,16 @@ Holder<ProjectileExtension> PROImporter::GetAreaExtension()
 	str->Read( &e->ExplType,1 );
 	str->ReadWord(e->ExplColor);
 	//this index is off by one in the .pro files, consolidating it here
-	str->ReadWord(tmp);
-	if (tmp) {
-		tmp--;
+	str->ReadWord(e->ExplProjIdx);
+	if (e->ExplProjIdx) {
+		--e->ExplProjIdx;
 	}
-	e->ExplProjIdx = tmp;
 
 	str->ReadResRef( e->VVCRes );
-	str->ReadWord(tmp);
+	str->ReadWord(e->ConeWidth);
 	//limit the cone width to 359 degrees (for full compatibility)
-	e->ConeWidth = tmp > 359 ? 359 : tmp;
-	str->ReadWord(tmp); // padding
+	e->ConeWidth = e->ConeWidth > 359 ? 359 : e->ConeWidth;
+	str->Seek(2, GEM_CURRENT_POS); // padding
 
 	//These are GemRB specific, not used in the original engine
 	// bg2 has 216 bytes of reserved space here instead

--- a/gemrb/plugins/PROImporter/PROImporter.cpp
+++ b/gemrb/plugins/PROImporter/PROImporter.cpp
@@ -148,14 +148,13 @@ Holder<ProjectileExtension> PROImporter::GetAreaExtension()
 	str->ReadDword(e->APFlags);
 	str->ReadWord(e->DiceCount);
 	str->ReadWord(e->DiceSize);
-	str->ReadWord(e->TileX);
-	str->ReadWord(e->TileY);
+	str->ReadPoint(e->tileCoord);
 
-	if (!e->TileX) {
-		e->TileX=64;
+	if (!e->tileCoord.x) {
+		e->tileCoord.x = 64;
 	}
-	if (!e->TileY) {
-		e->TileY=64;
+	if (!e->tileCoord.y) {
+		e->tileCoord.y = 64;
 	}
 
 	//we skip the rest

--- a/gemrb/plugins/STOImporter/STOImporter.cpp
+++ b/gemrb/plugins/STOImporter/STOImporter.cpp
@@ -276,7 +276,6 @@ void STOImporter::PutPurchasedCategories(DataStream *stream, const Store* s) con
 void STOImporter::PutHeader(DataStream *stream, const Store *s)
 {
 	char Signature[9];
-	ieWord tmpWord;
 
 	version = s->version;
 	strlcpy(Signature, "STORV0.0", 9);
@@ -293,13 +292,13 @@ void STOImporter::PutHeader(DataStream *stream, const Store *s)
 
 	switch (version) {
 	case 10: case 0: // bg2, gemrb
-		tmpWord = s->Capacity;
+		stream->WriteWord(s->Capacity);
 		break;
 	default:
-		tmpWord = 0;
+		stream->WriteWord(0);
 		break;
 	}
-	stream->WriteWord(tmpWord);
+	
 
 	stream->Write( s->unknown, 8);
 	stream->WriteDword(s->PurchasedCategoriesOffset);

--- a/gemrb/plugins/WEDImporter/WEDImporter.h
+++ b/gemrb/plugins/WEDImporter/WEDImporter.h
@@ -29,8 +29,7 @@
 namespace GemRB {
 
 struct Overlay {
-	ieWord  Width;
-	ieWord  Height;
+	Size size;
 	ResRef TilesetResRef;
 	ieWord UniqueTileCount; // nNumUniqueTiles in the original (currently unused)
 	ieWord MovementType; // nMovementType in the original (currently unused)


### PR DESCRIPTION
## Description
Some minor enhancements to DataStream for reading data along with cleanup in the importers to favor things like ReadRegion/ReadSize/ReadPoint and removal of needless temporaries

I've tested loading+saving+loading in BG2. Will do some more testing in other games soon.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
