### PR TITLE
TIS DXT1 fix

### DIFF
--- a/gemrb/plugins/PVRZImporter/PVRZImporter.cpp
+++ b/gemrb/plugins/PVRZImporter/PVRZImporter.cpp
@@ -248,7 +248,7 @@ Holder<Sprite2D> PVRZImporter::getSprite2DDXT1(Region&& region) const {
 			bool col1IsGreater = std::get<0>(color1n2) > std::get<1>(color1n2);
 
 			auto pixelMask = getBlockPixelMask(region, grid, x, y);
-			uint32_t blockValue = *(reinterpret_cast<const uint32_t*>(&data[srcDataOffset + 12])); // 4x4x2 bit
+			uint32_t blockValue = *(reinterpret_cast<const uint32_t*>(&data[srcDataOffset + 4])); // 4x4x2 bit
 			for (uint8_t i = 0; i < 16; ++i) {
 				if ((pixelMask & (1 << i)) == 0) {
 					continue;


### PR DESCRIPTION
## Description

Bad C&Ping the memory accessor from the other format, so this was this nicely distorted noise effect. Now we are good:
![2023-01-09_22-27](https://user-images.githubusercontent.com/238558/211413875-61fbec34-f4d8-4b8b-94ee-d655d4e54f15.jpg)

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [] The proposed change builds also on our build bots (check after submission)
