### PR TITLE
Faster vector normalization in Map code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,11 @@ IF(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 	if (NOT APPLE AND NOT UNSAFE_PLUGIN)
 		string(APPEND CMAKE_MODULE_LINKER_FLAGS " -Wl,--no-undefined")
 	endif (NOT APPLE AND NOT UNSAFE_PLUGIN)
+
+	# Fast math helps us covering some things that need a little more rework soon
+	string(APPEND CMAKE_CXX_FLAGS " -ffast-math")
+ELSEIF(MSVC)
+	string(APPEND CMAKE_CXX_FLAGS " /fp:fast")
 ENDIF()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")

--- a/gemrb/core/Map.h
+++ b/gemrb/core/Map.h
@@ -457,13 +457,13 @@ private:
 
 	MainAmbients dayAmbients;
 	MainAmbients nightAmbients;
-	
+
 	friend class AREImporter;
 
 public:
 	Map(TileMap *tm, TileProps tileProps, Holder<Sprite2D> sm);
 	~Map(void) override;
-	static void NormalizeDeltas(double &dx, double &dy, const double &factor = 1);
+	static void NormalizeDeltas(double &dx, double &dy, double factor = 1);
 	static Point ConvertCoordToTile(const Point&);
 	static Point ConvertCoordFromTile(const Point&);
 

--- a/gemrb/core/PathFinder.cpp
+++ b/gemrb/core/PathFinder.cpp
@@ -453,10 +453,9 @@ PathListNode *Map::FindPath(const Point &s, const Point &d, unsigned int size, u
 	return nullptr;
 }
 
-void Map::NormalizeDeltas(double &dx, double &dy, const double &factor)
+void Map::NormalizeDeltas(double &dx, double &dy, double factor)
 {
 	constexpr double STEP_RADIUS = 2.0;
-	constexpr double STEP_RADIUS_SQ = STEP_RADIUS * STEP_RADIUS;
 
 	double ySign = std::copysign(1.0, dy);
 	double xSign = std::copysign(1.0, dx);
@@ -469,16 +468,15 @@ void Map::NormalizeDeltas(double &dx, double &dy, const double &factor)
 	} else if (dy == 0.0) {
 		dx = STEP_RADIUS;
 	} else {
-		double dxSq = dx * dx;
-		double dySq = dy * dy;
-		double ratio = STEP_RADIUS_SQ / (dxSq + dySq);
-		dx = sqrt(dxSq * ratio);
-		// Speed on the y axis is downscaled (12 / 16) in order to correct searchmap scaling and avoid curved paths
-		dy = sqrt(dySq * ratio) * 0.75;
+		double ql = dx * dx + dy * dy;
+		double q = 1.0f / std::sqrt(ql);
+		dx = dx * q * STEP_RADIUS;
+		dy = dy * q * STEP_RADIUS * 0.75f;
 	}
 	dx = std::min(dx * factor, dxOrig);
 	dy = std::min(dy * factor, dyOrig);
 	dx = std::ceil(dx) * xSign;
 	dy = std::ceil(dy) * ySign;
 }
+
 }


### PR DESCRIPTION
I was investigating why there is an extreme slowdown in some cases of changing areas that do not look particularly difficult at a first glance.

Anway, the profilers indicate another interesting thing: When spending a lot of time waiting for map changes, `Map::NormalizeDeltas` has an insane amount of calls, and `sqrt` even consumes some systime.

Looking at this, there one obvious thing: One can do that with only one instead of two `sqrt` operations. And doing a bit of micro-benchmarking fun, it turns out that using something called [Quake Inverse Fast Sqrt](https://en.wikipedia.org/wiki/Fast_inverse_square_root) is even faster, if you can live with tiny little errors that don't really matter here (doing `ceil` and such). What was even mind-blowing: This optimization is not just faster by 20% in `-O2` but almost 2000% (Clang)/3000% (gcc) faster under `-O3`.

![deltas](https://user-images.githubusercontent.com/238558/204939153-df5743c0-f9c0-479c-8d44-598081a7530e.png)
(that's the whole `NormalizeDeltas` body code with old / new code)

There is still some noticeable I/O concern, I guess, and we should maybe look for ways to largely reduce the # of calls that end up in `NormalizeDeltas` in this situation but changing areas has really improved a little in Release mode, like relative 25-30% on that function counter.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
