### PR TITLE
BG: modify current HP following Con changes

### DIFF
--- a/gemrb/GUIScripts/LUCommon.py
+++ b/gemrb/GUIScripts/LUCommon.py
@@ -458,8 +458,6 @@ def SetupHP (pc, Level=None, LevelDiff=None):
 
 	#update our hp values
 	GemRB.SetPlayerStat (pc, IE_MAXHITPOINTS, CurrentHP+OldHP)
-	# HACK: account also for the new constitution bonus for the current hitpoints
-	GemRB.SetPlayerStat (pc, IE_HITPOINTS, GemRB.GetPlayerStat (pc, IE_HITPOINTS, 1)+CurrentHP+5)
 	return
 
 def ApplyFeats(MyChar):

--- a/gemrb/core/Scriptable/Actor.h
+++ b/gemrb/core/Scriptable/Actor.h
@@ -475,6 +475,7 @@ private:
 	tick_t remainingTalkSoundTime = 0;
 	tick_t lastTalkTimeCheckAt = 0;
 	ieDword lastScriptCheck = 0;
+	int lastConBonus;
 	/** paint the actor itself. Called internally by Draw() */
 	void DrawActorSprite(const Point& p, BlitFlags flags,
 						 const std::vector<AnimationPart>& anims, const Color& tint) const;


### PR DESCRIPTION
> In the original BG1&2, temporary increases in constitution also increased current HP equal to max HP bonus.  In EE, these bonuses also cause equal amount of damage on expiring.  This commit implements the EE behavior, projecting any max HP change from constitution to current HP.

ATM GemRB does not adjust current HP at all, which makes e.g. DUHM significantly worse defensively.

Personally I feel the EE way is more fair (especially if you want to add early Con equipment), that said, the original game behavior is literally one comparison operator change away, if you'd like that more.  Or it could be controlled by those EE flags whenever you implement them.