### PR TITLE
Smooth fog edges

### DIFF
--- a/gemrb/GemRB.cfg.noinstall.sample
+++ b/gemrb/GemRB.cfg.noinstall.sample
@@ -75,6 +75,11 @@ Bpp=32
 #Fullscreen [Boolean]
 Fullscreen=0
 
+# Use sprited fog of war [Boolean]. For nostalgia. By
+# default it looks more like accelerated FoW in BG2.
+
+#SpriteFogOfWar=1
+
 #####################################################
 #  Audio Parameters                                 #
 #####################################################

--- a/gemrb/GemRB.cfg.sample.in
+++ b/gemrb/GemRB.cfg.sample.in
@@ -81,6 +81,11 @@ Bpp=32
 #Fullscreen [Boolean]
 Fullscreen=0
 
+# Use sprited fog of war [Boolean]. For nostalgia. By
+# default it looks more like accelerated FoW in BG2.
+
+#SpriteFogOfWar=1
+
 #####################################################
 #  Audio Parameters                                 #
 #####################################################

--- a/gemrb/core/CMakeLists.txt
+++ b/gemrb/core/CMakeLists.txt
@@ -14,6 +14,7 @@ FILE(GLOB gemrb_core_LIB_SRCS
 	Effect.cpp
 	EffectQueue.cpp
 	Factory.cpp
+	FogRenderer.cpp
 	FontManager.cpp
 	Game.cpp
 	GameData.cpp

--- a/gemrb/core/FogRenderer.cpp
+++ b/gemrb/core/FogRenderer.cpp
@@ -1,0 +1,407 @@
+/* GemRB - Infinity Engine Emulator
+ * Copyright (C) 2023 The GemRB Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ *
+ */
+
+#include "FogRenderer.h"
+#include "Interface.h"
+#include "Video/Video.h"
+
+namespace GemRB {
+
+constexpr BlitFlags FogRenderer::BAM_FLAGS[];
+
+FogRenderer::FogRenderer(Video *video, bool doBAMRendering) :
+	video(video),
+	videoCanRenderGeometry(!doBAMRendering && video->CanDrawRawGeometry()),
+	fogVertices(24),
+	fogColors(12)
+{}
+
+void FogRenderer::DrawFog(const FogMapData& mapData) {
+	const Size& fogSize = mapData.fogSize;
+	auto largeFog = mapData.largeFog;
+
+	// Unbind this data from the object when there is more than one public method
+	this->vp = mapData.vp;
+	this->mapSize = mapData.mapSize;
+	this->start = Clamp(ConvertPointToFog(vp.origin), Point(), Point(fogSize.w, fogSize.h));
+	this->end = Clamp(ConvertPointToFog(vp.Maximum()) + Point(2 + largeFog, 2 + largeFog), Point(), Point(fogSize.w, fogSize.h));
+
+	this->p0 = {
+		(start.x * CELL_SIZE - vp.x) - (largeFog * CELL_SIZE / 2),
+		(start.y * CELL_SIZE - vp.y) - (largeFog * CELL_SIZE / 2)
+	};
+
+	DrawVPBorders();
+
+	for (int y = start.y; y < end.y; y++) {
+		int unexploredQueue = 0;
+		int shroudedQueue = 0;
+		int x = start.x;
+		for (; x < end.x; x++) {
+			Point cell{x, y};
+
+			if (IsUncovered(cell, mapData.exploredMask)) {
+				if (unexploredQueue) {
+					FillFog(ConvertPointToScreen(cell.x - unexploredQueue, cell.y), unexploredQueue, OPAQUE_FOG);
+					unexploredQueue = 0;
+				}
+
+				if (IsUncovered(cell, mapData.visibleMask)) {
+					if (shroudedQueue) {
+						FillFog(ConvertPointToScreen(cell.x - shroudedQueue, cell.y), shroudedQueue, TRANSPARENT_FOG);
+						shroudedQueue = 0;
+					}
+					DrawVisibleCell(cell, mapData.visibleMask);
+				} else {
+					// coalesce all horizontally adjacent shrouded cells
+					++shroudedQueue;
+				}
+
+				DrawExploredCell(cell, mapData.exploredMask);
+			} else {
+				// coalesce all horizontally adjacent unexplored cells
+				++unexploredQueue;
+				if (shroudedQueue) {
+					FillFog(ConvertPointToScreen(cell.x - shroudedQueue, cell.y), shroudedQueue, TRANSPARENT_FOG);
+					shroudedQueue = 0;
+				}
+			}
+		}
+
+		if (shroudedQueue) {
+			FillFog(ConvertPointToScreen(x - (shroudedQueue + unexploredQueue), y), shroudedQueue, TRANSPARENT_FOG);
+		}
+
+		if (unexploredQueue) {
+			FillFog(ConvertPointToScreen(x - unexploredQueue, y), unexploredQueue, OPAQUE_FOG);
+		}
+	}
+}
+
+Point FogRenderer::ConvertPointToFog(Point p) {
+	return Point(p.x / 32, p.y / 32);
+}
+
+Point FogRenderer::ConvertPointToScreen(int x, int y) const {
+	x = (x - start.x) * CELL_SIZE + p0.x;
+	y = (y - start.y) * CELL_SIZE + p0.y;
+
+	return Point(x, y);
+}
+
+void FogRenderer::DrawExploredCell(Point p, const Bitmap *exploredMask) {
+	auto IsExplored = [=](int x, int y) {
+		return IsUncovered({x, y}, exploredMask);
+	};
+	Point sp = ConvertPointToScreen(p.x, p.y);
+
+	FogDirection dirs = IsExplored(p.x, p.y - 1) ? FogDirection::O : FogDirection::N;
+	if (!IsExplored(p.x - 1, p.y)) dirs |= FogDirection::W;
+	if (!IsExplored(p.x, p.y + 1)) dirs |= FogDirection::S;
+	if (!IsExplored(p.x + 1, p.y)) dirs |= FogDirection::E;
+
+	if (dirs && !DrawFogCellByDirection(sp, dirs, BlitFlags::BLENDED)) {
+		FillFog(sp, 1, OPAQUE_FOG);
+	}
+
+	if (videoCanRenderGeometry) {
+		dirs = FogDirection::O;
+
+		if (!IsExplored(p.x - 1, p.y - 1)) dirs |= FogDirection::NW;
+		if (!IsExplored(p.x + 1, p.y - 1)) dirs |= FogDirection::NE;
+		if (dirs) {
+			DrawFogSmoothing(sp, dirs, OPAQUE_FOG, FogDirection::O);
+		}
+
+		dirs = FogDirection::O;
+		if (!IsExplored(p.x - 1, p.y + 1)) dirs |= FogDirection::SW;
+		if (!IsExplored(p.x + 1, p.y + 1)) dirs |= FogDirection::SE;
+		if (dirs) {
+			DrawFogSmoothing(sp, dirs, OPAQUE_FOG, FogDirection::O);
+		}
+	}
+}
+
+void FogRenderer::DrawVisibleCell(Point p, const Bitmap *visibleMask) {
+	auto IsVisible = [=](int x, int y) {
+		return IsUncovered({x, y}, visibleMask);
+	};
+	Point sp = ConvertPointToScreen(p.x, p.y);
+
+	FogDirection dirs = IsVisible(p.x, p.y - 1) ? static_cast<FogDirection>(0) : FogDirection::N;
+	if (!IsVisible(p.x - 1, p.y)) dirs |= FogDirection::W;
+	if (!IsVisible(p.x, p.y + 1)) dirs |= FogDirection::S;
+	if (!IsVisible(p.x + 1, p.y)) dirs |= FogDirection::E;
+
+	if (dirs && !DrawFogCellByDirection(sp, dirs, TRANSPARENT_FOG)) {
+		FillFog(sp, 1, TRANSPARENT_FOG);
+	}
+
+	if (videoCanRenderGeometry) {
+		FogDirection smoothDirs = FogDirection::O;
+
+		if (!IsVisible(p.x - 1, p.y - 1)) smoothDirs |= FogDirection::NW;
+		if (!IsVisible(p.x + 1, p.y - 1)) smoothDirs |= FogDirection::NE;
+		if (smoothDirs) {
+			DrawFogSmoothing(sp, smoothDirs, TRANSPARENT_FOG, dirs);
+		}
+
+		smoothDirs = FogDirection::O;
+		if (!IsVisible(p.x - 1, p.y + 1)) smoothDirs |= FogDirection::SW;
+		if (!IsVisible(p.x + 1, p.y + 1)) smoothDirs |= FogDirection::SE;
+		if (smoothDirs) {
+			DrawFogSmoothing(sp, smoothDirs, TRANSPARENT_FOG, dirs);
+		}
+	}
+}
+
+void FogRenderer::DrawFogCellBAM(Point p, FogDirection direction, BlitFlags flags) {
+	video->BlitGameSprite(core->FogSprites[direction], p, flags | BAM_FLAGS[direction]);
+}
+
+void FogRenderer::DrawFogCellVertices(Point p, FogDirection direction, BlitFlags flags) {
+	SetFogVerticesByOrigin(p);
+
+	// don't always make center vertices dark, see below
+	uint16_t halvingBits = 1 | (1 << 3) | (1 << 6) | (1 << 9);
+	uint16_t fillBits = halvingBits;
+
+	if (direction & FogDirection::N) {
+		fillBits |= (3 << 1) | (1 << 4) | (1 << 11);
+	}
+	if (direction & FogDirection::S) {
+		fillBits |= (3 << 7) | (1 << 5) | (1 << 10);
+	}
+	if (direction & FogDirection::E) {
+		fillBits |= (3 << 4) | (1 << 2) | (1 << 7);
+	}
+	if (direction & FogDirection::W) {
+		fillBits |= (3 << 10) | (1 << 1) | (1 << 8);
+	}
+
+	Color baseColor{0, 0, 0, 255};
+	if (flags & BlitFlags::HALFTRANS) {
+		baseColor = {0, 0, 0, 128};
+	};
+
+	for (size_t i = 0; i < fogColors.size(); ++i) {
+		fogColors[i] = baseColor;
+
+		if ((fillBits & (1 << i)) == 0) {
+			// 0xDB6 means that all outer vertices are requested, i. e. fill
+			// otherwise take down the alpha a little as it would be too dark
+			if ((halvingBits & (1 << i)) && fillBits != 0xDB6) {
+				fogColors[i].a = baseColor.a / 2;
+			} else {
+				fogColors[i].a = 0;
+			}
+		}
+	}
+
+	video->DrawRawGeometry(fogVertices, fogColors, BlitFlags::BLENDED);
+}
+
+void FogRenderer::DrawFogSmoothing(Point p, FogDirection direction, BlitFlags flags, FogDirection adjacentDir) {
+	// We need this when relying on smooth, alpha interpolation. The FOGOWAR.bam patterns
+	// cannot be simply replaced by one triangle fan: Given how the interpolation works, there
+	// will be ugly eges since usually the darkening is notable for way too long. We could also
+	// transform the vertices into something more fitting but that'd probably require more code.
+	//
+	// Instead, look for cells that have an over-the-edge fog cell and do a little smoothing
+	// to hide the edges.
+
+	SetFogVerticesByOrigin(p);
+
+	uint16_t fillBits = 0;
+
+	// We use adjacentDir to check whether the corners have already been used in the last
+	// draw pass of the edge-adjacent fog. This prevents over-blending (darkening) in the case
+	// that something has one edge and one corner-adjacent cover.
+	if ((direction & FogDirection::NW) == FogDirection::NW && !(adjacentDir & FogDirection::NW)) {
+		fillBits |= (1 << 1) | (1 << 11);
+	}
+	if ((direction & FogDirection::NE) == FogDirection::NE && !(adjacentDir & FogDirection::NE)) {
+		fillBits |= (1 << 2) | (1 << 4);
+	}
+	if ((direction & FogDirection::SE) == FogDirection::SE && !(adjacentDir & FogDirection::SE)) {
+		fillBits |= (1 << 5) | (1 << 7);
+	}
+	if ((direction & FogDirection::SW) == FogDirection::SW && !(adjacentDir & FogDirection::SW)) {
+		fillBits |= (1 << 8) | (1 << 10);
+	}
+
+	Color baseColor{0, 0, 0, 255};
+	if (flags & BlitFlags::HALFTRANS) {
+		baseColor = {0, 0, 0, 128};
+	};
+
+	for (size_t i = 0; i < fogColors.size(); ++i) {
+		fogColors[i] = baseColor;
+
+		if ((fillBits & (1 << i)) == 0) {
+			fogColors[i].a = 0;
+		}
+	}
+
+	video->DrawRawGeometry(fogVertices, fogColors, BlitFlags::BLENDED);
+}
+
+bool FogRenderer::DrawFogCellByDirection(Point p, FogDirection direction, BlitFlags flags) {
+	if (videoCanRenderGeometry) {
+		DrawFogCellVertices(p, direction, flags);
+		// accepts any adjacent-direction setup in one call
+		return true;
+	} else {
+		return DrawFogCellByDirectionBAMs(p, direction, flags);
+	}
+}
+
+bool FogRenderer::DrawFogCellByDirectionBAMs(Point p, FogDirection direction, BlitFlags flags) {
+	switch (direction & 0xF) {
+		case FogDirection::N:
+		case FogDirection::W:
+		case FogDirection::NW:
+		case FogDirection::S:
+		case FogDirection::SW:
+		case FogDirection::E:
+		case FogDirection::NE:
+		case FogDirection::SE:
+			DrawFogCellBAM(p, direction, flags);
+			return true;
+		case FogDirection::N|FogDirection::S:
+			DrawFogCellBAM(p, FogDirection::N, flags);
+			DrawFogCellBAM(p, FogDirection::S, flags);
+			return true;
+		case FogDirection::NW|FogDirection::SW:
+			DrawFogCellBAM(p, FogDirection::NW, flags);
+			DrawFogCellBAM(p, FogDirection::SW, flags);
+			return true;
+		case FogDirection::W|FogDirection::E:
+			DrawFogCellBAM(p, FogDirection::W, flags);
+			DrawFogCellBAM(p, FogDirection::E, flags);
+			return true;
+		case FogDirection::NW|FogDirection::NE:
+			DrawFogCellBAM(p, FogDirection::NW, flags);
+			DrawFogCellBAM(p, FogDirection::NE, flags);
+			return true;
+		case FogDirection::NE|FogDirection::SE:
+			DrawFogCellBAM(p, FogDirection::NE, flags);
+			DrawFogCellBAM(p, FogDirection::SE, flags);
+			return true;
+		case FogDirection::SW|FogDirection::SE:
+			DrawFogCellBAM(p, FogDirection::SW, flags);
+			DrawFogCellBAM(p, FogDirection::SE, flags);
+			return true;
+		default: // a fully surrounded tile is filled
+			return false;
+	}
+}
+
+void FogRenderer::DrawVPBorder(Point p, FogDirection direction, const Region& r, BlitFlags flags) {
+	if (videoCanRenderGeometry) {
+		DrawFogCellVertices(p, direction, OPAQUE_FOG);
+	} else {
+		video->BlitSprite(core->FogSprites[direction], p, &r, flags);
+	}
+}
+
+void FogRenderer::DrawVPBorders() {
+	// the amount of fuzzing to apply to map edges when the viewport overscans
+	constexpr int FUZZ_AMT = 8;
+
+	if (vp.y < 0) { // north border
+		Region r(0, 0, vp.w, -vp.y);
+		video->DrawRect(r, ColorBlack, true);
+		r.y += r.h;
+		r.h = FUZZ_AMT;
+		for (int x = r.x + p0.x; x < r.w; x += CELL_SIZE) {
+			DrawVPBorder(Point(x, r.y), FogDirection::N, r, BAM_FLAGS[FogDirection::N]);
+		}
+	}
+
+	if (vp.y + vp.h > mapSize.h) { // south border
+		Region r(0, mapSize.h - vp.y, vp.w, vp.y + vp.h - mapSize.h);
+		video->DrawRect(r, ColorBlack, true);
+		r.y -= FUZZ_AMT;
+		r.h = FUZZ_AMT;
+		for (int x = r.x + p0.x; x < r.w; x += CELL_SIZE) {
+			DrawVPBorder(Point(x, r.y), FogDirection::S, r, BAM_FLAGS[FogDirection::S]);
+		}
+	}
+
+	if (vp.x < 0) { // west border
+		Region r(0, std::max(0, -vp.y), -vp.x, mapSize.h);
+		video->DrawRect(r, ColorBlack, true);
+		r.x += r.w;
+		r.w = FUZZ_AMT;
+		for (int y = r.y + p0.y; y < r.h; y += CELL_SIZE) {
+			DrawVPBorder(Point(r.x, y), FogDirection::W, r, BAM_FLAGS[FogDirection::W]);
+		}
+	}
+
+	if (vp.x + vp.w > mapSize.w) { // east border
+		Region r(mapSize.w -vp.x, std::max(0, -vp.y), vp.x + vp.w - mapSize.w, mapSize.h);
+		video->DrawRect(r, ColorBlack, true);
+		r.x -= FUZZ_AMT;
+		r.w = FUZZ_AMT;
+		for (int y = r.y + p0.y; y < r.h; y += CELL_SIZE) {
+			DrawVPBorder(Point(r.x, y), FogDirection::E, r, BAM_FLAGS[FogDirection::E]);
+		}
+	}
+}
+
+void FogRenderer::FillFog(Point p, int numRowItems, BlitFlags flags) {
+	Region r(p, Size(CELL_SIZE * numRowItems, CELL_SIZE));
+	video->DrawRect(r, ColorBlack, true, flags);
+}
+
+bool FogRenderer::IsUncovered(Point p, const Bitmap *mask) {
+	if (mask == nullptr) return true;
+
+	return mask->GetAt(p, false);
+}
+
+void FogRenderer::SetFogVerticesByOrigin(Point p) {
+	// Triangle fan of 4: center
+	fogVertices[0] = fogVertices[6] = fogVertices[12] = fogVertices[18] = p.x + CELL_SIZE / 2;
+	fogVertices[1] = fogVertices[7] = fogVertices[13] = fogVertices[19] = p.y + CELL_SIZE / 2;
+	// Top (l, r)
+	fogVertices[2] = p.x;
+	fogVertices[3] = p.y;
+	fogVertices[4] = p.x + CELL_SIZE;
+	fogVertices[5] = p.y;
+	// Right (t, b)
+	fogVertices[8] = p.x + CELL_SIZE;
+	fogVertices[9] = p.y;
+	fogVertices[10] = p.x + CELL_SIZE;
+	fogVertices[11] = p.y + CELL_SIZE;
+	// Bottom (r, l)
+	fogVertices[14] = p.x + CELL_SIZE;
+	fogVertices[15] = p.y + CELL_SIZE;
+	fogVertices[16] = p.x;
+	fogVertices[17] = p.y + CELL_SIZE;
+	// left (b, t)
+	fogVertices[20] = p.x;
+	fogVertices[21] = p.y + CELL_SIZE;
+	fogVertices[22] = p.x;
+	fogVertices[23] = p.y;
+}
+
+}

--- a/gemrb/core/FogRenderer.h
+++ b/gemrb/core/FogRenderer.h
@@ -1,0 +1,122 @@
+/* GemRB - Infinity Engine Emulator
+ * Copyright (C) 2023 The GemRB Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ *
+ */
+
+#ifndef FOG_RENDERER_H
+#define FOG_RENDERER_H
+
+#include <vector>
+
+#include "exports.h"
+#include "globals.h"
+
+#include "Bitmap.h"
+#include "Region.h"
+#include "Sprite2D.h"
+
+namespace GemRB {
+
+class Video;
+
+struct FogMapData {
+	FogMapData(
+		const Bitmap *exploredMask,
+		const Bitmap *visibleMask,
+		Region vp,
+		Size mapSize,
+		Size fogSize,
+		int largeFog
+	) : exploredMask(exploredMask),
+		visibleMask(visibleMask),
+		vp(vp),
+		mapSize(mapSize),
+		fogSize(fogSize),
+		largeFog(largeFog)
+	{}
+
+	const Bitmap *exploredMask;
+	const Bitmap *visibleMask;
+	Region vp;
+	Size mapSize;
+	Size fogSize;
+	int largeFog;
+};
+
+class GEM_EXPORT FogRenderer {
+	private:
+		Video* video;
+		bool videoCanRenderGeometry = false;
+		std::vector<float> fogVertices;
+		std::vector<Color> fogColors;
+
+		Region vp;
+		Size mapSize;
+		Point start;
+		Point end;
+		Point p0;
+
+		enum FogDirection : uint8_t {
+			O,
+			N = 1,
+			W = 2,
+			NW = N|W, // 3
+			S = 4,
+			SW = S|W, // 6
+			E = 8,
+			NE = N|E, // 9
+			SE = S|E  // 12
+		};
+
+		// Size of Fog-Of-War shadow tile (and bitmap)
+		static constexpr int CELL_SIZE = 32;
+		static constexpr BlitFlags BAM_FLAGS[] = {
+			BlitFlags::NONE, BlitFlags::NONE, BlitFlags::NONE, BlitFlags::NONE,
+			BlitFlags::MIRRORY, BlitFlags::NONE, BlitFlags::MIRRORY,
+			BlitFlags::NONE, BlitFlags::MIRRORX, BlitFlags::MIRRORX,
+			BlitFlags::NONE, BlitFlags::NONE, static_cast<BlitFlags>(BlitFlags::MIRRORX | BlitFlags::MIRRORY)
+		};
+
+		static constexpr BlitFlags OPAQUE_FOG = BlitFlags::NONE;
+		static constexpr BlitFlags TRANSPARENT_FOG = static_cast<BlitFlags>(BlitFlags::HALFTRANS | BlitFlags::BLENDED);
+	public:
+		FogRenderer(Video*, bool doBAMRendering = false);
+
+		void DrawFog(const FogMapData& mapData);
+
+	private:
+		Point ConvertPointToScreen(int x, int y) const;
+		static Point ConvertPointToFog(Point p);
+		void DrawExploredCell(Point cellPoint, const Bitmap *mask);
+		void DrawFogCellBAM(Point p, FogDirection direction, BlitFlags flags);
+		void DrawFogCellVertices(Point p, FogDirection direction, BlitFlags flags);
+		bool DrawFogCellByDirection(Point p, FogDirection direction, BlitFlags flags);
+		bool DrawFogCellByDirectionBAMs(Point p, FogDirection direction, BlitFlags flags);
+		bool DrawFogCellByDirectionVertices(Point p, FogDirection direction, BlitFlags flags);
+		void DrawFogSmoothing(Point p, FogDirection direction, BlitFlags flags, FogDirection adjacentDir);
+		void DrawVisibleCell(Point cellPoint, const Bitmap *mask);
+		void DrawVPBorder(Point p, FogDirection direction, const Region& r, BlitFlags flags);
+		void DrawVPBorders();
+		void FillFog(Point p, int numRowItems, BlitFlags flags);
+		static bool IsUncovered(Point cellPoint, const Bitmap *mask);
+		void SetFogVerticesByOrigin(Point p);
+};
+
+}
+
+#endif

--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -550,7 +550,7 @@ void GameControl::DrawSelf(const Region& screen, const Region& /*clip*/)
 	}
 
 	//drawmap should be here so it updates fog of war
