### PR TITLE
SPLImporter: handle short icon names

### DIFF
--- a/gemrb/plugins/SPLImporter/SPLImporter.cpp
+++ b/gemrb/plugins/SPLImporter/SPLImporter.cpp
@@ -124,7 +124,7 @@ Spell* SPLImporter::GetSpell(Spell *s, bool /*silent*/)
 	str->ReadResRef( s->SpellbookIcon );
 	//this hack is needed in ToB at least
 	if (!s->SpellbookIcon.IsEmpty() && core->HasFeature(GF_SPELLBOOKICONHACK)) {
-		s->SpellbookIcon.Format("{:.7}c", s->SpellbookIcon);
+		*s->SpellbookIcon.rbegin() = 'c'; // replace last character
 	}
 
 	str->ReadWord(s->unknown6);


### PR DESCRIPTION
> aTweaks adds a seven-character-long-filename spellbook icon, and the old code mangled it by assuming all filenames are 8 characters long.

Fixes #1743.  Thanks to @bradallred for the neater code.