-	area->DrawMap(Viewport(), DebugFlags);
+	area->DrawMap(Viewport(), core->GetFogRenderer(), DebugFlags);
 
 	if (trackerID) {
 		const Actor *actor = area->GetActorByGlobalID(trackerID);

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -812,6 +812,7 @@ int Interface::Init(const InterfaceConfig* cfg)
 	CONFIG_INT("MultipleQuickSaves", config.MultipleQuickSaves =);
 	CONFIG_INT("RepeatKeyDelay", Control::ActionRepeatDelay =);
 	CONFIG_INT("SaveAsOriginal", config.SaveAsOriginal =);
+	CONFIG_INT("SpriteFogOfWar", config.SpriteFoW =);
 	CONFIG_INT("DebugMode", config.debugMode =);
 	int touchInput = -1;
 	CONFIG_INT("TouchInput", touchInput =);
@@ -1047,7 +1048,7 @@ int Interface::Init(const InterfaceConfig* cfg)
 		return GEM_ERROR;
 	}
 
-	fogRenderer = std::make_shared<FogRenderer>(video.get(), false);
+	fogRenderer = std::make_shared<FogRenderer>(video.get(), config.SpriteFoW);
 
 	// ask the driver if a touch device is in use
 	EventMgr::TouchInputEnabled = touchInput < 0 ? video->TouchInputEnabled() : touchInput;

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -1047,6 +1047,8 @@ int Interface::Init(const InterfaceConfig* cfg)
 		return GEM_ERROR;
 	}
 
+	fogRenderer = std::make_shared<FogRenderer>(video.get(), false);
+
 	// ask the driver if a touch device is in use
 	EventMgr::TouchInputEnabled = touchInput < 0 ? video->TouchInputEnabled() : touchInput;
 
@@ -1502,6 +1504,11 @@ ProjectileServer* Interface::GetProjectileServer() const noexcept
 Video* Interface::GetVideoDriver() const
 {
 	return video.get();
+}
+
+FogRenderer& Interface::GetFogRenderer()
+{
+	return *fogRenderer.get();
 }
 
 Audio* Interface::GetAudioDrv(void) const {

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -339,6 +339,7 @@ struct CFGConfigData {
 	int Height = 480;
 	int Bpp = 32;
 	bool DrawFPS = false;
+	bool SpriteFoW = false;
 	int debugMode = 0;
 	bool CheatFlag = false; /** Cheats enabled? */
 	int MaxPartySize = 6;

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -38,6 +38,7 @@
 #include "GUI/Tooltip.h"
 #include "GUI/Window.h"
 #include "GUI/GUIFactory.h"
+#include "FogRenderer.h"
 #include "Holder.h"
 #include "ImageMgr.h"
 #include "InterfaceConfig.h"
@@ -368,6 +369,7 @@ private:
 	WindowManager* winmgr = nullptr;
 	std::shared_ptr<GUIFactory> guifact;
 	std::shared_ptr<ScriptEngine> guiscript;
+	std::shared_ptr<FogRenderer> fogRenderer;
 	GameControl* gamectrl = nullptr;
 	SaveGameIterator *sgiterator = nullptr;
 	Variables * vars;
@@ -466,6 +468,7 @@ public:
 	const char * TypeExt(SClass_ID type) const;
 	ProjectileServer* GetProjectileServer() const noexcept;
 	Video * GetVideoDriver() const;
+	FogRenderer& GetFogRenderer();
 	/* create or change a custom string */
 	ieStrRef UpdateString(ieStrRef strref, const String& text) const;
 	/* returns a newly created string */

--- a/gemrb/core/Map.h
+++ b/gemrb/core/Map.h
@@ -25,6 +25,7 @@
 #include "globals.h"
 
 #include "Bitmap.h"
+#include "FogRenderer.h"
 #include "Interface.h"
 #include "MapReverb.h"
 #include "Scriptable/Scriptable.h"
@@ -484,7 +485,7 @@ public:
 	/* transfers all ever visible piles (loose items) to the specified position */
 	void MoveVisibleGroundPiles(const Point &Pos);
 
-	void DrawMap(const Region& viewport, uint32_t debugFlags);
+	void DrawMap(const Region& viewport, FogRenderer& fogRenderer, uint32_t debugFlags);
 	void PlayAreaSong(int SongType, bool restart = true, bool hard = false) const;
 	void AddAnimation(AreaAnimation anim);
 	aniIterator GetFirstAnimation() { return animations.begin(); }
@@ -691,25 +692,24 @@ private:
 	VEFObject *GetNextScriptedAnimation(const scaIterator &iter) const;
 	Actor *GetNextActor(int &q, size_t &index) const;
 	Container *GetNextPile (int &index) const;
-	
+
 	void RedrawScreenStencil(const Region& vp, const WallPolygonGroup& walls);
 	void DrawStencil(const VideoBufferPtr& stencilBuffer, const Region& vp, const WallPolygonGroup& walls) const;
 	WallPolygonSet WallsIntersectingRegion(Region, bool includeDisabled = false, const Point* loc = nullptr) const;
-	
+
 	void SetDrawingStencilForObject(const void*, const Region&, const WallPolygonSet&, const Point& viewPortOrigin);
 	BlitFlags SetDrawingStencilForScriptable(const Scriptable*, const Region& viewPort);
 	BlitFlags SetDrawingStencilForAreaAnimation(const AreaAnimation*, const Region& viewPort);
-	
+
 	void DrawDebugOverlay(const Region &vp, uint32_t dFlags) const;
 	void DrawPortal(const InfoPoint *ip, int enable);
 	void DrawHighlightables(const Region& viewport) const;
-	void DrawFogOfWar(const Bitmap* explored_mask, const Bitmap* visible_mask, const Region& viewport) const;
-	
+
 	Size PropsSize() const noexcept;
 	Size FogMapSize() const;
 	bool FogTileUncovered(const Point &p, const Bitmap*) const;
 	Point ConvertPointToFog(const Point &p) const;
-	
+
 	void GenerateQueues();
 	void SortQueues();
 	//Actor* GetRoot(int priority, int &index);

--- a/gemrb/core/Video/Video.h
+++ b/gemrb/core/Video/Video.h
@@ -159,6 +159,7 @@ public:
 	virtual bool InTextInput() = 0;
 
 	virtual bool TouchInputEnabled() = 0;
+	virtual bool CanDrawRawGeometry() const { return false; }
 
 	virtual Holder<Sprite2D> CreateSprite(const Region&, void* pixels, const PixelFormat&) = 0;
 	
@@ -195,6 +196,11 @@ public:
 	/** Draws a line segment */
 	void DrawLine(const Point& p1, const Point& p2, const Color& color, BlitFlags flags = BlitFlags::NONE);
 	void DrawLines(const std::vector<Point>& points, const Color& color, BlitFlags flags = BlitFlags::NONE);
+	virtual void DrawRawGeometry(
+		const std::vector<float>& /*vertices*/,
+		const std::vector<Color>& /*colors*/,
+		BlitFlags /*blitFlags*/
+	) {};
 	/** Sets Event Manager */
 	void SetEventMgr(EventMgr* evnt);
 

--- a/gemrb/plugins/SDLVideo/SDL20Video.h
+++ b/gemrb/plugins/SDLVideo/SDL20Video.h
@@ -238,9 +238,12 @@ public:
 	bool InTextInput() override;
 	
 	bool TouchInputEnabled() override;
+	bool CanDrawRawGeometry() const override;
 
 	void BlitVideoBuffer(const VideoBufferPtr& buf, const Point& p, BlitFlags flags,
 						 Color tint = Color()) override;
+
+	void DrawRawGeometry(const std::vector<float>& vertices, const std::vector<Color>& colors, BlitFlags blitFlags) override;
 private:
 	VideoBuffer* NewVideoBuffer(const Region&, BufferFormat) override;
 


### PR DESCRIPTION
## Description
See #1760. Turns out interpolating some vertex colors alone isn't sufficient, we will need to paint cells in a way to cover the edges to look good. Here we are now:

With modern SDLv2 (notice the machine in the lower left, and the room in the upper right):

![2023-01-13_22-31](https://user-images.githubusercontent.com/238558/212426012-d4878d8d-fbc7-4e5a-a2f3-5bc1a333e619.png)

Fallback:
![2023-01-13_22-32](https://user-images.githubusercontent.com/238558/212426035-dda1907a-61b0-4bcb-b3af-185e457e5940.png)


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
