### PR TITLE
Allow enums to be Iterable

### DIFF
--- a/gemrb/core/CharAnimations.cpp
+++ b/gemrb/core/CharAnimations.cpp
@@ -2791,10 +2791,10 @@ void CharAnimations::PulseRGBModifiers()
 		}
 	}
 
-	for (size_t i = 0; i < PAL_MAX; ++i) {
+	for (const PaletteType i : EnumIterator<PaletteType, PAL_MAIN, PAL_MAX>()) {
 		if (change[i]) {
 			change[i] = false;
-			SetupColors((PaletteType) i);
+			SetupColors(i);
 		}
 	}
 

--- a/gemrb/core/CharAnimations.cpp
+++ b/gemrb/core/CharAnimations.cpp
@@ -660,7 +660,7 @@ CharAnimations::CharAnimations(unsigned int AnimID, ieDword ArmourLevel)
 	GlobalColorMod.rgb = Color();
 
 	AvatarsRowNum = GetAvatarsCount();
-	if (core->HasFeature(GF_ONE_BYTE_ANIMID) ) {
+	if (core->HasFeature(GFFlags::ONE_BYTE_ANIMID) ) {
 		ieDword tmp = AnimID&0xf000;
 		if (tmp==0x6000 || tmp==0xe000) {
 			AnimID&=0xff;

--- a/gemrb/core/CharAnimations.h
+++ b/gemrb/core/CharAnimations.h
@@ -119,7 +119,7 @@ namespace GemRB {
 #define AV_NO_BODY_HEAT                 1
 #define AV_BUFFET_IMMUNITY              0x1000
 
-enum PaletteType {
+enum PaletteType : uint8_t {
 	PAL_MAIN,
 	PAL_MAIN_2,
 	PAL_MAIN_3,

--- a/gemrb/core/DialogHandler.cpp
+++ b/gemrb/core/DialogHandler.cpp
@@ -48,7 +48,7 @@ static const int noSections[4] = {0,0,0,0};
 
 DialogHandler::DialogHandler(void)
 {
-	if (core->HasFeature(GF_JOURNAL_HAS_SECTIONS)) {
+	if (core->HasFeature(GFFlags::JOURNAL_HAS_SECTIONS)) {
 		sectionMap = bg2Sections;
 	} else {
 		sectionMap = noSections;
@@ -88,7 +88,7 @@ void DialogHandler::UpdateJournalForTransition(const DialogTransition* tr) const
 			msg += L"[/color]\n";
 		}
 		if (core->HasFeedback(FT_MISC)) {
-			if (core->HasFeature(GF_ONSCREEN_TEXT)) {
+			if (core->HasFeature(GFFlags::ONSCREEN_TEXT)) {
 				core->GetGameControl()->SetDisplayText(HCStrings::JournalChange, 30);
 			} else {
 				displaymsg->DisplayMarkupString(msg);
@@ -364,7 +364,7 @@ bool DialogHandler::DialogChoose(unsigned int choose)
 			// FIXME: figure out if pst needs something similar (action missing)
 			//        (not conditional on GenerateAction to prevent console spam)
 			// iwd2 41nate.d breaks if this is included, since the original delayed execution in a different manner
-			if (!core->HasFeature(GF_AREA_OVERRIDE) && !core->HasFeature(GF_3ED_RULES) && !(tr->Flags & IE_DLG_IMMEDIATE)) {
+			if (!core->HasFeature(GFFlags::AREA_OVERRIDE) && !core->HasFeature(GFFlags::RULES_3ED) && !(tr->Flags & IE_DLG_IMMEDIATE)) {
 				target->AddAction(GenerateAction("BreakInstants()"));
 			}
 			for (unsigned int i = 0; i < tr->actions.size(); i++) {
@@ -418,7 +418,7 @@ bool DialogHandler::DialogChoose(unsigned int choose)
 				tgt = tgta;
 			}
 			// pst: check if we're carrying any items with the needed dialog (eg. mertwyn's head)
-			if (!tgt && core->HasFeature(GF_AREA_OVERRIDE)) {
+			if (!tgt && core->HasFeature(GFFlags::AREA_OVERRIDE)) {
 				tgta = target->GetCurrentArea()->GetItemByDialog(tr->Dialog);
 				tgt = tgta;
 			}

--- a/gemrb/core/DisplayMessage.cpp
+++ b/gemrb/core/DisplayMessage.cpp
@@ -238,11 +238,8 @@ std::map<GUIColors, std::string> DisplayMessage::GetAllColors() const
 	std::map<GUIColors, std::string> auxiliaryColors;
 	AutoTable colorTable = gamedata->LoadTable("colors", true);
 	assert(colorTable);
-	TableMgr::index_t index = static_cast<TableMgr::index_t>(GUIColors::FIRST_COLOR);
-	TableMgr::index_t finish = static_cast<TableMgr::index_t>(GUIColors::LAST_COLOR);
-	while (index < finish) {
-		auxiliaryColors[static_cast<GUIColors>(index)] = colorTable->GetRowName(index);
-		index++;
+	for (const GUIColors c : EnumIterator<GUIColors>()) {
+		auxiliaryColors[c] = colorTable->GetRowName(UnderType(c));
 	}
 	return auxiliaryColors;
 }

--- a/gemrb/core/DisplayMessage.cpp
+++ b/gemrb/core/DisplayMessage.cpp
@@ -55,15 +55,15 @@ String DisplayMessage::ResolveStringRef(ieStrRef stridx)
 
 DisplayMessage::StrRefs::StrRefs()
 {
-	table.fill(ieStrRef::INVALID);
+	std::fill(table.begin(), table.end(), ieStrRef::INVALID);
 }
 
 bool DisplayMessage::StrRefs::LoadTable(const std::string& name)
 {
 	AutoTable tab = gamedata->LoadTable(name);
 	if (tab) {
-		for (int i = 0; i < static_cast<int>(HCStrings::StringCount); i++) {
-			table[i] = tab->QueryFieldAsStrRef(i, 0);
+		for (const HCStrings i : EnumIterator<HCStrings>()) {
+			table[i] = tab->QueryFieldAsStrRef(UnderType(i), 0);
 		}
 		loadedTable = name;
 	} else {
@@ -74,10 +74,10 @@ bool DisplayMessage::StrRefs::LoadTable(const std::string& name)
 	// only pst has flags and complications
 	// they could have repurposed more verbal constants, but no, they built another layer instead
 	if (tab->QueryField(0, 1) != tab->QueryDefault()) {
-		for (int i = 0; i < static_cast<int>(HCStrings::StringCount); i++) {
-			std::string flag = tab->QueryField(i, 1);
+		for (const HCStrings i : EnumIterator<HCStrings>()) {
+			const std::string& flag = tab->QueryField(UnderType(i), 1);
 			if (flag.length() == 1) {
-				flags[i] = atoi(flag.c_str());
+				flags[i] = flag[0] - '0';
 			} else {
 				flags[i] = -1;
 				const auto& parts = Explode(flag, ':');
@@ -92,18 +92,17 @@ bool DisplayMessage::StrRefs::LoadTable(const std::string& name)
 
 ieStrRef DisplayMessage::StrRefs::Get(HCStrings idx, const Scriptable* speaker) const
 {
-	int sub = static_cast<int>(idx);
-	if (idx < HCStrings::StringCount) {
-		if (flags[sub] == 0 || !speaker || speaker->Type != ST_ACTOR) {
-			return table[sub];
+	if (idx < HCStrings::count) {
+		if (flags[idx] == 0 || !speaker || speaker->Type != ST_ACTOR) {
+			return table[idx];
 		}
 
 		// handle PST personalized strings
 		const Actor* gabber = Scriptable::As<Actor>(speaker);
-		if (flags[sub] == -1) {
-			if (gabber->GetStat(IE_SPECIFIC) == 2) return table[sub]; // TNO
-			if (gabber->GetStat(IE_SPECIFIC) == 8) return extraRefs.at(sub).first; // Annah
-			return extraRefs.at(sub).second; // anyone else
+		if (flags[idx] == -1) {
+			if (gabber->GetStat(IE_SPECIFIC) == 2) return table[idx]; // TNO
+			if (gabber->GetStat(IE_SPECIFIC) == 8) return extraRefs.at(idx).first; // Annah
+			return extraRefs.at(idx).second; // anyone else
 		}
 
 		// handle flags mode 1 and 2
@@ -114,13 +113,13 @@ ieStrRef DisplayMessage::StrRefs::Get(HCStrings idx, const Scriptable* speaker) 
 		const std::array<int, 8> spec2offset = { 0, 7, 5, 6, 4, 3, 2, 1 };
 		if (specific >= 2 && specific <= 9) {
 			pcOffset = spec2offset[specific - 2];
-		} else if (flags[sub] == 2) {
+		} else if (flags[idx] == 2) {
 			pcOffset = spec2offset.size();
 		} else { // rare, but could happen
 			pcOffset = 6; // use Ignus as fallback
 		}
 
-		return ieStrRef(int(table[sub]) + pcOffset);
+		return ieStrRef(int(table[idx]) + pcOffset);
 	}
 	return ieStrRef::INVALID;
 }
@@ -204,7 +203,7 @@ Color DisplayMessage::GetSpeakerColor(String& name, const Scriptable *&speaker) 
 //simply displaying a constant string
 void DisplayMessage::DisplayConstantString(HCStrings stridx, GUIColors color, Scriptable* target) const
 {
-	if (stridx > HCStrings::StringCount) return;
+	if (stridx > HCStrings::count) return;
 	String text = core->GetString(SRefs.Get(stridx, target), STRING_FLAGS::SOUND);
 	DisplayString(text, GetColor(color), target);
 }
@@ -277,7 +276,7 @@ void DisplayMessage::DisplayString(const String& text, GUIColors color, Scriptab
 // blah : whatever
 void DisplayMessage::DisplayConstantStringValue(HCStrings stridx, GUIColors color, ieDword value) const
 {
-	if (stridx > HCStrings::StringCount) return;
+	if (stridx > HCStrings::count) return;
 	String text = core->GetString(SRefs.Get(stridx, nullptr), STRING_FLAGS::SOUND);
 	DisplayMarkupString(fmt::format(DisplayFormatValue, GetColor(color).Packed(), text, value));
 }
@@ -286,7 +285,7 @@ void DisplayMessage::DisplayConstantStringValue(HCStrings stridx, GUIColors colo
 // <charname> - blah blah : whatever
 void DisplayMessage::DisplayConstantStringNameString(HCStrings stridx, GUIColors color, HCStrings stridx2, const Scriptable* actor) const
 {
-	if (stridx > HCStrings::StringCount) return;
+	if (stridx > HCStrings::count) return;
 
 	String name;
 	Color actor_color = GetSpeakerColor(name, actor);
@@ -305,7 +304,7 @@ void DisplayMessage::DisplayConstantStringNameString(HCStrings stridx, GUIColors
 // <charname> - blah blah
 void DisplayMessage::DisplayConstantStringName(HCStrings stridx, const Color& color, const Scriptable* speaker) const
 {
-	if (stridx > HCStrings::StringCount) return;
+	if (stridx > HCStrings::count) return;
 	if(!speaker) return;
 
 	String text = core->GetString(SRefs.Get(stridx, speaker), STRING_FLAGS::SOUND | STRING_FLAGS::SPEECH);
@@ -322,7 +321,7 @@ void DisplayMessage::DisplayConstantStringName(HCStrings stridx, GUIColors color
 //Treats the constant string as a numeric format string, otherwise like the previous method
 void DisplayMessage::DisplayConstantStringNameValue(HCStrings stridx, GUIColors color, const Scriptable* speaker, int value) const
 {
-	if (stridx > HCStrings::StringCount) return;
+	if (stridx > HCStrings::count) return;
 	if(!speaker) return;
 	String fmt = core->GetString(SRefs.Get(stridx, speaker), STRING_FLAGS::SOUND | STRING_FLAGS::SPEECH | STRING_FLAGS::RESOLVE_TAGS);
 	DisplayStringName(fmt::format(fmt, value), GetColor(color), speaker);
@@ -332,7 +331,7 @@ void DisplayMessage::DisplayConstantStringNameValue(HCStrings stridx, GUIColors 
 // <charname> - blah blah <someoneelse>
 void DisplayMessage::DisplayConstantStringAction(HCStrings stridx, GUIColors color, const Scriptable* attacker, const Scriptable* target) const
 {
-	if (stridx > HCStrings::StringCount) return;
+	if (stridx > HCStrings::count) return;
 
 	String name1, name2;
 

--- a/gemrb/core/DisplayMessage.cpp
+++ b/gemrb/core/DisplayMessage.cpp
@@ -375,7 +375,7 @@ void DisplayMessage::DisplayMsgAtLocation(HCStrings strIdx, int type, Scriptable
 {
 	if (!core->HasFeedback(type)) return;
 
-	if (core->HasFeature(GF_ONSCREEN_TEXT)) {
+	if (core->HasFeature(GFFlags::ONSCREEN_TEXT)) {
 		ieStrRef msg = GetStringReference(strIdx, trigger);
 		Color colorRef = GetColor(color);
 		owner->overHead.SetText(core->GetString(msg), true, true, colorRef);
@@ -392,7 +392,7 @@ void DisplayMessage::DisplayMsgCentered(HCStrings strIdx, int type, GUIColors co
 {
 	if (!core->HasFeedback(type)) return;
 
-	if (core->HasFeature(GF_ONSCREEN_TEXT)) {
+	if (core->HasFeature(GFFlags::ONSCREEN_TEXT)) {
 		core->GetGameControl()->SetDisplayText(strIdx, 30);
 	} else {
 		DisplayConstantString(strIdx, color);

--- a/gemrb/core/DisplayMessage.h
+++ b/gemrb/core/DisplayMessage.h
@@ -41,8 +41,7 @@ namespace GemRB {
 /** 
  * Indices for externalized GUI colors in colors.2da
  **/
-enum class GUIColors {
-	FIRST_COLOR,
+enum class GUIColors : uint8_t {
 	TOOLTIP = 0,
 	TOOLTIPBG,
 	MAPICNBG,
@@ -62,7 +61,8 @@ enum class GUIColors {
 	FLOAT_TXT_ACTOR,
 	FLOAT_TXT_INFO,
 	FLOAT_TXT_OTHER,
-	LAST_COLOR
+
+	count
 };
 
 class Scriptable;

--- a/gemrb/core/DisplayMessage.h
+++ b/gemrb/core/DisplayMessage.h
@@ -27,6 +27,7 @@
 #ifndef DISPLAYMESSAGE_H
 #define DISPLAYMESSAGE_H
 
+#include "EnumIndex.h"
 #include "exports.h"
 #include "strrefs.h"
 #include "StringMgr.h"
@@ -71,9 +72,10 @@ class GEM_EXPORT DisplayMessage
 private:
 	struct StrRefs {
 		std::string loadedTable;
-		std::array<ieStrRef, static_cast<int>(HCStrings::StringCount)> table;
-		std::array<int, static_cast<int>(HCStrings::StringCount)> flags;
-		std::map<int, std::pair<ieStrRef, ieStrRef>> extraRefs;
+		EnumArray<HCStrings, ieStrRef> table;
+		EnumArray<HCStrings, int> flags;
+
+		std::map<HCStrings, std::pair<ieStrRef, ieStrRef>> extraRefs;
 
 		StrRefs();
 		bool LoadTable(const std::string& name);

--- a/gemrb/core/EffectQueue.cpp
+++ b/gemrb/core/EffectQueue.cpp
@@ -99,8 +99,8 @@ struct Globals {
 private:
 	Globals()
 	{
-		pstflags = !!core->HasFeature(GF_PST_STATE_FLAGS);
-		iwd2fx = !!core->HasFeature(GF_ENHANCED_EFFECTS);
+		pstflags = core->HasFeature(GFFlags::PST_STATE_FLAGS);
+		iwd2fx = core->HasFeature(GFFlags::ENHANCED_EFFECTS);
 
 		AutoTable efftextTable = gamedata->LoadTable("efftext");
 
@@ -744,7 +744,7 @@ static inline bool check_level(const Actor *target, Effect *fx)
 		}
 		fx->Parameter1 = DICE_ROLL((signed)fx->Parameter1);
 		//this is a hack for PST style diced effects
-		if( core->HasFeature(GF_SAVE_FOR_HALF) ) {
+		if( core->HasFeature(GFFlags::SAVE_FOR_HALF) ) {
 			if (!fx->Resource.IsEmpty() && !fx->Resource.BeginsWith("NEG")) {
 				fx->IsSaveForHalfDamage=1;
 			}
@@ -985,7 +985,7 @@ static inline int check_magic_res(const Actor *actor, const Effect *fx, const Ac
 {
 	const auto& globals = Globals::Get();
 	//don't resist self
-	bool selective_mr = core->HasFeature(GF_SELECTIVE_MAGIC_RES);
+	bool selective_mr = core->HasFeature(GFFlags::SELECTIVE_MAGIC_RES);
 	if (fx->CasterID == actor->GetGlobalID() && selective_mr) {
 		return -1;
 	}
@@ -1064,7 +1064,7 @@ static int check_resistance(Actor* actor, Effect* fx)
 	}
 
 	// handle modifiers of specialist mages
-	if (!core->HasFeature(GF_PST_STATE_FLAGS)) {
+	if (!core->HasFeature(GFFlags::PST_STATE_FLAGS)) {
 		int specialist = KIT_BASECLASS;
 		if (caster) specialist = caster->GetStat(IE_KIT);
 		if (caster && caster->GetMageLevel() && specialist != KIT_BASECLASS) {
@@ -2432,7 +2432,7 @@ bool EffectQueue::CheckIWDTargeting(Scriptable* Owner, Actor* target, ieDword va
 			core->GetGame()->locals->Lookup("CHAPTER", chapter);
 			return DiffCore(chapter, val, rel);
 		case STI_EVASION:
-			if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+			if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 				// NOTE: no idea if this is used in iwd2 too (00misc32 has it set)
 				// FIXME: check for evasion itself
 				if (target->GetThiefLevel() < 2 && target->GetMonkLevel() < 1) {

--- a/gemrb/core/EnumFlags.h
+++ b/gemrb/core/EnumFlags.h
@@ -23,12 +23,15 @@
 
 #include <type_traits>
 
+template <typename ENUM>
+using under_t = typename std::underlying_type<ENUM>::type;
+
 template<typename ENUM_FLAGS>
 constexpr
-typename std::underlying_type<ENUM_FLAGS>::type
+under_t<ENUM_FLAGS>
 UnderType(ENUM_FLAGS a) noexcept
 {
-	return static_cast<typename std::underlying_type<ENUM_FLAGS>::type>(a);
+	return static_cast<under_t<ENUM_FLAGS>>(a);
 }
 
 template<typename ENUM_FLAGS>

--- a/gemrb/core/EnumIndex.h
+++ b/gemrb/core/EnumIndex.h
@@ -1,0 +1,133 @@
+/* GemRB - Infinity Engine Emulator
+ * Copyright (C) 2023 The GemRB Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ *
+ */
+#ifndef EnumIndex_h
+#define EnumIndex_h
+
+#include "EnumFlags.h"
+
+#include <array>
+#include <bitset>
+#include <cassert>
+#include <initializer_list>
+#include <type_traits>
+
+namespace GemRB {
+
+template <typename ENUM>
+using under_t = typename std::underlying_type<ENUM>::type;
+
+template <typename ENUM, typename ARG = under_t<ENUM>>
+// constexpr // FIXME: make this constexpr in c++14, assert cannot be used in constexper before then
+ENUM EnumIndex(ARG val) noexcept
+{
+	static_assert(std::is_same<under_t<ENUM>, ARG>::value, "Will not implicitly convert to EnumIndex");
+	static_assert(std::is_unsigned<under_t<ENUM>>::value, "EnumIndex must be unsigned");
+	assert(val < UnderType(ENUM::count));
+	// cannot static assert here without c++17 if constexpr
+	// static_assert(val < UnderType(ENUM::count), "Trying to create an EnumIndex beoynd the limit.");
+	return static_cast<ENUM>(val);
+}
+
+template <typename ENUM, ENUM BEGIN = ENUM(0), ENUM END = ENUM::count>
+class EnumIterator {
+	static_assert(std::is_unsigned<under_t<ENUM>>::value, "EnumIndex must be unsigned");
+
+	under_t<ENUM> val;
+public:
+	explicit EnumIterator(const ENUM& e) : val(UnderType(e)) {}
+	EnumIterator() : EnumIterator(BEGIN) {}
+	EnumIterator operator++() {
+		++val;
+		return *this;
+	}
+	ENUM operator*() const { return static_cast<ENUM>(val); }
+	EnumIterator begin() { return *this; }
+	EnumIterator end() { return EnumIterator(END); }
+	bool operator!=(const EnumIterator& i) { return val != i.val; }
+};
+
+template <typename ENUM, typename T>
+class EnumArray {
+	static_assert(std::is_unsigned<under_t<ENUM>>::value, "EnumIndex must be unsigned");
+
+	using array_t = std::array<T, UnderType(ENUM::count)>;
+	array_t array;
+public:
+	static constexpr auto size = UnderType(ENUM::count);
+	using KeyIterator_t = EnumIterator<ENUM>;
+	
+	KeyIterator_t KeyIterator() const { return KeyIterator_t(); }
+	
+	template<typename...ELEMS>
+	explicit constexpr EnumArray(ELEMS&&...e) : array{{std::forward<ELEMS>(e)...}} {}
+	
+	constexpr EnumArray() = default;
+	
+	constexpr
+	const T& operator[](ENUM key) const {
+	
+		return array[UnderType(key)];
+	}
+	
+	T& operator[](ENUM key) {
+		return array[UnderType(key)];
+	}
+	
+	typename array_t::iterator begin() {
+		return array.begin();
+	}
+	
+	typename array_t::iterator end() {
+		return array.end();
+	}
+};
+
+template <typename ENUM>
+class EnumBitset {
+	static_assert(std::is_unsigned<under_t<ENUM>>::value, "EnumIndex must be unsigned");
+
+	std::bitset<UnderType(ENUM::count)> bits;
+public:
+	static constexpr auto size = UnderType(ENUM::count);
+		
+	constexpr EnumBitset(under_t<ENUM> value) : bits(value) {}
+	constexpr EnumBitset() = default;
+	
+	constexpr
+	bool operator[](ENUM key) const {
+		return bits[UnderType(key)];
+	}
+	
+	typename std::bitset<UnderType(ENUM::count)>::reference
+	operator[](ENUM key) {
+		return bits[UnderType(key)];
+	}
+	
+	void SetAll() {
+		bits.set();
+	}
+	
+	void ClearAll() {
+		bits.reset();
+	}
+};
+
+}
+#endif /* EnumIndex_h */

--- a/gemrb/core/EnumIndex.h
+++ b/gemrb/core/EnumIndex.h
@@ -30,9 +30,6 @@
 
 namespace GemRB {
 
-template <typename ENUM>
-using under_t = typename std::underlying_type<ENUM>::type;
-
 template <typename ENUM, typename ARG = under_t<ENUM>>
 // constexpr // FIXME: make this constexpr in c++14, assert cannot be used in constexper before then
 ENUM EnumIndex(ARG val) noexcept

--- a/gemrb/core/FogRenderer.h
+++ b/gemrb/core/FogRenderer.h
@@ -27,6 +27,7 @@
 #include "globals.h"
 
 #include "Bitmap.h"
+#include "EnumIndex.h"
 #include "Region.h"
 #include "Sprite2D.h"
 
@@ -71,7 +72,7 @@ class GEM_EXPORT FogRenderer {
 		Point end;
 		Point p0;
 
-		enum FogDirection : uint8_t {
+		enum class Direction : uint8_t {
 			O,
 			N = 1,
 			W = 2,
@@ -80,20 +81,24 @@ class GEM_EXPORT FogRenderer {
 			SW = S|W, // 6
 			E = 8,
 			NE = N|E, // 9
-			SE = S|E  // 12
+			SE = S|E, // 12
+			count
 		};
 
 		// Size of Fog-Of-War shadow tile (and bitmap)
 		static constexpr int CELL_SIZE = 32;
-		static constexpr BlitFlags BAM_FLAGS[] = {
+		static constexpr EnumArray<Direction, BlitFlags> BAM_FLAGS {
 			BlitFlags::NONE, BlitFlags::NONE, BlitFlags::NONE, BlitFlags::NONE,
 			BlitFlags::MIRRORY, BlitFlags::NONE, BlitFlags::MIRRORY,
 			BlitFlags::NONE, BlitFlags::MIRRORX, BlitFlags::MIRRORX,
-			BlitFlags::NONE, BlitFlags::NONE, static_cast<BlitFlags>(BlitFlags::MIRRORX | BlitFlags::MIRRORY)
+			BlitFlags::NONE, BlitFlags::NONE, BlitFlags::MIRRORX | BlitFlags::MIRRORY
 		};
 
 		static constexpr BlitFlags OPAQUE_FOG = BlitFlags::NONE;
-		static constexpr BlitFlags TRANSPARENT_FOG = static_cast<BlitFlags>(BlitFlags::HALFTRANS | BlitFlags::BLENDED);
+		static constexpr BlitFlags TRANSPARENT_FOG = BlitFlags::HALFTRANS | BlitFlags::BLENDED;
+	
+		static EnumArray<Direction, Holder<Sprite2D>> LoadFogSprites();
+		EnumArray<Direction, Holder<Sprite2D>> fogSprites;
 	public:
 		FogRenderer(Video*, bool doBAMRendering = false);
 
@@ -103,14 +108,14 @@ class GEM_EXPORT FogRenderer {
 		Point ConvertPointToScreen(int x, int y) const;
 		static Point ConvertPointToFog(Point p);
 		void DrawExploredCell(Point cellPoint, const Bitmap *mask);
-		void DrawFogCellBAM(Point p, FogDirection direction, BlitFlags flags);
-		void DrawFogCellVertices(Point p, FogDirection direction, BlitFlags flags);
-		bool DrawFogCellByDirection(Point p, FogDirection direction, BlitFlags flags);
-		bool DrawFogCellByDirectionBAMs(Point p, FogDirection direction, BlitFlags flags);
-		bool DrawFogCellByDirectionVertices(Point p, FogDirection direction, BlitFlags flags);
-		void DrawFogSmoothing(Point p, FogDirection direction, BlitFlags flags, FogDirection adjacentDir);
+		void DrawFogCellBAM(Point p, Direction direction, BlitFlags flags);
+		void DrawFogCellVertices(Point p, Direction direction, BlitFlags flags);
+		bool DrawFogCellByDirection(Point p, Direction direction, BlitFlags flags);
+		bool DrawFogCellByDirectionBAMs(Point p, Direction direction, BlitFlags flags);
+		bool DrawFogCellByDirectionVertices(Point p, Direction direction, BlitFlags flags);
+		void DrawFogSmoothing(Point p, Direction direction, BlitFlags flags, Direction adjacentDir);
 		void DrawVisibleCell(Point cellPoint, const Bitmap *mask);
-		void DrawVPBorder(Point p, FogDirection direction, const Region& r, BlitFlags flags);
+		void DrawVPBorder(Point p, Direction direction, const Region& r, BlitFlags flags);
 		void DrawVPBorders();
 		void FillFog(Point p, int numRowItems, BlitFlags flags);
 		static bool IsUncovered(Point cellPoint, const Bitmap *mask);

--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -616,7 +616,7 @@ void GameControl::DrawSelf(const Region& screen, const Region& /*clip*/)
 		}
 	}
 
-	if (core->HasFeature(GF_ONSCREEN_TEXT) && !DisplayText.empty()) {
+	if (core->HasFeature(GFFlags::ONSCREEN_TEXT) && !DisplayText.empty()) {
 		Font::PrintColors colors = { displaymsg->GetColor(GUIColors::FLOAT_TXT_INFO), ColorBlack };
 		core->GetTextFont()->Print(screen, DisplayText, IE_FONT_ALIGN_CENTER | IE_FONT_ALIGN_MIDDLE, colors);
 		if (!(DialogueFlags & DF_FREEZE_SCRIPTS)) {
@@ -1139,7 +1139,7 @@ String GameControl::TooltipText() const {
 
 	static String tip; // only one game control and we return a const& so cant be temporary.
 	// pst ignores TalkCount
-	if (core->HasFeature(GF_PST_STATE_FLAGS)) {
+	if (core->HasFeature(GFFlags::PST_STATE_FLAGS)) {
 		tip = actor->GetName();
 	} else {
 		tip = actor->GetDefaultName();
@@ -1149,7 +1149,7 @@ String GameControl::TooltipText() const {
 	int maxhp = actor->GetStat(IE_MAXHITPOINTS);
 
 	if (actor->InParty) {
-		if (core->HasFeature(GF_ONSCREEN_TEXT)) {
+		if (core->HasFeature(GFFlags::ONSCREEN_TEXT)) {
 			tip += L": ";
 		} else {
 			tip += L"\n";
@@ -2044,7 +2044,7 @@ bool GameControl::OnMouseDown(const MouseEvent& me, unsigned short Mod)
 
 	switch(me.button) {
 	case GEM_MB_MENU: //right click.
-		if (core->HasFeature(GF_HAS_FLOAT_MENU) && !Mod) {
+		if (core->HasFeature(GFFlags::HAS_FLOAT_MENU) && !Mod) {
 			ScriptEngine::FunctionParameters params;
 			params.push_back(ScriptEngine::Parameter(p));
 			core->GetGUIScriptEngine()->RunFunction("GUICommon", "OpenFloatMenuWindow", params, false);
@@ -2081,7 +2081,7 @@ static const ResRefMap<std::vector<ResRef>> pstWMapExits {
 // has to be a plain travel region and on the whitelist
 bool GameControl::ShouldTriggerWorldMap(const Actor *pc) const
 {
-	if (!core->HasFeature(GF_TEAM_MOVEMENT)) return false;
+	if (!core->HasFeature(GFFlags::TEAM_MOVEMENT)) return false;
 
 	bool keyAreaVisited = CheckVariable(pc, "AR0500_Visited", "GLOBAL") == 1;
 	if (!keyAreaVisited) return false;
@@ -2118,7 +2118,7 @@ bool GameControl::OnMouseUp(const MouseEvent& me, unsigned short Mod)
 	Point p = ConvertPointFromScreen(me.Pos()) + vpOrigin;
 	bool isDoubleClick = me.repeats == 2;
 	bool tryToRun = isDoubleClick;
-	if (core->HasFeature(GF_HAS_FLOAT_MENU)) {
+	if (core->HasFeature(GFFlags::HAS_FLOAT_MENU)) {
 		tryToRun |= Mod & GEM_MOD_SHIFT;
 	}
 
@@ -2127,7 +2127,7 @@ bool GameControl::OnMouseUp(const MouseEvent& me, unsigned short Mod)
 		ieDword actionLevel;
 		core->GetDictionary()->Lookup("ActionLevel", actionLevel);
 		if (target_mode != TARGET_MODE_NONE || actionLevel) {
-			if (!core->HasFeature(GF_HAS_FLOAT_MENU)) {
+			if (!core->HasFeature(GFFlags::HAS_FLOAT_MENU)) {
 				SetTargetMode(TARGET_MODE_NONE);
 			}
 			// update the action bar
@@ -2201,10 +2201,10 @@ bool GameControl::OnMouseUp(const MouseEvent& me, unsigned short Mod)
 	}
 
 	// handle movement/travel, but not if we just opened the float window
-	if ((!core->HasFeature(GF_HAS_FLOAT_MENU) || me.button != GEM_MB_MENU) && lastCursor != IE_CURSOR_BLOCKED && lastCursor != IE_CURSOR_NORMAL) {
+	if ((!core->HasFeature(GFFlags::HAS_FLOAT_MENU) || me.button != GEM_MB_MENU) && lastCursor != IE_CURSOR_BLOCKED && lastCursor != IE_CURSOR_NORMAL) {
 		// pst has different mod keys
 		int modKey = GEM_MOD_SHIFT;
-		if (core->HasFeature(GF_HAS_FLOAT_MENU)) modKey = GEM_MOD_CTRL;
+		if (core->HasFeature(GFFlags::HAS_FLOAT_MENU)) modKey = GEM_MOD_CTRL;
 		CommandSelectedMovement(p, Mod & modKey, tryToRun);
 	}
 	ClearMouseState();
@@ -2240,7 +2240,7 @@ void GameControl::PerformSelectedAction(const Point& p)
 	} else if (overInfoPoint) {
 		if (overInfoPoint->Type==ST_TRAVEL && target_mode == TARGET_MODE_NONE) {
 			ieDword exitID = overInfoPoint->GetGlobalID();
-			if (core->HasFeature(GF_TEAM_MOVEMENT)) {
+			if (core->HasFeature(GFFlags::TEAM_MOVEMENT)) {
 				// pst forces everyone to travel (eg. ar0201 outside_portal)
 				int i = game->GetPartySize(false);
 				while(i--) {
@@ -2401,7 +2401,7 @@ void GameControl::PerformActionOn(Actor *actor)
 			if (!game->selected.empty()) {
 				//if we are in PST modify this to NO!
 				Actor *source;
-				if (core->HasFeature(GF_PROTAGONIST_TALKS) ) {
+				if (core->HasFeature(GFFlags::PROTAGONIST_TALKS) ) {
 					source = game->GetPC(0, false); //protagonist
 				} else {
 					source = core->GetFirstSelectedPC(false);

--- a/gemrb/core/GUI/Label.cpp
+++ b/gemrb/core/GUI/Label.cpp
@@ -54,7 +54,7 @@ void Label::SetText(String string)
 {
 	Text = std::move(string);
 	if (Alignment == IE_FONT_ALIGN_CENTER
-		&& core->HasFeature( GF_LOWER_LABEL_TEXT )) {
+		&& core->HasFeature( GFFlags::LOWER_LABEL_TEXT )) {
 		StringToLower(Text);
 	}
 	MarkDirty();
@@ -76,7 +76,7 @@ void Label::SetAlignment(unsigned char newAlignment)
 		newAlignment |= IE_FONT_NO_CALC;
 	}
 	Alignment = newAlignment;
-	if (newAlignment == IE_FONT_ALIGN_CENTER && core->HasFeature(GF_LOWER_LABEL_TEXT)) {
+	if (newAlignment == IE_FONT_ALIGN_CENTER && core->HasFeature(GFFlags::LOWER_LABEL_TEXT)) {
 		StringToLower(Text);
 	}
 	MarkDirty();

--- a/gemrb/core/GUI/TextArea.cpp
+++ b/gemrb/core/GUI/TextArea.cpp
@@ -264,7 +264,7 @@ void TextArea::DrawSelf(const Region& drawFrame, const Region& /*clip*/)
 
 void TextArea::SetSpeakerPicture(Holder<Sprite2D> pic)
 {
-	if (core->HasFeature(GF_DIALOGUE_SCROLLS)) {
+	if (core->HasFeature(GFFlags::DIALOGUE_SCROLLS)) {
 		// FIXME: there isnt a specific reason why animatied dialog couldnt also use pics
 		// However, PST does not and the animation makes the picture spaz currently
 		return;
@@ -337,7 +337,7 @@ void TextArea::UpdateScrollview()
 		ieDword anim = 0;
 		int y = 0;
 
-		if (core->HasFeature(GF_DIALOGUE_SCROLLS)) {
+		if (core->HasFeature(GFFlags::DIALOGUE_SCROLLS)) {
 			anim = 500;
 			y = 9999999; // FIXME: properly calculate the "bottom"?
 		} else {
@@ -355,7 +355,7 @@ void TextArea::UpdateScrollview()
 		// FIXME: must update before the scroll, but this should be automaticly done as a reaction to changing sizes/origins of subviews
 		scrollview.Update();
 		scrollview.ScrollTo(Point(0, -y), anim);
-	} else if (!core->HasFeature(GF_DIALOGUE_SCROLLS)) {
+	} else if (!core->HasFeature(GFFlags::DIALOGUE_SCROLLS)) {
 		scrollview.Update();
 	}
 	
@@ -636,7 +636,7 @@ void TextArea::ClearSelectOptions()
 	selectOptions = NULL;
 	optionContext = OptionContext();
 
-	if (!core->HasFeature(GF_DIALOGUE_SCROLLS)) {
+	if (!core->HasFeature(GFFlags::DIALOGUE_SCROLLS)) {
 		UpdateScrollview();
 	}
 }

--- a/gemrb/core/GUI/WindowManager.cpp
+++ b/gemrb/core/GUI/WindowManager.cpp
@@ -445,11 +445,11 @@ void WindowManager::DrawMouse() const
 
 	// pst displays actor name tooltips overhead, not at the mouse position
 	const GameControl* gc = core->GetGameControl();
-	if (core->HasFeature(GF_ONSCREEN_TEXT) && gc) {
+	if (core->HasFeature(GFFlags::ONSCREEN_TEXT) && gc) {
 		tooltipPos.y -= gc->GetOverheadOffset();
 	}
 
-	if (tooltip.tt.TextSize().IsZero() || core->HasFeature(GF_ONSCREEN_TEXT)) {
+	if (tooltip.tt.TextSize().IsZero() || core->HasFeature(GFFlags::ONSCREEN_TEXT)) {
 		DrawCursor(cursorPos);
 	}
 	DrawTooltip(tooltipPos);

--- a/gemrb/core/GUI/WorldMapControl.cpp
+++ b/gemrb/core/GUI/WorldMapControl.cpp
@@ -64,7 +64,8 @@ WorldMapControl::WorldMapControl(const Region& frame, Font *font, const Color &n
 	ControlEventHandler handler = [this](const Control* /*this*/) {
 		//this also updates visible locations
 		WorldMap* map = core->GetWorldMap();
-		map->CalculateDistances(currentArea, GetValue());
+		uint8_t dir = static_cast<uint8_t>(GetValue());
+		map->CalculateDistances(currentArea, EnumIndex<WMPDirection>(dir));
 	};
 	
 	SetAction(handler, Control::ValueChange);

--- a/gemrb/core/GUI/WorldMapControl.cpp
+++ b/gemrb/core/GUI/WorldMapControl.cpp
@@ -54,7 +54,7 @@ WorldMapControl::WorldMapControl(const Region& frame, Font *font, const Color &n
 
 	//if there is no trivial area, look harder
 	if (!worldmap->GetArea(currentArea, (unsigned int &) entry) &&
-		core->HasFeature(GF_FLEXIBLE_WMAP) ) {
+		core->HasFeature(GFFlags::FLEXIBLE_WMAP) ) {
 		const WMPAreaEntry *m = worldmap->FindNearestEntry(currentArea, (unsigned int &) entry);
 		if (m) {
 			currentArea = m->AreaResRef;
@@ -105,7 +105,7 @@ void WorldMapControl::DrawSelf(const Region& rgn, const Region& /*clip*/)
 		Point offset = MapToScreen(m->pos);
 		Holder<Sprite2D> icon = m->GetMapIcon(worldmap->bam);
 		if (icon) {
-			BlitFlags flags =  core->HasFeature(GF_AUTOMAP_INI) ? BlitFlags::BLENDED : (BlitFlags::BLENDED | BlitFlags::COLOR_MOD);
+			BlitFlags flags =  core->HasFeature(GFFlags::AUTOMAP_INI) ? BlitFlags::BLENDED : (BlitFlags::BLENDED | BlitFlags::COLOR_MOD);
 			if (m == Area && m->HighlightSelected()) {
 				video->BlitGameSprite(icon, offset, flags, hoverAnim.Current());
 			} else if (!(m->GetAreaStatus() & WMP_ENTRY_VISITED)) {
@@ -120,7 +120,7 @@ void WorldMapControl::DrawSelf(const Region& rgn, const Region& /*clip*/)
 				Point indicatorPos = offset - icon->Frame.origin;
 				indicatorPos.x += areaIndicator->Frame.x + icon->Frame.w / 2 - areaIndicator->Frame.w / 2;
 				// bg2 centered also vertically, while the rest didn't
-				if (core->HasFeature(GF_JOURNAL_HAS_SECTIONS)) {
+				if (core->HasFeature(GFFlags::JOURNAL_HAS_SECTIONS)) {
 					indicatorPos.y += areaIndicator->Frame.y + icon->Frame.h / 2 - areaIndicator->Frame.h / 2;
 				}
 				potentialIndicators.push_back(indicatorPos);

--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -375,7 +375,7 @@ int Game::LeaveParty (Actor* actor)
 	actor->SetPersistent(0);
 	NPCs.push_back( actor );
 
-	if (core->HasFeature( GF_HAS_DPLAYER )) {
+	if (core->HasFeature( GFFlags::HAS_DPLAYER )) {
 		// we must reset various existing scripts
 		actor->SetScript("", SCR_DEFAULT );
 		actor->SetScript("", SCR_CLASS, false);
@@ -460,7 +460,7 @@ int Game::JoinParty(Actor* actor, int join)
 	if (join&JP_JOIN) {
 		//update kit abilities of actor
 		ieDword baseclass = 0;
-		if (core->HasFeature(GF_LEVELSLOT_PER_CLASS)) {
+		if (core->HasFeature(GFFlags::LEVELSLOT_PER_CLASS)) {
 			// get the class for iwd2; luckily there are no NPCs, everyone joins at level 1, so multi-kit annoyances can be ignored
 			baseclass = actor->GetBase(IE_CLASS);
 		}
@@ -704,7 +704,7 @@ Map *Game::GetMap(const ResRef &areaname, bool change)
 	// call area customization script for PST
 	// moved here because the current area is set here
 	ScriptEngine *sE = core->GetGUIScriptEngine();
-	if (core->HasFeature(GF_AREA_OVERRIDE) && sE) {
+	if (core->HasFeature(GFFlags::AREA_OVERRIDE) && sE) {
 		// area ResRef is accessible by GemRB.GetGameString (STR_AREANAME)
 		sE->RunFunction("Maze", "CustomizeArea");
 	}
@@ -866,7 +866,7 @@ int Game::LoadMap(const ResRef &resRef, bool loadscreen)
 	//this feature exists in all blackisle games but not in bioware games
 	// make sure to do it after other actors, so UpdateFog can run and
 	// the ignore_can_see key actually filters spawns
-	if (core->HasFeature(GF_SPAWN_INI)) {
+	if (core->HasFeature(GFFlags::SPAWN_INI)) {
 		newMap->UpdateFog();
 		newMap->LoadIniSpawn();
 	}
@@ -1014,7 +1014,7 @@ bool Game::AddJournalEntry(ieStrRef strref, int Section, int Group)
 			je->Section = (ieByte) Section;
 			je->Group = (ieByte) Group;
 			ieDword chapter = 0;
-			if (!core->HasFeature(GF_NO_NEW_VARIABLES)) {
+			if (!core->HasFeature(GFFlags::NO_NEW_VARIABLES)) {
 				locals->Lookup("CHAPTER", chapter);
 			}
 			je->Chapter = (ieByte) chapter;
@@ -1025,7 +1025,7 @@ bool Game::AddJournalEntry(ieStrRef strref, int Section, int Group)
 	je = new GAMJournalEntry;
 	je->GameTime = GameTime;
 	ieDword chapter = 0;
-	if (!core->HasFeature(GF_NO_NEW_VARIABLES)) {
+	if (!core->HasFeature(GFFlags::NO_NEW_VARIABLES)) {
 		locals->Lookup("CHAPTER", chapter);
 	}
 	je->Chapter = (ieByte) chapter;
@@ -1207,7 +1207,7 @@ void Game::ShareXP(int xp, int flags) const
 			xp = -xp;
 			strIdx = HCStrings::LostXP;
 		}
-		if (core->HasFeature(GF_ONSCREEN_TEXT)) {
+		if (core->HasFeature(GFFlags::ONSCREEN_TEXT)) {
 			ieStrRef complaint = DisplayMessage::GetStringReference(strIdx);
 			String text = fmt::format(L"{}: {}", core->GetString(complaint), xp);
 			core->GetGameControl()->SetDisplayText(text, core->Time.ai_update_time * 4);
@@ -1303,7 +1303,7 @@ void Game::IncrementChapter() const
 	ieDword chapter = (ieDword) -1;
 	locals->Lookup("CHAPTER",chapter);
 	//increment chapter only if it exists
-	locals->SetAt("CHAPTER", chapter+1, core->HasFeature(GF_NO_NEW_VARIABLES) );
+	locals->SetAt("CHAPTER", chapter+1, core->HasFeature(GFFlags::NO_NEW_VARIABLES) );
 	//clear statistics
 	for (const auto& pc : PCs) {
 		//all PCs must have this!
@@ -1452,7 +1452,7 @@ bool Game::EveryoneDead() const
 	if (protagonist==PM_NO) {
 		const Actor *nameless = PCs[0];
 		// don't trigger this outside pst, our game loop depends on it
-		if (nameless->GetStat(IE_STATE_ID)&STATE_NOSAVE && core->HasFeature(GF_PST_STATE_FLAGS)) {
+		if (nameless->GetStat(IE_STATE_ID)&STATE_NOSAVE && core->HasFeature(GFFlags::PST_STATE_FLAGS)) {
 			if (area->INISpawn) {
 				area->INISpawn->RespawnNameless();
 			}
@@ -1686,7 +1686,7 @@ bool Game::CanPartyRest(int checks, ieStrRef* err) const
 			return false;
 		}
 
-		if (core->HasFeature(GF_AREA_OVERRIDE)) {
+		if (core->HasFeature(GFFlags::AREA_OVERRIDE)) {
 			// pst doesn't care about area types (see comments near AF_NOSAVE definition)
 			// and repurposes these area flags!
 			if ((area->AreaFlags & (AF_TUTORIAL|AF_DEADMAGIC)) == (AF_TUTORIAL|AF_DEADMAGIC)) {
@@ -1706,7 +1706,7 @@ bool Game::CanPartyRest(int checks, ieStrRef* err) const
 			// you may not rest here, find an inn
 			if (!(area->AreaType & (AT_FOREST|AT_DUNGEON|AT_CAN_REST_INDOORS))) {
 				// at least in iwd1, the outdoor bit is not enough
-				if (area->AreaType & AT_OUTDOOR && !core->HasFeature(GF_AREA_VISITED_VAR)) {
+				if (area->AreaType & AT_OUTDOOR && !core->HasFeature(GFFlags::AREA_VISITED_VAR)) {
 					return true;
 				}
 				*err = DisplayMessage::GetStringReference(HCStrings::MayNotRest);
@@ -2030,7 +2030,7 @@ const Color *Game::GetGlobalTint() const
 	if (map->AreaFlags&AF_DREAM) {
 		return &DreamTint;
 	}
-	bool pstDayNight = map->AreaType & AT_PST_DAYNIGHT && core->HasFeature(GF_PST_STATE_FLAGS);
+	bool pstDayNight = map->AreaType & AT_PST_DAYNIGHT && core->HasFeature(GFFlags::PST_STATE_FLAGS);
 	if ((map->AreaType & (AT_OUTDOOR | AT_DAYNIGHT | AT_EXTENDED_NIGHT)) == (AT_OUTDOOR | AT_DAYNIGHT) || pstDayNight) {
 		//get daytime colour
 		ieDword daynight = core->Time.GetHour(GameTime);

--- a/gemrb/core/GameData.cpp
+++ b/gemrb/core/GameData.cpp
@@ -571,7 +571,7 @@ int GameData::GetSpellAbilityDie(const Actor *target, int which)
 
 int GameData::GetTrapSaveBonus(ieDword level, int cls)
 {
-	if (!core->HasFeature(GF_3ED_RULES)) return 0;
+	if (!core->HasFeature(GFFlags::RULES_3ED)) return 0;
 
 	AutoTable trapSaveBonus = LoadTable("trapsave", true);
 	if (!trapSaveBonus) return 0;
@@ -945,7 +945,7 @@ const std::vector<int>& GameData::GetBonusSpells(int ability)
 		// iwd2 has mxsplbon instead, since all casters get a bonus with high enough stats (which are not always wisdom)
 		// luckily, they both use the same format
 		AutoTable mxSplBon;
-		if (core->HasFeature(GF_3ED_RULES)) {
+		if (core->HasFeature(GFFlags::RULES_3ED)) {
 			mxSplBon = LoadTable("mxsplbon");
 		} else {
 			mxSplBon = LoadTable("mxsplwis");

--- a/gemrb/core/GameScript/Actions.cpp
+++ b/gemrb/core/GameScript/Actions.cpp
@@ -1876,7 +1876,7 @@ void GameScript::DestroySelf(Scriptable* Sender, Action* /*parameters*/)
 	}
 	actor->DestroySelf();
 	// needeed in pst #532, but softly breaks bg2 #1179
-	if (actor == core->GetCutSceneRunner() && core->HasFeature(GF_PST_STATE_FLAGS)) {
+	if (actor == core->GetCutSceneRunner() && core->HasFeature(GFFlags::PST_STATE_FLAGS)) {
 		core->SetCutSceneMode(false);
 	}
 }
@@ -2174,7 +2174,7 @@ void GameScript::NIDSpecial2(Scriptable* Sender, Action* /*parameters*/)
 	}
 
 	// pst enables worldmap travel only after visiting the lower ward
-	bool keyAreaVisited = core->HasFeature(GF_TEAM_MOVEMENT) && CheckVariable(Sender, "AR0500_Visited", "GLOBAL") == 1;
+	bool keyAreaVisited = core->HasFeature(GFFlags::TEAM_MOVEMENT) && CheckVariable(Sender, "AR0500_Visited", "GLOBAL") == 1;
 	if (direction == WMPDirection::NONE && !keyAreaVisited) {
 		Sender->ReleaseCurrentAction();
 		return;
@@ -2319,7 +2319,7 @@ void GameScript::SetDoorFlag(Scriptable* Sender, Action* parameters)
 	}
 	// take care of iwd2 flag bit differences as in AREIMporter's FixIWD2DoorFlags
 	// ... it matters for exactly 1 user from the original data (20ctord3.bcs)
-	if (core->HasFeature(GF_3ED_RULES) && flag == DOOR_KEY) {
+	if (core->HasFeature(GFFlags::RULES_3ED) && flag == DOOR_KEY) {
 		flag = DOOR_TRANSPARENT;
 	}
 
@@ -2722,7 +2722,7 @@ void GameScript::Deactivate(Scriptable* Sender, Action* parameters)
 	//PST allows deactivating of containers
 	//but IWD doesn't, ar9705 chests rely on it (if this is changed, make sure they are all still selectable!)
 	//FIXME: add a new game flag / differentiate more container flags
-	if (tar->Type == ST_CONTAINER && !core->HasFeature(GF_SPECIFIC_DMG_BONUS)) {
+	if (tar->Type == ST_CONTAINER && !core->HasFeature(GFFlags::SPECIFIC_DMG_BONUS)) {
 		static_cast<Container*>(tar)->Flags |= CONT_DISABLED;
 		return;
 	}
@@ -2876,7 +2876,7 @@ void GameScript::AddExperienceParty(Scriptable* /*Sender*/, Action* parameters)
 	core->PlaySound(DS_GOTXP, SFX_CHAN_ACTIONS);
 }
 
-//this needs moncrate.2da, but otherwise independent from GF_CHALLENGERATING
+//this needs moncrate.2da, but otherwise independent from GFFlags::CHALLENGERATING
 void GameScript::AddExperiencePartyCR(Scriptable* /*Sender*/, Action* parameters)
 {
 	core->GetGame()->ShareXP(parameters->int0Parameter, SX_DIVIDE|SX_CR);
@@ -2956,7 +2956,7 @@ void GameScript::JoinParty(Scriptable* Sender, Action* parameters)
 	/* i'm not sure this is required here at all */
 	SetBeenInPartyFlags(Sender, parameters);
 	act->SetBase( IE_EA, EA_PC );
-	if (core->HasFeature( GF_HAS_DPLAYER )) {
+	if (core->HasFeature( GFFlags::HAS_DPLAYER )) {
 		/* we must reset various existing scripts */
 		act->SetScript( "DEFAULT", AI_SCRIPT_LEVEL, true );
 		act->SetScript(ResRef(), SCR_RACE, true);
@@ -4456,7 +4456,7 @@ void GameScript::PickPockets(Scriptable *Sender, Action* parameters)
 		return;
 	}
 
-	static bool turnHostile = core->HasFeature(GF_STEAL_IS_ATTACK);
+	static bool turnHostile = core->HasFeature(GFFlags::STEAL_IS_ATTACK);
 	static bool reportFailure = core->HasFeedback(FT_MISC);
 	static bool breakInvisibility = true;
 	AutoTable ppBehave = gamedata->LoadTable("ppbehave");
@@ -4487,7 +4487,7 @@ void GameScript::PickPockets(Scriptable *Sender, Action* parameters)
 	int skill = snd->GetStat(IE_PICKPOCKET);
 	int tgt = scr->GetStat(IE_PICKPOCKET);
 	int check;
-	if (core->HasFeature(GF_3ED_RULES)) {
+	if (core->HasFeature(GFFlags::RULES_3ED)) {
 		skill = snd->GetSkill(IE_PICKPOCKET);
 		int roll = core->Roll(1, 20, 0);
 		int level = scr->GetXPLevel(true);
@@ -4568,7 +4568,7 @@ void GameScript::PickPockets(Scriptable *Sender, Action* parameters)
 	core->GetGame()->ShareXP(xp, SX_DIVIDE);
 
 	if (ret == MIC_FULL && snd->InParty) {
-		if (!core->HasFeature(GF_PST_STATE_FLAGS)) snd->VerbalConstant(VB_INVENTORY_FULL);
+		if (!core->HasFeature(GFFlags::PST_STATE_FLAGS)) snd->VerbalConstant(VB_INVENTORY_FULL);
 		if (reportFailure) displaymsg->DisplayMsgAtLocation(HCStrings::PickpocketInventoryFull, FT_ANY, Sender, Sender, GUIColors::WHITE);
 	}
 	Sender->ReleaseCurrentAction();
@@ -5894,7 +5894,7 @@ void GameScript::ExportParty(Scriptable* /*Sender*/, Action* parameters)
 
 void GameScript::SaveGame(Scriptable* /*Sender*/, Action* parameters)
 {
-	if (core->HasFeature(GF_STRREF_SAVEGAME)) {
+	if (core->HasFeature(GFFlags::STRREF_SAVEGAME)) {
 		std::string basename = "Auto-Save";
 		AutoTable tab = gamedata->LoadTable("savegame");
 		if (tab) {

--- a/gemrb/core/GameScript/GSUtils.cpp
+++ b/gemrb/core/GameScript/GSUtils.cpp
@@ -115,7 +115,7 @@ void InitScriptTables()
 	}
 
 	// see note in voodooconst.h
-	if (core->HasFeature(GF_AREA_OVERRIDE)) {
+	if (core->HasFeature(GFFlags::AREA_OVERRIDE)) {
 		MAX_OPERATING_DISTANCE = 40*3;
 	}
 }
@@ -508,7 +508,7 @@ void DisplayStringCore(Scriptable* const Sender, ieStrRef Strref, int flags, con
 	// PST does not echo verbal constants in the console, their strings
 	// actually contain development related identifying comments
 	// thus the console flag is unset.
-	if (core->HasFeature(GF_ONSCREEN_TEXT) || !charactersubtitles) {
+	if (core->HasFeature(GFFlags::ONSCREEN_TEXT) || !charactersubtitles) {
 		flags &= ~DS_CONSOLE;
 	}
 
@@ -1291,7 +1291,7 @@ void BeginDialog(Scriptable* Sender, const Action* parameters, int Flags)
 
 	// When dialog is initiated in IWD2 it directly clears the action queue of all party members.
 	// Bubb: in this case, and only this case as far as I can tell, it specifically preserves spell actions.
-	if (core->HasFeature(GF_3ED_RULES)) {
+	if (core->HasFeature(GFFlags::RULES_3ED)) {
 		const Game* game = core->GetGame();
 		for (int i = game->GetPartySize(false) - 1; i >= 0; --i) {
 			Actor *pc = game->GetPC(i, false);
@@ -2002,7 +2002,7 @@ bool IsInObjectRect(const Point &pos, const Region &rect)
 	if (rect.w <= 0) return true;
 
 	// iwd2: testing shows the first point must be 0.0 for matching to work
-	if (core->HasFeature(GF_3ED_RULES) && !rect.origin.IsZero()) {
+	if (core->HasFeature(GFFlags::RULES_3ED) && !rect.origin.IsZero()) {
 		return false;
 	}
 
@@ -2659,7 +2659,7 @@ void SpellCore(Scriptable *Sender, Action *parameters, int flags)
 {
 	ResRef spellResRef;
 	int level = 0;
-	static bool third = core->HasFeature(GF_3ED_RULES);
+	static bool third = core->HasFeature(GFFlags::RULES_3ED);
 
 	// handle iwd2 marked spell casting (MARKED_SPELL is 0)
 	// NOTE: supposedly only casting via SpellWait checks this, so refactor if needed
@@ -2920,7 +2920,7 @@ void AddXPCore(const Action *parameters, bool divide)
 {
 	AutoTable xptable;
 
-	if (core->HasFeature(GF_HAS_EXPTABLE)) {
+	if (core->HasFeature(GFFlags::HAS_EXPTABLE)) {
 		xptable = gamedata->LoadTable("exptable");
 	} else {
 		xptable = gamedata->LoadTable("xplist");

--- a/gemrb/core/GameScript/GameScript.cpp
+++ b/gemrb/core/GameScript/GameScript.cpp
@@ -1430,8 +1430,8 @@ void InitializeIEScript()
 
 	PluginMgr::Get()->RegisterCleanup(CleanupIEScript);
 
-	NoCreate = core->HasFeature(GF_NO_NEW_VARIABLES);
-	HasKaputz = core->HasFeature(GF_HAS_KAPUTZ);
+	NoCreate = core->HasFeature(GFFlags::NO_NEW_VARIABLES);
+	HasKaputz = core->HasFeature(GFFlags::HAS_KAPUTZ);
 
 	InitScriptTables();
 	int tT = core->LoadSymbol( "trigger" );
@@ -2049,7 +2049,7 @@ bool GameScript::Update(bool *continuing, bool *done)
 					// BG2 needs this, however... (eg. spirit trolls trollsp01 in ar1506)
 					// previously we thought iwd:totlm needed this bit, but it turns out only iwd2 does (bg2 breaks with it)
 					// targos goblins misbehave without it; see https://github.com/gemrb/gemrb/issues/344 for the gory details
-					if (core->HasFeature(GF_3ED_RULES) && done) {
+					if (core->HasFeature(GFFlags::RULES_3ED) && done) {
 						*done = true;
 					}
 					return false;
@@ -2257,7 +2257,7 @@ bool Condition::Evaluate(Scriptable *Sender) const
 	for (const Trigger *tR : triggers) {
 		//do not evaluate triggers in an Or() block if one of them
 		//was already True() ... but this sane approach was only used in iwd2!
-		if (!core->HasFeature(GF_EFFICIENT_OR) || !ORcount || !subresult) {
+		if (!core->HasFeature(GFFlags::EFFICIENT_OR) || !ORcount || !subresult) {
 			result = tR->Evaluate(Sender);
 		}
 		if (result > 1) {
@@ -2389,10 +2389,10 @@ static void HandleActionOverride(Scriptable* target, const Action* aC)
 	// it shouldn't matter that we set it on all
 	newAction->flags |= ACF_OVERRIDE;
 
-	if (core->HasFeature(GF_CLEARING_ACTIONOVERRIDE)) {
+	if (core->HasFeature(GFFlags::CLEARING_ACTIONOVERRIDE)) {
 		// bg2, but not iwd2, clears the previous non-actionoverriden actions in the queue
 		target->ClearActions(1);
-	} else if (core->HasFeature(GF_3ED_RULES)) { // iwd2
+	} else if (core->HasFeature(GFFlags::RULES_3ED)) { // iwd2
 		// it was more complicated, always releasing if the game was paused — not something to replicate
 		if (target->CurrentActionInterruptable) {
 			target->ReleaseCurrentAction();

--- a/gemrb/core/GameScript/Matching.cpp
+++ b/gemrb/core/GameScript/Matching.cpp
@@ -195,7 +195,7 @@ static Targets *EvaluateObject(const Map *map, const Scriptable *Sender, const O
 		// unless it's pst, which relies on it in 3012cut2-3012cut7.bcs
 		// FIXME: do we need more fine-grained control?
 		// FIXME: stop abusing old GF flags
-		if (!core->HasFeature(GF_AREA_OVERRIDE) && ac == Sender) continue;
+		if (!core->HasFeature(GFFlags::AREA_OVERRIDE) && ac == Sender) continue;
 
 		bool filtered = false;
 		if (!DoObjectIDSCheck(oC, ac, &filtered)) {

--- a/gemrb/core/GameScript/Objects.cpp
+++ b/gemrb/core/GameScript/Objects.cpp
@@ -111,7 +111,7 @@ Targets *GameScript::Protagonist(const Scriptable *Sender, Targets *parameters, 
 {
 	parameters->Clear();
 	//this sucks but IWD2 is like that...
-	static bool charnameisgabber = core->HasFeature(GF_CHARNAMEISGABBER);
+	static bool charnameisgabber = core->HasFeature(GFFlags::CHARNAMEISGABBER);
 	if (charnameisgabber) {
 		const GameControl* gc = core->GetGameControl();
 		if (gc) {
@@ -1083,7 +1083,7 @@ inline bool idclass(const Actor *actor, int parameter, bool iwd2) {
 
 int GameScript::ID_Class(const Actor *actor, int parameter)
 {
-	if (core->HasFeature(GF_3ED_RULES)) {
+	if (core->HasFeature(GFFlags::RULES_3ED)) {
 		//iwd2 has different values, see also the note for AVClass
 		return idclass(actor, parameter, true);
 	}

--- a/gemrb/core/GameScript/Triggers.cpp
+++ b/gemrb/core/GameScript/Triggers.cpp
@@ -4030,7 +4030,7 @@ int GameScript::Unusable(Scriptable *Sender, const Trigger *parameters)
 		return 0;
 	}
 	int ret;
-	if (actor->Unusable(item) == HCStrings::StringCount) {
+	if (actor->Unusable(item) == HCStrings::count) {
 		ret = 1;
 	} else {
 		ret = 0;

--- a/gemrb/core/GameScript/Triggers.cpp
+++ b/gemrb/core/GameScript/Triggers.cpp
@@ -341,7 +341,7 @@ int GameScript::InParty(Scriptable *Sender, const Trigger *parameters, bool allo
 
 int GameScript::InParty(Scriptable *Sender, const Trigger *parameters)
 {
-	return InParty(Sender, parameters, core->HasFeature(GF_IN_PARTY_ALLOWS_DEAD));
+	return InParty(Sender, parameters, core->HasFeature(GFFlags::IN_PARTY_ALLOWS_DEAD));
 }
 
 int GameScript::InPartyAllowDead(Scriptable *Sender, const Trigger *parameters)
@@ -639,7 +639,7 @@ int GameScript::NumDead(Scriptable *Sender, const Trigger *parameters)
 {
 	ieDword value;
 
-	if (core->HasFeature(GF_HAS_KAPUTZ) ) {
+	if (core->HasFeature(GFFlags::HAS_KAPUTZ) ) {
 		value = CheckVariable(Sender, parameters->string0Parameter, "KAPUTZ");
 	} else {
 		ieVariable VariableName;
@@ -653,7 +653,7 @@ int GameScript::NumDeadGT(Scriptable *Sender, const Trigger *parameters)
 {
 	ieDword value;
 
-	if (core->HasFeature(GF_HAS_KAPUTZ) ) {
+	if (core->HasFeature(GFFlags::HAS_KAPUTZ) ) {
 		value = CheckVariable(Sender, parameters->string0Parameter, "KAPUTZ");
 	} else {
 		ieVariable VariableName;
@@ -667,7 +667,7 @@ int GameScript::NumDeadLT(Scriptable *Sender, const Trigger *parameters)
 {
 	ieDword value;
 
-	if (core->HasFeature(GF_HAS_KAPUTZ) ) {
+	if (core->HasFeature(GFFlags::HAS_KAPUTZ) ) {
 		value = CheckVariable(Sender, parameters->string0Parameter, "KAPUTZ");
 	} else {
 		ieVariable VariableName;
@@ -834,7 +834,7 @@ int GameScript::GlobalTimerExpired(Scriptable *Sender, const Trigger *parameters
 	bool valid=true;
 
 	ieDword value1 = CheckVariable(Sender, parameters->string0Parameter, parameters->string1Parameter, &valid );
-	if (valid && (core->HasFeature(GF_ZERO_TIMER_IS_VALID) || value1)) {
+	if (valid && (core->HasFeature(GFFlags::ZERO_TIMER_IS_VALID) || value1)) {
 		if ( value1 < core->GetGame()->GameTime ) return 1;
 	}
 	return 0;
@@ -1750,7 +1750,7 @@ int GameScript::Dead(Scriptable *Sender, const Trigger *parameters)
 		ieVariable Variable;
 		bool valid;
 
-		if (core->HasFeature( GF_HAS_KAPUTZ )) {
+		if (core->HasFeature( GFFlags::HAS_KAPUTZ )) {
 			valid = Variable.Format("{}_DEAD", parameters->string0Parameter);
 			value = CheckVariable( Sender, Variable, "KAPUTZ");
 		} else {

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -3142,7 +3142,7 @@ int Interface::CanUseItemType(int slottype, const Item *item, const Actor *actor
 
 		//constant strings
 		HCStrings idx = actor->Unusable(item);
-		if (idx != HCStrings::StringCount) {
+		if (idx != HCStrings::count) {
 			if (feedback) displaymsg->DisplayConstantString(idx, GUIColors::WHITE);
 			return 0;
 		}

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -698,24 +698,6 @@ int Interface::LoadSprites()
 	WindowManager::CursorMouseUp = Cursors[0];
 	WindowManager::CursorMouseDown = Cursors[1];
 
-	// Load fog-of-war bitmaps
-	anim = (const AnimationFactory*) gamedata->GetFactoryResource("fogowar", IE_BAM_CLASS_ID);
-	Log(MESSAGE, "Core", "Loading Fog-Of-War bitmaps...");
-	if (!anim) {
-		// unknown type of fog anim
-		Log(ERROR, "Core", "Failed to load Fog-of-War bitmaps.");
-		return GEM_ERROR;
-	}
-
-	FogSprites[1] = anim->GetFrame(0, 0); // horizontal edge
-	FogSprites[2] = anim->GetFrame(1, 0); // vertical edge
-	FogSprites[3] = anim->GetFrame(2, 0); // corner
-	FogSprites[4] = FogSprites[1];
-	FogSprites[6] = FogSprites[3];
-	FogSprites[8] = FogSprites[2];
-	FogSprites[9] = FogSprites[3];
-	FogSprites[12] = FogSprites[6];
-
 	// Load ground circle bitmaps (PST only)
 	Log(MESSAGE, "Core", "Loading Ground circle bitmaps...");
 	for (int size = 0; size < MAX_CIRCLE_SIZE; size++) {

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -450,7 +450,6 @@ public:
 	ResRef WorldMapName[2] = { "WORLDMAP", "" };
 
 	std::vector<Holder<Sprite2D> > Cursors;
-	Holder<Sprite2D> FogSprites[16] {};
 	Holder<Sprite2D> GroundCircles[MAX_CIRCLE_SIZE][6] {};
 	std::vector<ieVariable> musiclist;
 	std::multimap<ieDword, DamageInfoStruct> DamageInfoMap;

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -387,7 +387,7 @@ private:
 	Game* game = nullptr;
 	Calendar* calendar = nullptr;
 	WorldMapArray* worldmap = nullptr;
-	ieDword GameFeatures[(GF_COUNT+31)/32]{};
+	EnumBitset<GFFlags> GameFeatures;
 	ResRef MainCursorsImage;
 	ResRef TextCursorBam;
 	ResRef ScrollCursorBam;
@@ -463,9 +463,9 @@ public:
 	
 	int Init(const InterfaceConfig* config);
 	//TODO: Core Methods in Interface Class
-	void SetFeature(int value, int position);
-	/* don't rely on the exact return value of this function */
-	ieDword HasFeature(int position) const;
+	void SetFeature(GFFlags flag);
+	void ClearFeature(GFFlags flag);
+	bool HasFeature(GFFlags flag) const;
 	bool IsAvailable(SClass_ID filetype) const;
 	const char * TypeExt(SClass_ID type) const;
 	ProjectileServer* GetProjectileServer() const noexcept;

--- a/gemrb/core/Inventory.cpp
+++ b/gemrb/core/Inventory.cpp
@@ -621,7 +621,7 @@ int Inventory::AddSlotItem(CREItem* item, int slot, int slottype, bool ranged)
 		}
 
 		//check for equipping weapons
-		if (WhyCantEquip(slot, twohanded, ranged) != HCStrings::StringCount) {
+		if (WhyCantEquip(slot, twohanded, ranged) != HCStrings::count) {
 			return ASI_FAILED;
 		}
 
@@ -1916,7 +1916,7 @@ HCStrings Inventory::WhyCantEquip(int slot, int twohanded, bool ranged) const
 {
 	// check only for hand slots
 	if ((slot<SLOT_MELEE || slot>LAST_MELEE) && (slot != SLOT_LEFT) ) {
-		return HCStrings::StringCount;
+		return HCStrings::count;
 	}
 
 	//magic items have the highest priority
@@ -1957,7 +1957,7 @@ HCStrings Inventory::WhyCantEquip(int slot, int twohanded, bool ranged) const
 			return HCStrings::OffhandUsed;
 		}
 	}
-	return HCStrings::StringCount;
+	return HCStrings::count;
 }
 
 //recharge items on rest, if rest was partial, recharge only 'hours'

--- a/gemrb/core/Inventory.cpp
+++ b/gemrb/core/Inventory.cpp
@@ -112,7 +112,7 @@ void Inventory::Init()
 	LAST_QUICK=-1;
 	SLOT_LEFT=-1;
 	SLOT_ARMOR=-1;
-	IWD2 = core->HasFeature(GF_HAS_WEAPON_SETS);
+	IWD2 = core->HasFeature(GFFlags::HAS_WEAPON_SETS);
 }
 
 Inventory::~Inventory()
@@ -570,7 +570,7 @@ int Inventory::RemoveItem(const ResRef& resref, unsigned int flags, CREItem **re
 {
 	size_t slot = Slots.size();
 	unsigned int mask = (flags^IE_INV_ITEM_UNDROPPABLE);
-	if (core->HasFeature(GF_NO_DROP_CAN_MOVE) ) {
+	if (core->HasFeature(GFFlags::NO_DROP_CAN_MOVE) ) {
 		mask &= ~IE_INV_ITEM_UNDROPPABLE;
 	}
 	while(slot--) {
@@ -694,7 +694,7 @@ int Inventory::AddStoreItem(STOItem* item, int action)
 
 		//except the Expired flag
 		temp->Expired=0;
-		if (action==STA_STEAL && !core->HasFeature(GF_PST_STATE_FLAGS)) {
+		if (action==STA_STEAL && !core->HasFeature(GFFlags::PST_STATE_FLAGS)) {
 			temp->Flags |= IE_INV_ITEM_STOLEN; // "steel" in pst
 		}
 		temp->Flags &= ~IE_INV_ITEM_SELECTED;
@@ -774,7 +774,7 @@ int Inventory::DepleteItem(ieDword flags) const
 int Inventory::FindItem(const ResRef &resref, unsigned int flags, unsigned int skip) const
 {
 	unsigned int mask = (flags^IE_INV_ITEM_UNDROPPABLE);
-	if (core->HasFeature(GF_NO_DROP_CAN_MOVE) ) {
+	if (core->HasFeature(GFFlags::NO_DROP_CAN_MOVE) ) {
 		mask &= ~IE_INV_ITEM_UNDROPPABLE;
 	}
 	for (size_t i = 0; i < Slots.size(); i++) {
@@ -1012,7 +1012,7 @@ bool Inventory::UnEquipItem(ieDword slot, bool removecurse) const
 	if (!item) {
 		return false;
 	}
-	if (item->Flags & IE_INV_ITEM_UNDROPPABLE && !core->HasFeature(GF_NO_DROP_CAN_MOVE)) {
+	if (item->Flags & IE_INV_ITEM_UNDROPPABLE && !core->HasFeature(GFFlags::NO_DROP_CAN_MOVE)) {
 		return false;
 	}
 
@@ -1632,7 +1632,7 @@ void Inventory::BreakItemSlot(ieDword slot)
 	//if it is the magic weapon slot, don't break it, just remove it, because it couldn't be removed
 	//or for pst, just remove it as there is no breaking (the replacement item is a sound)
 	// also don't break ranged weapons (eg. when running out of throwing axes)
-	if (slot == (unsigned int) SLOT_MAGIC || core->HasFeature(GF_HAS_PICK_SOUND) || Owner->weaponInfo[0].wflags & WEAPON_RANGED) {
+	if (slot == (unsigned int) SLOT_MAGIC || core->HasFeature(GFFlags::HAS_PICK_SOUND) || Owner->weaponInfo[0].wflags & WEAPON_RANGED) {
 		newItem.Reset();
 	} else {
 		newItem = itm->ReplacementItem;

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -276,7 +276,7 @@ private:
 	}
 
 	Explore() noexcept {
-		LargeFog = !core->HasFeature(GF_SMALL_FOG);
+		LargeFog = !core->HasFeature(GFFlags::SMALL_FOG);
 
 		//circle perimeter size for MaxVisibility
 		int x = MaxVisibility;
@@ -1828,9 +1828,9 @@ void Map::ActorSpottedByPlayer(const Actor *actor) const
 {
 	unsigned int animid;
 
-	if(core->HasFeature(GF_HAS_BEASTS_INI)) {
+	if(core->HasFeature(GFFlags::HAS_BEASTS_INI)) {
 		animid=actor->BaseStats[IE_ANIMATION_ID];
-		if(core->HasFeature(GF_ONE_BYTE_ANIMID)) {
+		if(core->HasFeature(GFFlags::ONE_BYTE_ANIMID)) {
 			animid&=0xff;
 		}
 		if (animid < (ieDword)CharAnimations::GetAvatarsCount()) {
@@ -1869,7 +1869,7 @@ void Map::InitActors()
 
 void Map::MarkVisited(const Actor *actor) const
 {
-	if (actor->InParty && core->HasFeature(GF_AREA_VISITED_VAR)) {
+	if (actor->InParty && core->HasFeature(GFFlags::AREA_VISITED_VAR)) {
 		ieVariable key;
 		if (!key.Format("{}_visited", scriptName)) {
 			Log(ERROR, "Map", "Area {} has a too long script name for generating _visited globals!", scriptName);
@@ -2203,7 +2203,7 @@ Scriptable *Map::GetScriptableByDialog(const ResRef &resref) const
 		}
 	}
 
-	if (!core->HasFeature(GF_INFOPOINT_DIALOGS)) {
+	if (!core->HasFeature(GFFlags::INFOPOINT_DIALOGS)) {
 		return NULL;
 	}
 
@@ -2327,7 +2327,7 @@ void Map::PlayAreaSong(int SongType, bool restart, bool hard) const
 	// it's not the correct music, perhaps it needs the one from the master area
 	// it would match for ar2607 and ar2600, but very annoying (see GetMasterArea)
 	// ... but this is also definitely wrong for iwd
-	if (IsStar(*poi) && !MasterArea && SongType == SONG_BATTLE && core->HasFeature(GF_BREAKABLE_WEAPONS)) {
+	if (IsStar(*poi) && !MasterArea && SongType == SONG_BATTLE && core->HasFeature(GFFlags::BREAKABLE_WEAPONS)) {
 		poi = &core->GetMusicPlaylist(SongType);
 		pl = SongType;
 	}
@@ -3034,7 +3034,7 @@ const MapNote* Map::MapNoteAtPoint(const Point& point, unsigned int radius) cons
 //--------spawning------------------
 void Map::LoadIniSpawn()
 {
-	if (core->HasFeature(GF_RESDATA_INI)) {
+	if (core->HasFeature(GFFlags::RESDATA_INI)) {
 		// 85 cases where we'd miss the ini and 1 where we'd use the wrong one
 		INISpawn = new IniSpawn(this, ResRef(scriptName));
 	} else {
@@ -3601,7 +3601,7 @@ bool Map::DisplayTrackString(const Actor *target) const
 	// +5% for every three levels and +5% per point of wisdom
 	int skill = target->GetStat(IE_TRACKING);
 	int success;
-	if (core->HasFeature(GF_3ED_RULES)) {
+	if (core->HasFeature(GFFlags::RULES_3ED)) {
 		// ~Wilderness Lore check. Wilderness Lore (skill + D20 roll + WIS modifier) =  %d vs. ((Area difficulty pct / 5) + 10) = %d ( Skill + WIS MOD = %d ).~
 		skill += target->LuckyRoll(1, 20, 0) + target->GetAbilityBonus(IE_WIS);
 		success = skill > (trackDiff/5 + 10);

--- a/gemrb/core/SaveGameIterator.cpp
+++ b/gemrb/core/SaveGameIterator.cpp
@@ -62,7 +62,7 @@ static std::string ParseGameDate(DataStream *ds)
 		return "ERROR";
 	}
 	// bg1 displays 7 hours less in game, sigh
-	if (core->HasFeature(GF_BREAKABLE_WEAPONS)) {
+	if (core->HasFeature(GFFlags::BREAKABLE_WEAPONS)) {
 		GameTime -= 2100;
 
 		// also read the Chapter global, since bg1 displays it
@@ -256,7 +256,7 @@ static bool IsSaveGameSlot(const char* Path, const char* slotname)
 	}
 
 	// no worldmaps in saves in ees
-	if (core->HasFeature(GF_HAS_EE_EFFECTS)) return true;
+	if (core->HasFeature(GFFlags::HAS_EE_EFFECTS)) return true;
 
 	PathJoinExt(ftmp, dtmp, core->WorldMapName[0].c_str(), "wmp");
 	if (access( ftmp, R_OK )) {

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -5906,7 +5906,7 @@ int Actor::LearnSpell(const ResRef& spellname, ieDword flags, int bookmask, int 
 		bookmask = GetBookMask();
 	}
 	int explev = spellbook.LearnSpell(spell, flags&LS_MEMO, bookmask, kit, level);
-	HCStrings message = HCStrings::StringCount;
+	HCStrings message = HCStrings::count;
 	if (flags&LS_LEARN) {
 		core->GetTokenDictionary()->SetAt("SPECIALABILITYNAME", core->GetString(spell->SpellName));
 		switch (spell->SpellType) {
@@ -5925,7 +5925,7 @@ int Actor::LearnSpell(const ResRef& spellname, ieDword flags, int bookmask, int 
 	if (!explev) {
 		return LSR_INVALID;
 	}
-	if (message != HCStrings::StringCount) {
+	if (message != HCStrings::count) {
 		displaymsg->DisplayConstantStringName(message, GUIColors::XPCHANGE, this);
 	}
 	if (flags&LS_ADDXP && !(flags&LS_NOXP)) {
@@ -8728,7 +8728,7 @@ HCStrings Actor::SetEquippedQuickSlot(int slot, int header)
 {
 	if (!PCStats) {
 		inventory.SetEquippedSlot(ieWordSigned(slot), std::max<ieWord>(0, header));
-		return HCStrings::StringCount;
+		return HCStrings::count;
 	}
 
 
@@ -8746,7 +8746,7 @@ HCStrings Actor::SetEquippedQuickSlot(int slot, int header)
 		//if it is the fist slot and not currently used, then set it up
 		if (i==MAX_QUICKWEAPONSLOT) {
 			inventory.SetEquippedSlot(IW_NO_EQUIPPED, 0);
-			return HCStrings::StringCount;
+			return HCStrings::count;
 		}
 	}
 
@@ -8758,7 +8758,7 @@ HCStrings Actor::SetEquippedQuickSlot(int slot, int header)
 	}
 	slot = Inventory::GetWeaponQuickSlot(PCStats->QuickWeaponSlots[slot]);
 	if (inventory.SetEquippedSlot(ieWordSigned(slot), ieWord(header))) {
-		return HCStrings::StringCount;
+		return HCStrings::count;
 	}
 	return HCStrings::MagicWeapon;
 }
@@ -9568,7 +9568,7 @@ no_resolve:
 		}
 	}
 
-	return HCStrings::StringCount;
+	return HCStrings::count;
 }
 
 //this one is the same, but returns strrefs based on effects
@@ -9601,7 +9601,7 @@ HCStrings Actor::Unusable(const Item* item) const
 	}
 	if (!GetStat(IE_CANUSEANYITEM) && !fx) {
 		HCStrings unusable = CheckUsability(item);
-		if (unusable != HCStrings::StringCount) {
+		if (unusable != HCStrings::count) {
 			return unusable;
 		}
 	}
@@ -9612,7 +9612,7 @@ HCStrings Actor::Unusable(const Item* item) const
 	}
 
 	if (!CheckAbilities) {
-		return HCStrings::StringCount;
+		return HCStrings::count;
 	}
 
 	if (item->MinStrength>GetStat(IE_STR)) {
@@ -9644,7 +9644,7 @@ HCStrings Actor::Unusable(const Item* item) const
 	}
 	//note, weapon proficiencies shouldn't be checked here
 	//missing proficiency causes only attack penalty
-	return HCStrings::StringCount;
+	return HCStrings::count;
 }
 
 //full palette will be shaded in gradient color

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -448,7 +448,7 @@ void Actor::SetAnimationID(unsigned int AnimID)
 	}
 
 	// hacking PST no palette
-	if (core->HasFeature(GF_ONE_BYTE_ANIMID) && (AnimID & 0xf000) == 0xe000) {
+	if (core->HasFeature(GFFlags::ONE_BYTE_ANIMID) && (AnimID & 0xf000) == 0xe000) {
 		if (BaseStats[IE_COLORCOUNT]) {
 			Log(WARNING, "Actor", "Animation ID {:#x} is supposed to be real colored (no recoloring), patched creature", AnimID);
 		}
@@ -485,7 +485,7 @@ void Actor::SetAnimationID(unsigned int AnimID)
 
 	// PST and EE 2.0+ use an ini to define animation data, including walk and run speed
 	// the rest had it hardcoded
-	if (!core->HasFeature(GF_RESDATA_INI)) {
+	if (!core->HasFeature(GFFlags::RESDATA_INI)) {
 		// handle default speed and per-animation overrides
 		TableMgr::index_t row = TableMgr::npos;
 		if (extspeed) {
@@ -864,7 +864,7 @@ static void pcf_morale (Actor *actor, ieDword /*oldValue*/, ieDword /*newValue*/
 
 static void UpdateHappiness(Actor *actor) {
 	if (!actor->InParty) return;
-	if (!core->HasFeature(GF_HAPPINESS)) return;
+	if (!core->HasFeature(GFFlags::HAPPINESS)) return;
 
 	ieWordSigned newHappiness = GetHappiness(actor, core->GetGame()->Reputation);
 	if (newHappiness == actor->PCStats->Happiness) return;
@@ -1583,11 +1583,11 @@ static void ReadModalStates()
 static void InitActorTables()
 {
 	UpdateActorConfig();
-	pstflags = core->HasFeature(GF_PST_STATE_FLAGS) != 0;
-	nocreate = core->HasFeature(GF_NO_NEW_VARIABLES) != 0;
-	third = core->HasFeature(GF_3ED_RULES) != 0;
-	raresnd = core->HasFeature(GF_RARE_ACTION_VB) != 0;
-	iwd2class = core->HasFeature(GF_LEVELSLOT_PER_CLASS) != 0;
+	pstflags = core->HasFeature(GFFlags::PST_STATE_FLAGS) != 0;
+	nocreate = core->HasFeature(GFFlags::NO_NEW_VARIABLES) != 0;
+	third = core->HasFeature(GFFlags::RULES_3ED) != 0;
+	raresnd = core->HasFeature(GFFlags::RARE_ACTION_VB) != 0;
+	iwd2class = core->HasFeature(GFFlags::LEVELSLOT_PER_CLASS) != 0;
 	// iwd2 has some different base class names
 	if (iwd2class) {
 		isclassnames[ISTHIEF] = "ROGUE";
@@ -1600,15 +1600,15 @@ static void InitActorTables()
 		state_invisible=STATE_INVISIBLE;
 	}
 
-	if (core->HasFeature(GF_CHALLENGERATING)) {
+	if (core->HasFeature(GFFlags::CHALLENGERATING)) {
 		sharexp=SX_DIVIDE|SX_COMBAT|SX_CR;
 	} else {
 		sharexp=SX_DIVIDE|SX_COMBAT;
 	}
-	ReverseToHit = core->HasFeature(GF_REVERSE_TOHIT);
-	CheckAbilities = core->HasFeature(GF_CHECK_ABILITIES);
-	DeathOnZeroStat = core->HasFeature(GF_DEATH_ON_ZERO_STAT);
-	IWDSound = core->HasFeature(GF_SOUNDS_INI);
+	ReverseToHit = core->HasFeature(GFFlags::REVERSE_TOHIT);
+	CheckAbilities = core->HasFeature(GFFlags::CHECK_ABILITIES);
+	DeathOnZeroStat = core->HasFeature(GFFlags::DEATH_ON_ZERO_STAT);
+	IWDSound = core->HasFeature(GFFlags::SOUNDS_INI);
 	NUM_RARE_SELECT_SOUNDS = core->GetRareSelectSoundCount();
 
 	//this table lists skill groups assigned to classes
@@ -1746,7 +1746,7 @@ static void InitActorTables()
 
 	//csound for bg1/bg2
 	memset(csound,0,sizeof(csound));
-	if (!core->HasFeature(GF_SOUNDFOLDERS)) {
+	if (!core->HasFeature(GFFlags::SOUNDFOLDERS)) {
 		tm = gamedata->LoadTable("csound");
 		if (tm) {
 			for (int i = 0; i < VCONST_COUNT; i++) {
@@ -3003,7 +3003,7 @@ void Actor::RefreshPCStats() {
 	int rate = GetConHealAmount();
 	if (rate && !(game->GameTime % rate)) {
 		NewBase(IE_HITPOINTS, 1, MOD_ADDITIVE);
-		if (core->HasFeature(GF_ONSCREEN_TEXT) && InParty && Modified[IE_HITPOINTS] < Modified[IE_MAXHITPOINTS]) {
+		if (core->HasFeature(GFFlags::ONSCREEN_TEXT) && InParty && Modified[IE_HITPOINTS] < Modified[IE_MAXHITPOINTS]) {
 			// eeeh, no token (Heal: 1)
 			static const String text = fmt::format(L"{} 1", core->GetString(ieStrRef::HEAL));
 			overHead.SetText(text);
@@ -3047,7 +3047,7 @@ int Actor::GetConHealAmount() const
 	const Game *game = core->GetGame();
 	if (!game) return rate;
 
-	if (core->HasFeature(GF_AREA_OVERRIDE) && game->GetPC(0, false) == this) {
+	if (core->HasFeature(GFFlags::AREA_OVERRIDE) && game->GetPC(0, false) == this) {
 		rate = core->GetConstitutionBonus(STAT_CON_TNO_REGEN, Modified[IE_CON]);
 	} else {
 		rate = core->GetConstitutionBonus(STAT_CON_HP_REGEN, Modified[IE_CON]);
@@ -3080,7 +3080,7 @@ void Actor::UpdateFatigue()
 	}
 	LastFatigueCheck = game->GameTime;
 
-	if (!core->HasFeature(GF_AREA_OVERRIDE)) {
+	if (!core->HasFeature(GFFlags::AREA_OVERRIDE)) {
 		// pst has TNO regeneration stored there
 		// shouldn't we check for our own flag, though?
 		// FIXME: the Con bonus is applied dynamically, but this doesn't appear to conform to
@@ -3639,7 +3639,7 @@ bool Actor::GetPartyComment()
 		if (target->BaseStats[IE_MC_FLAGS]&MC_EXPORTABLE) continue; //not NPC
 		if (target->GetCurrentArea()!=GetCurrentArea()) continue;
 
-		if (core->HasFeature(GF_RANDOM_BANTER_DIALOGS)) {
+		if (core->HasFeature(GFFlags::RANDOM_BANTER_DIALOGS)) {
 			if (core->Roll(1, 50, 0) == 1) { // TODO: confirm frequency
 				//V1 interact
 				HandleInteractV1(target);
@@ -3998,7 +3998,7 @@ bool Actor::CheckSpellDisruption(int damage) const
 	int spellLevel = spl->SpellLevel;
 	gamedata->FreeSpell(spl, SpellResRef, false);
 
-	if (core->HasFeature(GF_SIMPLE_DISRUPTION)) {
+	if (core->HasFeature(GFFlags::SIMPLE_DISRUPTION)) {
 		return LuckyRoll(1, 20, 0) < (damage + spellLevel);
 	}
 	if (!third) {
@@ -4216,7 +4216,7 @@ int Actor::Damage(int damage, int damagetype, Scriptable* hitter, int modtype, i
 	}
 
 	// also apply reputation damage if we hurt (but not killed) an innocent
-	if (core->HasFeature(GF_DAMAGE_INNOCENT_REP) &&
+	if (core->HasFeature(GFFlags::DAMAGE_INNOCENT_REP) &&
 			Modified[IE_CLASS] == CLASS_INNOCENT &&
 			!core->InCutSceneMode() &&
 			act && act->GetStat(IE_EA) <= EA_CONTROLLABLE) {
@@ -4362,7 +4362,7 @@ void Actor::DisplayCombatFeedback(unsigned int damage, int resisted, int damaget
 				strref = HCStrings(int(strref) - (int(HCStrings::DamageDetail1) - int(HCStrings::Damage1)));
 			}
 			displaymsg->DisplayConstantStringName(strref, GUIColors::WHITE, this);
-		} else if (core->HasFeature(GF_ONSCREEN_TEXT) ) {
+		} else if (core->HasFeature(GFFlags::ONSCREEN_TEXT) ) {
 			auto color = GUIColors::WHITE;
 			if (InParty) {
 				color = GUIColors::RED;
@@ -4427,7 +4427,7 @@ void Actor::PlayWalkSound()
 	char suffix = 0;
 	uint8_t l = Sound.length();
 	/* IWD1, HOW, IWD2 sometimes append numbers here, not letters. */
-	if (core->HasFeature(GF_SOUNDFOLDERS) && Sound.BeginsWith("FS_")) {
+	if (core->HasFeature(GFFlags::SOUNDFOLDERS) && Sound.BeginsWith("FS_")) {
 		suffix = char(chosenWalkSnd + 0x31);
 	} else if (chosenWalkSnd) {
 		suffix = char(chosenWalkSnd + 0x60); // 'a'-'g'
@@ -4469,7 +4469,7 @@ void Actor::PlayHitSound(const DataFileMgr *resdata, int damagetype, bool suffix
 	int armor = 0;
 	if (resdata) {
 		unsigned int animid=BaseStats[IE_ANIMATION_ID];
-		if(core->HasFeature(GF_ONE_BYTE_ANIMID)) {
+		if(core->HasFeature(GFFlags::ONE_BYTE_ANIMID)) {
 			animid&=0xff;
 		}
 
@@ -4490,7 +4490,7 @@ void Actor::PlayHitSound(const DataFileMgr *resdata, int damagetype, bool suffix
 	}
 
 	ResRef Sound;
-	if (core->HasFeature(GF_IWD2_SCRIPTNAME)) {
+	if (core->HasFeature(GFFlags::IWD2_SCRIPTNAME)) {
 		// TODO: RE and unhardcode, especially the "armor" mapping
 		// no idea what RK stands for, so use it for everything else
 		if (type > 5) type = 5;
@@ -4600,7 +4600,7 @@ std::string Actor::dump() const
 	AppendFormat(buffer, "Mod[IE_ANIMATION_ID]: 0x{:^4X} ResRef:{} Stance: {}\n", Modified[IE_ANIMATION_ID], anims->ResRefBase, GetStance());
 	AppendFormat(buffer, "TURNUNDEADLEVEL: {} current: {}\n", BaseStats[IE_TURNUNDEADLEVEL], Modified[IE_TURNUNDEADLEVEL]);
 	AppendFormat(buffer, "Colors:    ");
-	if (core->HasFeature(GF_ONE_BYTE_ANIMID) ) {
+	if (core->HasFeature(GFFlags::ONE_BYTE_ANIMID) ) {
 		for(unsigned int i = 0; i < Modified[IE_COLORCOUNT]; i++) {
 			AppendFormat(buffer, "   {}", Modified[IE_COLORS+i]);
 		}
@@ -4865,7 +4865,7 @@ int Actor::GetEncumbranceFactor(bool feedback) const
 
 int Actor::CalculateSpeed(bool feedback) const
 {
-	if (core->HasFeature(GF_RESDATA_INI)) {
+	if (core->HasFeature(GFFlags::RESDATA_INI)) {
 		return CalculateSpeedFromINI(feedback);
 	} else {
 		return CalculateSpeedFromRate(feedback);
@@ -4893,7 +4893,7 @@ int Actor::CalculateSpeedFromINI(bool feedback) const
 {
 	int encumbranceFactor = GetEncumbranceFactor(feedback);
 	ieDword animid = BaseStats[IE_ANIMATION_ID];
-	if (core->HasFeature(GF_ONE_BYTE_ANIMID)) {
+	if (core->HasFeature(GFFlags::ONE_BYTE_ANIMID)) {
 		animid = animid & 0xff;
 	}
 	assert(animid < (ieDword)CharAnimations::GetAvatarsCount());
@@ -5008,7 +5008,7 @@ void Actor::Resurrect(const Point &destPoint)
 	Game *game = core->GetGame();
 	//readjust death variable on resurrection
 	ieVariable DeathVar;
-	if (core->HasFeature(GF_HAS_KAPUTZ) && (AppearanceFlags&APP_DEATHVAR)) {
+	if (core->HasFeature(GFFlags::HAS_KAPUTZ) && (AppearanceFlags&APP_DEATHVAR)) {
 		if (!DeathVar.Format("{}_DEAD", scriptName)) {
 			Log(ERROR, "Actor", "Scriptname {} (name: {}) is too long for generating death globals!", scriptName, fmt::WideToChar{GetName()});
 		}
@@ -5019,7 +5019,7 @@ void Actor::Resurrect(const Point &destPoint)
 			game->kaputz->SetAt(DeathVar, value-1);
 		}
 	// not bothering with checking actor->SetDeathVar, since the SetAt nocreate parameter is true
-	} else if (!core->HasFeature(GF_HAS_KAPUTZ)) {
+	} else if (!core->HasFeature(GFFlags::HAS_KAPUTZ)) {
 		if (!DeathVar.Format(Interface::GetDeathVarFormat(), scriptName)) {
 			Log(ERROR, "Actor", "Scriptname {} (name: {}) is too long for generating death globals (on resurrect)!", scriptName, fmt::WideToChar{GetName()});
 		}
@@ -5319,7 +5319,7 @@ bool Actor::CheckOnDeath()
 	SetBaseBit(IE_STATE_ID, STATE_DEAD, true);
 
 	// death variables are updated at the moment of death in the original
-	if (core->HasFeature(GF_HAS_KAPUTZ)) {
+	if (core->HasFeature(GFFlags::HAS_KAPUTZ)) {
 		const char* format = AppearanceFlags & APP_ADDKILL ? "KILL_{}" : "{}";
 
 		//don't use the raw killVar here (except when the flags explicitly ask for it)
@@ -6001,7 +6001,7 @@ ResRef Actor::GetScript(int ScriptIndex) const
 inline ieStrRef PersonalizePSTString(ieStrRef ref, const Actor* pc)
 {
 	if (pc->Modal.State != MS_STEALTH) return ref;
-	if (!core->HasFeature(GF_PST_STATE_FLAGS)) return ref;
+	if (!core->HasFeature(GFFlags::PST_STATE_FLAGS)) return ref;
 
 	int pcOffset = 8;
 	int specific = pc->GetStat(IE_SPECIFIC);
@@ -7017,7 +7017,7 @@ void Actor::PerformAttack(ieDword gameTime)
 		}
 		if (wi.wflags & WEAPON_RANGED) {//no need for this with melee weapon!
 			UseItem(wi.slot, (ieDword) -2, target, UI_MISS|UI_NOAURA);
-		} else if (core->HasFeature(GF_BREAKABLE_WEAPONS) && InParty) {
+		} else if (core->HasFeature(GFFlags::BREAKABLE_WEAPONS) && InParty) {
 			//break sword
 			// a random roll on-hit (perhaps critical failure too)
 			//  in 0,5% (1d20*1d10==1) cases
@@ -7174,7 +7174,7 @@ void Actor::ModifyDamage(Scriptable *hitter, int &damage, int &resisted, int dam
 			Log(ERROR, "ModifyDamage", "Unhandled damagetype: {}", damagetype);
 		} else if (it->second.resist_stat) {
 			// check for bonuses for specific damage types
-			if (core->HasFeature(GF_SPECIFIC_DMG_BONUS) && attacker) {
+			if (core->HasFeature(GFFlags::SPECIFIC_DMG_BONUS) && attacker) {
 				int bonus = attacker->fxqueue.BonusForParam2(fx_damage_bonus_modifier_ref, it->second.iwd_mod_type);
 				if (bonus) {
 					resisted -= int (damage * bonus / 100.0);
@@ -7205,7 +7205,7 @@ void Actor::ModifyDamage(Scriptable *hitter, int &damage, int &resisted, int dam
 			}
 			Log(COMBAT, "ModifyDamage", "Resisted {} of {} at {}% resistance to {}", resisted, damage + resisted, GetSafeStat(it->second.resist_stat), damagetype);
 			// PST and BG1 may actually heal on negative damage
-			if (!core->HasFeature(GF_HEAL_ON_100PLUS)) {
+			if (!core->HasFeature(GFFlags::HEAL_ON_100PLUS)) {
 				if (damage <= 0) {
 					resisted = DR_IMMUNE;
 					damage = 0;
@@ -7323,7 +7323,7 @@ void Actor::UpdateModalState(ieDword gameTime)
 	//actually, iwd2 has autosearch, also, this is useful for dayblindness
 	//apply the modal effect about every second (pst and iwds have round sizes that are not multiples of 15)
 	// FIXME: split dayblindness out of detect.spl and only run that each tick + simplify this check
-	if (InParty && core->HasFeature(GF_AUTOSEARCH_HIDDEN) && (third || (roundFraction % core->Time.ai_update_time == 0))) {
+	if (InParty && core->HasFeature(GFFlags::AUTOSEARCH_HIDDEN) && (third || (roundFraction % core->Time.ai_update_time == 0))) {
 		core->ApplySpell(ResRef("detect"), this, this, 0);
 	}
 
@@ -8165,7 +8165,7 @@ void Actor::Draw(const Region& vp, Color baseTint, Color tint, BlitFlags flags) 
 				Color irTint = Color(255, 120, 120, tint.a);
 
 				/* IWD2: infravision is white, not red. */
-				if(core->HasFeature(GF_3ED_RULES)) {
+				if(core->HasFeature(GFFlags::RULES_3ED)) {
 					irTint = Color(255, 255, 255, tint.a);
 				}
 
@@ -8253,7 +8253,7 @@ bool Actor::GetSoundFromFile(ResRef& Sound, TableMgr::index_t index) const
 		if (Modified[IE_STATE_ID] & STATE_CANTLISTEN) return false;
 	}
 
-	if (core->HasFeature(GF_RESDATA_INI)) {
+	if (core->HasFeature(GFFlags::RESDATA_INI)) {
 		return GetSoundFromINI(Sound, index);
 	} else {
 		return GetSoundFrom2DA(Sound, index);
@@ -8319,7 +8319,7 @@ bool Actor::GetSoundFrom2DA(ResRef &Sound, TableMgr::index_t index) const
 bool Actor::GetSoundFromINI(ResRef& Sound, TableMgr::index_t index) const
 {
 	unsigned int animid=BaseStats[IE_ANIMATION_ID];
-	if(core->HasFeature(GF_ONE_BYTE_ANIMID)) {
+	if(core->HasFeature(GFFlags::ONE_BYTE_ANIMID)) {
 		animid&=0xff;
 	}
 
@@ -8417,7 +8417,7 @@ void Actor::GetVerbalConstantSound(ResRef& Sound, size_t index) const
 
 	Sound.Reset();
 
-	if (core->HasFeature(GF_RESDATA_INI)) {
+	if (core->HasFeature(GFFlags::RESDATA_INI)) {
 		GetSoundFromINI(Sound, index);
 	} else {
 		GetSoundFrom2DA(Sound, index);
@@ -8556,7 +8556,7 @@ void Actor::SetPortrait(const ResRef& portraitRef, int Which)
 
 void Actor::SetSoundFolder(const ieVariable& soundset) const
 {
-	if (!core->HasFeature(GF_SOUNDFOLDERS)) {
+	if (!core->HasFeature(GFFlags::SOUNDFOLDERS)) {
 		PCStats->SoundSet = soundset;
 		PCStats->SoundFolder[0] = 0;
 		return;
@@ -8594,7 +8594,7 @@ std::string Actor::GetSoundFolder(int full, const ResRef& overrideSet) const
 	}
 
 	std::string soundset;
-	if (core->HasFeature(GF_SOUNDFOLDERS)) {
+	if (core->HasFeature(GFFlags::SOUNDFOLDERS)) {
 		if (full) {
 			soundset = fmt::format("{}/{}", PCStats->SoundFolder, set);
 		} else {
@@ -9146,7 +9146,7 @@ int Actor::GetBackstabDamage(const Actor *target, WeaponInfo &wi, int multiplier
 		return backstabDamage;
 	}
 
-	if ((!core->HasFeature(GF_PROPER_BACKSTAB) || !IsBehind(target)) && !(always & 0x5)) {
+	if ((!core->HasFeature(GFFlags::PROPER_BACKSTAB) || !IsBehind(target)) && !(always & 0x5)) {
 		return backstabDamage;
 	}
 
@@ -9166,7 +9166,7 @@ int Actor::GetBackstabDamage(const Actor *target, WeaponInfo &wi, int multiplier
 			} else {
 				multiplierText = ieStrRef(int(DisplayMessage::GetStringReference(HCStrings::BackstabDouble, this)) + multiplier - 2);
 			}
-			if (multiplier < 7 || (core->HasFeature(GF_JOURNAL_HAS_SECTIONS) && multiplier < 10)) {
+			if (multiplier < 7 || (core->HasFeature(GFFlags::JOURNAL_HAS_SECTIONS) && multiplier < 10)) {
 				displaymsg->DisplayStringName(multiplierText, GUIColors::WHITE, this, STRING_FLAGS::SOUND);
 			} else {
 				// display a simple message for all other cases
@@ -10438,7 +10438,7 @@ bool Actor::TryToHide()
 	bool seen = SeeAnyOne(true, true);
 
 	stat_t skill;
-	if (core->HasFeature(GF_HAS_HIDE_IN_SHADOWS)) {
+	if (core->HasFeature(GFFlags::HAS_HIDE_IN_SHADOWS)) {
 		skill = (GetStat(IE_HIDEINSHADOWS) + GetStat(IE_STEALTH))/2;
 	} else {
 		skill = GetStat(IE_STEALTH);

--- a/gemrb/core/Scriptable/CombatInfo.cpp
+++ b/gemrb/core/Scriptable/CombatInfo.cpp
@@ -81,7 +81,7 @@ ArmorClass::ArmorClass()
 {
 	ResetAll();
 
-	third = !!core->HasFeature(GF_3ED_RULES);
+	third = core->HasFeature(GFFlags::RULES_3ED);
 }
 
 void ArmorClass::SetOwner( Actor* owner)
@@ -199,7 +199,7 @@ ToHitStats::ToHitStats()
 {
 	ResetAll();
 
-	third = !!core->HasFeature(GF_3ED_RULES);
+	third = core->HasFeature(GFFlags::RULES_3ED);
 }
 
 void ToHitStats::SetOwner(Actor* owner)

--- a/gemrb/core/Scriptable/Container.cpp
+++ b/gemrb/core/Scriptable/Container.cpp
@@ -169,7 +169,7 @@ void Container::TryPickLock(Actor* actor)
 		return;
 	}
 	int stat = actor->GetStat(IE_LOCKPICKING);
-	if (core->HasFeature(GF_3ED_RULES)) {
+	if (core->HasFeature(GFFlags::RULES_3ED)) {
 		int skill = actor->GetSkill(IE_LOCKPICKING);
 		if (skill == 0) { // a trained skill, make sure we fail
 			stat = 0;
@@ -203,7 +203,7 @@ void Container::TryBashLock(Actor *actor)
 	int bonus;
 	unsigned int roll;
 
-	if (core->HasFeature(GF_3ED_RULES)) {
+	if (core->HasFeature(GFFlags::RULES_3ED)) {
 		bonus = actor->GetAbilityBonus(IE_STR);
 		roll = actor->LuckyRoll(1, 100, bonus, 0);
 	} else {
@@ -213,7 +213,7 @@ void Container::TryBashLock(Actor *actor)
 		roll = actor->LuckyRoll(1, 10, bonus, 0);
 	}
 
-	if (core->HasFeature(GF_3ED_RULES)) {
+	if (core->HasFeature(GFFlags::RULES_3ED)) {
 		// ~Bash door check. Roll %d + %d Str mod > %d door DC.~
 		// there is no separate string for non-doors
 		displaymsg->DisplayRollStringName(ieStrRef::ROLL1, GUIColors::LIGHTGREY, actor, roll, bonus, LockDifficulty);

--- a/gemrb/core/Scriptable/Door.cpp
+++ b/gemrb/core/Scriptable/Door.cpp
@@ -130,7 +130,7 @@ void Door::ToggleTiles(int State, int playsound)
 	}
 
 	//set door_open as state
-	Flags = (Flags & ~DOOR_OPEN) | (State == !core->HasFeature(GF_REVERSE_DOOR) );
+	Flags = (Flags & ~DOOR_OPEN) | (State == !core->HasFeature(GFFlags::REVERSE_DOOR) );
 }
 
 //this is the short name (not the scripting name)
@@ -157,7 +157,7 @@ void Door::SetDoorLocked(int Locked, int playsound)
 		if (Flags & DOOR_LOCKED) return;
 		Flags|=DOOR_LOCKED;
 		// only close it in pst, needed for Dead nations (see 4a3e1cb4ef)
-		if (core->HasFeature(GF_REVERSE_DOOR)) SetDoorOpen(false, playsound, 0);
+		if (core->HasFeature(GFFlags::REVERSE_DOOR)) SetDoorOpen(false, playsound, 0);
 		if (playsound && !LockSound.IsEmpty())
 			core->GetAudioDrv()->PlayRelative(LockSound, SFX_CHAN_ACTIONS);
 	}
@@ -171,7 +171,7 @@ void Door::SetDoorLocked(int Locked, int playsound)
 
 int Door::IsOpen() const
 {
-	int ret = core->HasFeature(GF_REVERSE_DOOR);
+	int ret = core->HasFeature(GFFlags::REVERSE_DOOR);
 	if (Flags&DOOR_OPEN) {
 		ret = !ret;
 	}
@@ -260,7 +260,7 @@ void Door::SetDoorOpen(int Open, int playsound, ieDword openerID, bool addTrigge
 		}
 
 		// in PS:T, opening a door does not unlock it
-		if (!core->HasFeature(GF_REVERSE_DOOR)) {
+		if (!core->HasFeature(GFFlags::REVERSE_DOOR)) {
 			SetDoorLocked(false,playsound);
 		}
 	} else if (addTrigger) {
@@ -282,7 +282,7 @@ bool Door::TryUnlock(Actor *actor) const
 	if (!(Flags&DOOR_LOCKED)) return true;
 
 	// don't remove key in PS:T!
-	bool removekey = !core->HasFeature(GF_REVERSE_DOOR) && Flags&DOOR_KEY;
+	bool removekey = !core->HasFeature(GFFlags::REVERSE_DOOR) && Flags&DOOR_KEY;
 	return Highlightable::TryUnlock(actor, removekey);
 }
 
@@ -328,7 +328,7 @@ void Highlightable::TryDisarm(Actor* actor)
 	int bonus = 0;
 	int trapDC = TrapRemovalDiff;
 
-	if (core->HasFeature(GF_3ED_RULES)) {
+	if (core->HasFeature(GFFlags::RULES_3ED)) {
 		skill = actor->GetSkill(IE_TRAPS);
 		roll = core->Roll(1, 20, 0);
 		bonus = actor->GetAbilityBonus(IE_INT);
@@ -346,7 +346,7 @@ void Highlightable::TryDisarm(Actor* actor)
 		AddTrigger(TriggerEntry(trigger_disarmed, actor->GetGlobalID()));
 		//trap removed
 		Trapped = 0;
-		if (core->HasFeature(GF_3ED_RULES)) {
+		if (core->HasFeature(GFFlags::RULES_3ED)) {
 			// ~Successful Disarm Device - d20 roll %d + Disarm Device skill %d + INT mod %d >= Trap DC %d~
 			displaymsg->DisplayRollStringName(ieStrRef::ROLL6, GUIColors::LIGHTGREY, actor, roll, skill-bonus, bonus, trapDC);
 		}
@@ -358,7 +358,7 @@ void Highlightable::TryDisarm(Actor* actor)
 		core->PlaySound(DS_DISARMED, SFX_CHAN_HITS);
 	} else {
 		AddTrigger(TriggerEntry(trigger_disarmfailed, actor->GetGlobalID()));
-		if (core->HasFeature(GF_3ED_RULES)) {
+		if (core->HasFeature(GFFlags::RULES_3ED)) {
 			// ~Failed Disarm Device - d20 roll %d + Disarm Device skill %d + INT mod %d >= Trap DC %d~
 			displaymsg->DisplayRollStringName(ieStrRef::ROLL6, GUIColors::LIGHTGREY, actor, roll, skill-bonus, bonus, trapDC);
 		}
@@ -379,7 +379,7 @@ void Door::TryPickLock(Actor* actor)
 		return;
 	}
 	int stat = actor->GetStat(IE_LOCKPICKING);
-	if (core->HasFeature(GF_3ED_RULES)) {
+	if (core->HasFeature(GFFlags::RULES_3ED)) {
 		int skill = actor->GetSkill(IE_LOCKPICKING);
 		if (skill == 0) { // a trained skill, make sure we fail
 			stat = 0;
@@ -413,7 +413,7 @@ void Door::TryBashLock(Actor *actor)
 	int bonus;
 	unsigned int roll;
 
-	if (core->HasFeature(GF_3ED_RULES)) {
+	if (core->HasFeature(GFFlags::RULES_3ED)) {
 		bonus = actor->GetAbilityBonus(IE_STR);
 		roll = actor->LuckyRoll(1, 100, bonus, 0);
 	} else {
@@ -424,7 +424,7 @@ void Door::TryBashLock(Actor *actor)
 	}
 
 	actor->FaceTarget(this);
-	if (core->HasFeature(GF_3ED_RULES)) {
+	if (core->HasFeature(GFFlags::RULES_3ED)) {
 		// ~Bash door check. Roll %d + %d Str mod > %d door DC.~
 		displaymsg->DisplayRollStringName(ieStrRef::ROLL1, GUIColors::LIGHTGREY, actor, roll, bonus, LockDifficulty);
 	}

--- a/gemrb/core/Scriptable/InfoPoint.cpp
+++ b/gemrb/core/Scriptable/InfoPoint.cpp
@@ -47,8 +47,8 @@ InfoPoint::InfoPoint(void)
 		//0     - PST - no such flag
 		//0x200 - IWD2 - it has no TRAP_NONPC flag, the usepoint flag takes it over
 		//0x400 - all other engines (some don't use it)
-		if (core->HasFeature(GF_USEPOINT_400)) TRAP_USEPOINT = _TRAP_USEPOINT;
-		else if (core->HasFeature(GF_USEPOINT_200)) TRAP_USEPOINT = _TRAVEL_NONPC;
+		if (core->HasFeature(GFFlags::USEPOINT_400)) TRAP_USEPOINT = _TRAP_USEPOINT;
+		else if (core->HasFeature(GFFlags::USEPOINT_200)) TRAP_USEPOINT = _TRAVEL_NONPC;
 		else TRAP_USEPOINT = 0;
 	}
 }
@@ -78,7 +78,7 @@ int InfoPoint::CheckTravel(const Actor *actor) const
 	}
 
 	// pst doesn't care about distance, selection or the party bit at all
-	static const bool teamMove = core->HasFeature(GF_TEAM_MOVEMENT);
+	static const bool teamMove = core->HasFeature(GFFlags::TEAM_MOVEMENT);
 	if (pm && ((Flags&TRAVEL_PARTY) || teamMove)) {
 		if (teamMove || core->GetGame()->EveryoneNearPoint(actor->GetCurrentArea(), actor->Pos, ENP_CANMOVE) ) {
 			return CT_WHOLE;
@@ -109,12 +109,12 @@ bool InfoPoint::CanDetectTrap() const
 }
 
 // returns true if the infopoint is a PS:T portal
-// GF_REVERSE_DOOR is the closest game feature (exists only in PST, and about area objects)
+// GFFlags::REVERSE_DOOR is the closest game feature (exists only in PST, and about area objects)
 bool InfoPoint::IsPortal() const
 {
 	if (Type!=ST_TRAVEL) return false;
 	if (Cursor != IE_CURSOR_PORTAL) return false;
-	return core->HasFeature(GF_REVERSE_DOOR);
+	return core->HasFeature(GFFlags::REVERSE_DOOR);
 }
 
 // returns the appropriate cursor over an active region (trap, infopoint, travel region)

--- a/gemrb/core/Scriptable/OverHeadText.cpp
+++ b/gemrb/core/Scriptable/OverHeadText.cpp
@@ -44,7 +44,7 @@ void OverHeadText::SetText(String newText, bool display, bool append, const Colo
 	}
 
 	// always append for actors and areas ... unless it's the head hp ratio
-	if (append && core->HasFeature(GF_ONSCREEN_TEXT) && (owner->Type == ST_ACTOR || owner->Type == ST_AREA)) {
+	if (append && core->HasFeature(GFFlags::ONSCREEN_TEXT) && (owner->Type == ST_ACTOR || owner->Type == ST_AREA)) {
 		idx = messages.size();
 		messages.emplace_back();
 		if (owner->Type == ST_ACTOR) {
@@ -130,7 +130,7 @@ bool OverHeadMsg::Draw(int heightOffset, const Point& fallbackPos, int ownerType
 {
 	static constexpr tick_t maxDelay = 6000;
 	tick_t delay = maxDelay;
-	if (core->HasFeature(GF_ONSCREEN_TEXT) && !scrollOffset.IsInvalid()) {
+	if (core->HasFeature(GFFlags::ONSCREEN_TEXT) && !scrollOffset.IsInvalid()) {
 		// empirically determined estimate to get the right speed and distance and 2px/tick
 		delay = 1800;
 	}

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -53,9 +53,9 @@ static const unsigned short ClearActionsID = 133; // same for all games
  ***********************/
 Scriptable::Scriptable(ScriptableType type)
 {
-	startActive = core->HasFeature(GF_START_ACTIVE);
-	third = core->HasFeature(GF_3ED_RULES);
-	pst_flags = core->HasFeature(GF_PST_STATE_FLAGS);
+	startActive = core->HasFeature(GFFlags::START_ACTIVE);
+	third = core->HasFeature(GFFlags::RULES_3ED);
+	pst_flags = core->HasFeature(GFFlags::PST_STATE_FLAGS);
 
 	globalID = ++globalActorCounter;
 	if (globalActorCounter == 0) {
@@ -255,7 +255,7 @@ void Scriptable::ExecuteScript(int scriptCount)
 	// area scripts still run for at least the current area, in bg1 (see ar2631, confirmed by testing)
 	// but not in bg2 (kill Abazigal in ar6005)
 	if (gc->GetScreenFlags() & SF_CUTSCENE) {
-		if (! (core->HasFeature(GF_CUTSCENE_AREASCRIPTS) && Type == ST_AREA)) {
+		if (! (core->HasFeature(GFFlags::CUTSCENE_AREASCRIPTS) && Type == ST_AREA)) {
 			return;
 		}
 	}
@@ -280,8 +280,8 @@ void Scriptable::ExecuteScript(int scriptCount)
 	Actor* act = Scriptable::As<Actor>(this);
 
 	// don't run if the final dialog action queue is still playing out (we're already out of dialog!)
-	// currently limited with GF_CUTSCENE_AREASCRIPTS and to area scripts, to minimize risk into known test cases
-	if (Type == ST_AREA && !core->HasFeature(GF_CUTSCENE_AREASCRIPTS) && gc->GetDialogueFlags() & DF_POSTPONE_SCRIPTS) {
+	// currently limited with GFFlags::CUTSCENE_AREASCRIPTS and to area scripts, to minimize risk into known test cases
+	if (Type == ST_AREA && !core->HasFeature(GFFlags::CUTSCENE_AREASCRIPTS) && gc->GetDialogueFlags() & DF_POSTPONE_SCRIPTS) {
 		return;
 	}
 
@@ -1706,7 +1706,7 @@ void Highlightable::DrawOutline(Point origin) const
 	}
 	origin = outline->BBox.origin - origin;
 
-	if (core->HasFeature(GF_PST_STATE_FLAGS)) {
+	if (core->HasFeature(GFFlags::PST_STATE_FLAGS)) {
 		core->GetVideoDriver()->DrawPolygon( outline.get(), origin, outlineColor, true, BlitFlags::MULTIPLY|BlitFlags::HALFTRANS );
 	} else {
 		core->GetVideoDriver()->DrawPolygon( outline.get(), origin, outlineColor, true, BlitFlags::BLENDED|BlitFlags::HALFTRANS );

--- a/gemrb/core/Spell.cpp
+++ b/gemrb/core/Spell.cpp
@@ -53,7 +53,7 @@ private:
 		EffectRef dmgref = { "Damage", -1 };
 		damageOpcode = EffectQueue::ResolveEffect(dmgref);
 
-		pstflags = core->HasFeature(GF_PST_STATE_FLAGS);
+		pstflags = core->HasFeature(GFFlags::PST_STATE_FLAGS);
 		AutoTable tm = gamedata->LoadTable("splfocus", true);
 		if (tm) {
 			TableMgr::index_t schoolcount = tm->GetRowCount();
@@ -127,7 +127,7 @@ void Spell::AddCastingGlow(EffectQueue *fxqueue, ieDword duration, int gender) c
 			t = 'm';
 		}
 		//check if bg1
-		if (!core->HasFeature(GF_CASTING_SOUNDS) && !core->HasFeature(GF_CASTING_SOUNDS2)) {
+		if (!core->HasFeature(GFFlags::CASTING_SOUNDS) && !core->HasFeature(GFFlags::CASTING_SOUNDS2)) {
 			Resource.Format("CAS_P{}{:01d}{}", t, std::min(cgsound, 9), g);
 		} else {
 			Resource.Format("CHA_{}{}{:02d}", g, t, std::min(cgsound & 0xff, 99));

--- a/gemrb/core/Spellbook.cpp
+++ b/gemrb/core/Spellbook.cpp
@@ -61,12 +61,12 @@ void Spellbook::InitializeSpellbook()
 {
 	if (!SBInitialized) {
 		SBInitialized=true;
-		if (core->HasFeature(GF_HAS_SPELLLIST)) {
+		if (core->HasFeature(GFFlags::HAS_SPELLLIST)) {
 			NUM_BOOK_TYPES=NUM_IWD2_SPELLTYPES; //iwd2 spell types
 			IWD2Style = true;
 		} else {
 			NUM_BOOK_TYPES=NUM_SPELLTYPES; //bg/pst/iwd1 spell types
-			if (core->HasFeature(GF_IWD_MAP_DIMENSIONS)) NUM_BOOK_TYPES++; // make iwd songs full members
+			if (core->HasFeature(GFFlags::IWD_MAP_DIMENSIONS)) NUM_BOOK_TYPES++; // make iwd songs full members
 			IWD2Style = false;
 		}
 	}

--- a/gemrb/core/Store.cpp
+++ b/gemrb/core/Store.cpp
@@ -260,7 +260,7 @@ void Store::RechargeItem(CREItem *item) const
 	//flag     0   0   1   1
 	//recharge 1   0   0   1
 	if (IsBag() != !(Flags&IE_STORE_RECHARGE)) {
-		bool feature = core->HasFeature(GF_SHOP_RECHARGE);
+		bool feature = core->HasFeature(GFFlags::SHOP_RECHARGE);
 		for (int i=0;i<CHARGE_COUNTERS;i++) {
 			const ITMExtHeader *h = itm->GetExtHeader(i);
 			if (!h) {

--- a/gemrb/core/TileMap.cpp
+++ b/gemrb/core/TileMap.cpp
@@ -131,7 +131,7 @@ void TileMap::UpdateDoors()
 // used during time compression in bg1 ... but potentially problematic, so we don't enable it elsewhere
 void TileMap::AutoLockDoors() const
 {
-	if (!core->HasFeature(GF_RANDOM_BANTER_DIALOGS)) return;
+	if (!core->HasFeature(GFFlags::RANDOM_BANTER_DIALOGS)) return;
 
 	for (Door *door : doors) {
 		if (door->CantAutoClose()) continue;

--- a/gemrb/core/TileOverlay.cpp
+++ b/gemrb/core/TileOverlay.cpp
@@ -75,11 +75,11 @@ void TileOverlay::Draw(const Region& viewport, std::vector<TileOverlayPtr> &over
 					const Tile &ovtile = ov->tiles[0]; //allow only 1x1 tiles now
 					if (tile.om & mask) {
 						//draw overlay tiles, they should be half transparent except for BG1
-						BlitFlags transFlag = (core->HasFeature(GF_LAYERED_WATER_TILES)) ? BlitFlags::HALFTRANS : BlitFlags::NONE;
+						BlitFlags transFlag = (core->HasFeature(GFFlags::LAYERED_WATER_TILES)) ? BlitFlags::HALFTRANS : BlitFlags::NONE;
 						// this is the water (or whatever)
 						vid->BlitGameSprite(ovtile.GetAnimation(0)->NextFrame(), p, flags | transFlag, tintcol);
 
-						if (core->HasFeature(GF_LAYERED_WATER_TILES)) {
+						if (core->HasFeature(GFFlags::LAYERED_WATER_TILES)) {
 							Animation* anim1 = tile.GetAnimation(1);
 							if (anim1) {
 								// this is the mask to blend the terrain tile with the water for everything but BG1

--- a/gemrb/core/WorldMap.cpp
+++ b/gemrb/core/WorldMap.cpp
@@ -86,7 +86,7 @@ Holder<Sprite2D> WMPAreaEntry::GetMapIcon(const AnimationFactory *bam)
 ieDword WMPAreaEntry::GetAreaStatus() const
 {
 	ieDword tmp = AreaStatus;
-	if (core->HasFeature(GF_KNOW_WORLD) ) {
+	if (core->HasFeature(GFFlags::KNOW_WORLD) ) {
 		tmp |=WMP_ENTRY_VISITED;
 	}
 	return tmp;

--- a/gemrb/core/WorldMap.cpp
+++ b/gemrb/core/WorldMap.cpp
@@ -119,15 +119,15 @@ void WorldMap::SetAreaEntry(unsigned int x, WMPAreaEntry&& ae)
 	}
 }
 
-void WorldMap::InsertAreaLink(unsigned int areaidx, unsigned int dir, WMPAreaLink&& arealink)
+void WorldMap::InsertAreaLink(unsigned int areaidx, WMPDirection dir, WMPAreaLink&& arealink)
 {
-	unsigned int idx = area_entries[areaidx].AreaLinksIndex[dir];
+	ieDword idx = area_entries[areaidx].AreaLinksIndex[dir];
 	area_links.emplace(area_links.begin()+idx, std::move(arealink));
 
 	size_t max = area_entries.size();
 	for (unsigned int pos = 0; pos < max; pos++) {
 		WMPAreaEntry& ae = area_entries[pos];
-		for (unsigned int k=0;k<4;k++) {
+		for (WMPDirection k : EnumIterator<WMPDirection>()) {
 			if ((pos==areaidx) && (k==dir)) {
 				ae.AreaLinksCount[k]++;
 				continue;
@@ -226,18 +226,13 @@ const WMPAreaEntry* WorldMap::FindNearestEntry(const ResRef& areaName, unsigned 
 
 //this is a pathfinding algorithm
 //you have to find the optimal path
-int WorldMap::CalculateDistances(const ResRef& areaName, int direction)
+int WorldMap::CalculateDistances(const ResRef& areaName, WMPDirection direction)
 {
 	//first, update reachable/visible areas by worlde.2da if exists
 	UpdateReachableAreas();
 	UpdateAreaVisibility(areaName, direction);
-	if (direction==-1) {
+	if (direction == WMPDirection::NONE) {
 		return 0;
-	}
-
-	if (direction<0 || direction>3) {
-		Log(ERROR, "WorldMap", "CalculateDistances for invalid direction: {}", areaName);
-		return -1;
 	}
 
 	unsigned int i;
@@ -264,12 +259,12 @@ int WorldMap::CalculateDistances(const ResRef& areaName, int direction)
 		const WMPAreaEntry& ae = area_entries[i];
 		std::fill(seen_entry.begin(), seen_entry.end(), -1);
 		//all directions should be used
-		for(int d=0;d<4;d++) {
+		for (WMPDirection d : EnumIterator<WMPDirection>()) {
 			int j=ae.AreaLinksIndex[d];
 			int k=j+ae.AreaLinksCount[d];
 			if ((size_t) k>area_links.size()) {
 				Log(ERROR, "WorldMap", "The worldmap file is corrupted... and it would crash right now! Entry #: {} Direction: {}",
-					i, d);
+					i, UnderType(d));
 				break;
 			}
 			for(;j<k;j++) {
@@ -307,7 +302,7 @@ unsigned int WorldMap::WhoseLinkAmI(int link_index) const
 	unsigned int cnt = GetEntryCount();
 	for (unsigned int i = 0; i < cnt; i++) {
 		const WMPAreaEntry& ae = area_entries[i];
-		for (int direction=0;direction<4;direction++)
+		for (WMPDirection direction : EnumIterator<WMPDirection>())
 		{
 			int j=ae.AreaLinksIndex[direction];
 			if (link_index < j) continue;
@@ -330,9 +325,9 @@ WMPAreaLink *WorldMap::GetLink(const ResRef& A, const ResRef& B)
 	}
 
 	//looking for destination area, returning the first link found
-	for (i = 0; i < 4; i++) {
-		unsigned int j = ae->AreaLinksCount[i];
-		unsigned int k = ae->AreaLinksIndex[i];
+	for (WMPDirection dir : EnumIterator<WMPDirection>()) {
+		unsigned int j = ae->AreaLinksCount[dir];
+		unsigned int k = ae->AreaLinksIndex[dir];
 		while(j--) {
 			WMPAreaLink& al = area_links[k++];
 			const WMPAreaEntry& ae2 = area_entries[al.AreaIndex];
@@ -440,13 +435,13 @@ void WorldMap::SetEncounterArea(const ResRef& area, const WMPAreaLink *link) {
 	lsrc.DistanceScale /= 2;
 	lsrc.EncounterChance = 0;
 
-	size_t idx = area_links.size();
+	ieDword idx = Clamp<ieDword>(area_links.size());
 	AddAreaLink(std::move(ldest));
 	AddAreaLink(std::move(lsrc));
 
-	for (i = 0; i < 4; ++i) {
-		ae.AreaLinksCount[i] = 2;
-		ae.AreaLinksIndex[i] = static_cast<ieDword>(idx);
+	for (WMPDirection dir : EnumIterator<WMPDirection>()) {
+		ae.AreaLinksCount[dir] = 2;
+		ae.AreaLinksIndex[dir] = idx;
 	}
 	
 	encounterArea = area_entries.size();
@@ -464,8 +459,8 @@ void WorldMap::ClearEncounterArea()
 	//NOTE: if anything else added links after us we'd have to globally
 	//update all link indices, but since ambush areas do not allow
 	//saving/loading we should be okay with this
-	area_links.erase(area_links.begin() + ea.AreaLinksIndex[0],
-		area_links.begin() + ea.AreaLinksIndex[0] + ea.AreaLinksCount[0]);
+	auto begin = area_links.begin() + ea.AreaLinksIndex[WMPDirection::NORTH];
+	area_links.erase(begin, begin + ea.AreaLinksCount[WMPDirection::NORTH]);
 
 	area_entries.erase(area_entries.begin() + encounterArea);
 	encounterArea = -1;
@@ -480,7 +475,7 @@ int WorldMap::GetDistance(const ResRef& areaName) const
 	return -1;
 }
 
-void WorldMap::UpdateAreaVisibility(const ResRef& areaName, int direction)
+void WorldMap::UpdateAreaVisibility(const ResRef& areaName, WMPDirection direction)
 {
 	unsigned int i;
 
@@ -491,8 +486,6 @@ void WorldMap::UpdateAreaVisibility(const ResRef& areaName, int direction)
 	Log(DEBUG, "WorldMap", "Updated Area visibility: {} (visited, accessible and visible)", areaName);
 
 	ae->SetAreaStatus(WMP_ENTRY_VISITED|WMP_ENTRY_VISIBLE|WMP_ENTRY_ACCESSIBLE, BitOp::OR);
-	if (direction<0 || direction>3)
-		return;
 	i=ae->AreaLinksCount[direction];
 	while (i--) {
 		const WMPAreaLink& al = area_links[ae->AreaLinksIndex[direction] + i];

--- a/gemrb/core/WorldMap.h
+++ b/gemrb/core/WorldMap.h
@@ -32,6 +32,7 @@
 #include "ie_types.h"
 
 #include "AnimationFactory.h"
+#include "EnumIndex.h"
 #include "Sprite2D.h"
 
 #include <vector>
@@ -39,12 +40,13 @@
 namespace GemRB {
 
 /** this is the physical order the links appear in WMPAreaEntry */
-enum class WMPDirection {
-	NONE = -1,
+enum class WMPDirection : uint8_t {
+	NONE = 0xff,
 	NORTH = 0,
 	WEST = 1,
 	SOUTH = 2,
-	EAST = 3
+	EAST = 3,
+	count
 };
 
 /** Area is visible on WorldMap */
@@ -94,8 +96,8 @@ public:
 	ieStrRef LocCaptionName = ieStrRef::INVALID;
 	ieStrRef LocTooltipName = ieStrRef::INVALID;
 	ResRef LoadScreenResRef;
-	ieDword AreaLinksIndex[4]{};
-	ieDword AreaLinksCount[4]{};
+	EnumArray<WMPDirection, ieDword> AreaLinksIndex;
+	EnumArray<WMPDirection, ieDword> AreaLinksCount;
 };
 
 /**
@@ -150,12 +152,12 @@ public:
 	int GetLinkCount() const { return (int) area_links.size(); }
 	const WMPAreaLink *GetLink(unsigned int index) const { return &area_links[index]; }
 	void SetAreaEntry(unsigned int index, WMPAreaEntry&& areaentry);
-	void InsertAreaLink(unsigned int idx, unsigned int dir, WMPAreaLink&& arealink);
+	void InsertAreaLink(unsigned int idx, WMPDirection dir, WMPAreaLink&& arealink);
 	void SetAreaLink(unsigned int index, const WMPAreaLink *arealink);
 	void AddAreaEntry(WMPAreaEntry&& ae);
 	void AddAreaLink(WMPAreaLink&& al);
 	/** Calculates the distances from A, call this when first on an area */
-	int CalculateDistances(const ResRef& A, int direction);
+	int CalculateDistances(const ResRef& A, WMPDirection direction);
 	/** Returns the precalculated distance to area B */
 	int GetDistance(const ResRef& A) const;
 	/** Returns the link between area A and area B */
@@ -175,7 +177,7 @@ public:
 	void ClearEncounterArea();
 private:
 	/** updates visibility of adjacent areas, called from CalculateDistances */
-	void UpdateAreaVisibility(const ResRef& areaName, int direction);
+	void UpdateAreaVisibility(const ResRef& areaName, WMPDirection direction);
 	/** internal function to calculate the distances from areaindex */
 	void CalculateDistance(int areaindex, int direction);
 	unsigned int WhoseLinkAmI(int link_index) const;

--- a/gemrb/includes/globals.h
+++ b/gemrb/includes/globals.h
@@ -55,94 +55,95 @@ namespace GemRB {
 //Global Variables
 
 /////feature flags
-enum GameFeatureFlags : uint32_t {
-	GF_HAS_KAPUTZ,          			//pst
-	GF_ALL_STRINGS_TAGGED,   			//bg1, pst, iwd1
-	GF_HAS_SONGLIST,        			//bg2
-	GF_TEAM_MOVEMENT,       			//pst
-	GF_UPPER_BUTTON_TEXT,   			//bg2
-	GF_LOWER_LABEL_TEXT,    			//bg2
-	GF_HAS_PARTY_INI,       			//iwd2
-	GF_SOUNDFOLDERS,        			//iwd2
-	GF_IGNORE_BUTTON_FRAMES,			// all?
-	GF_ONE_BYTE_ANIMID,     			// pst
-	GF_HAS_DPLAYER,         			// not pst
-	GF_HAS_EXPTABLE,        			// iwd, iwd2
-	GF_HAS_BEASTS_INI,      			//pst; also for quests.ini
-	GF_HAS_EE_EFFECTS,       			//ees
-	GF_HAS_PICK_SOUND,      			//pst
-	GF_IWD_MAP_DIMENSIONS,  			//iwd, iwd2
-	GF_AUTOMAP_INI,         			//pst
-	GF_SMALL_FOG,           			//bg1, pst
-	GF_REVERSE_DOOR,        			//pst
-	GF_PROTAGONIST_TALKS,   			//pst
-	GF_HAS_SPELLLIST,       			//iwd2
-	GF_IWD2_SCRIPTNAME,     			//iwd2, iwd, how
-	GF_DIALOGUE_SCROLLS,    			//pst
-	GF_KNOW_WORLD,          			//iwd2
-	GF_REVERSE_TOHIT,       			//all except iwd2
-	GF_SAVE_FOR_HALF,       			//pst
-	GF_CHARNAMEISGABBER,   				//iwd2
-	GF_MAGICBIT,            			//iwd, iwd2
-	GF_CHECK_ABILITIES,     			//bg2 (others?)
-	GF_CHALLENGERATING,     			//iwd2
-	GF_SPELLBOOKICONHACK,   			//bg2
-	GF_ENHANCED_EFFECTS,    			//iwd2 (maybe iwd/how too)
-	GF_DEATH_ON_ZERO_STAT,  			//not in iwd2
-	GF_SPAWN_INI,           			//pst, iwd, iwd2
-	GF_IWD2_DEATHVARFORMAT,  			//iwd branch (maybe pst)
-	GF_RESDATA_INI,         			//pst
-	GF_OVERRIDE_CURSORPOS,  			//pst, iwd2
-	GF_BREAKABLE_WEAPONS,     			//only bg1
-	GF_3ED_RULES,              			//iwd2
-	GF_LEVELSLOT_PER_CLASS,    			//iwd2
-	GF_SELECTIVE_MAGIC_RES,    			//bg2, iwd2, (how)
-	GF_HAS_HIDE_IN_SHADOWS,    			// bg2, iwd2
-	GF_AREA_VISITED_VAR,    			//iwd, iwd2
-	GF_PROPER_BACKSTAB,     			//bg2, iwd2, how?
-	GF_ONSCREEN_TEXT,       			//pst
-	GF_SPECIFIC_DMG_BONUS,				//how, iwd2
-	GF_STRREF_SAVEGAME,       			//iwd2
-	GF_SIMPLE_DISRUPTION,      			// ToBEx: simplified disruption
-	GF_BIOGRAPHY_RES,               	//iwd branch
-	GF_NO_BIOGRAPHY,                	//pst
-	GF_STEAL_IS_ATTACK,             	//bg2 for sure
-	GF_CUTSCENE_AREASCRIPTS,			//bg1, maybe more
-	GF_FLEXIBLE_WMAP,               	//iwd
-	GF_AUTOSEARCH_HIDDEN,           	//all except iwd2
-	GF_PST_STATE_FLAGS,             	//pst complicates this
-	GF_NO_DROP_CAN_MOVE,            	//bg1
-	GF_JOURNAL_HAS_SECTIONS,        	//bg2
-	GF_CASTING_SOUNDS,              	//all except pst and bg1
-	GF_CASTING_SOUNDS2,             	//bg2
-	GF_FORCE_AREA_SCRIPT,           	//how and iwd2 (maybe iwd1)
-	GF_AREA_OVERRIDE,               	//pst maze and other hardcode
-	GF_NO_NEW_VARIABLES,            	//pst
-	GF_SOUNDS_INI,                  	//iwd/how/iwd2
-	GF_USEPOINT_400,                	//all except pst and iwd2
-	GF_USEPOINT_200,                	//iwd2
-	GF_HAS_FLOAT_MENU,              	//pst
-	GF_RARE_ACTION_VB,              	//pst
-	GF_NO_UNDROPPABLE,              	//iwd,how
-	GF_START_ACTIVE,                	//bg1
-	GF_INFOPOINT_DIALOGS,           	//pst, but only bg1 has garbage there
-	GF_IMPLICIT_AREAANIM_BACKGROUND,	//idw,how,iwd2
-	GF_HEAL_ON_100PLUS,             	//bg1, bg2, pst
-	GF_IN_PARTY_ALLOWS_DEAD,			//all except bg2
-	GF_ZERO_TIMER_IS_VALID,         	// how, not bg2, other unknown
-	GF_SHOP_RECHARGE,               	// all?
-	GF_MELEEHEADER_USESPROJECTILE,  	// minimally bg2
-	GF_FORCE_DIALOGPAUSE,           	// all except if using v1.04 DLG files (bg2, special)
-	GF_RANDOM_BANTER_DIALOGS,       	// bg1
-	GF_FIXED_MORALE_OPCODE,         	// bg2
-	GF_HAPPINESS,                   	// all except pst and iwd2
-	GF_EFFICIENT_OR,                	// does the OR trigger shortcircuit on success or not? Only in iwd2
-	GF_LAYERED_WATER_TILES,				// TileOverlay for water has an extra half transparent layer (all but BG1)
-	GF_CLEARING_ACTIONOVERRIDE,         // bg2, not iwd2
-	GF_DAMAGE_INNOCENT_REP,             // not bg1
-	GF_HAS_WEAPON_SETS,             	// iwd2
+enum class GFFlags : uint32_t {
+	// this enum must begin at 0 for iteration
+	HAS_KAPUTZ = 0,          		//pst
+	ALL_STRINGS_TAGGED,   			//bg1, pst, iwd1
+	HAS_SONGLIST,        			//bg2
+	TEAM_MOVEMENT,       			//pst
+	UPPER_BUTTON_TEXT,   			//bg2
+	LOWER_LABEL_TEXT,    			//bg2
+	HAS_PARTY_INI,       			//iwd2
+	SOUNDFOLDERS,        			//iwd2
+	IGNORE_BUTTON_FRAMES,			// all?
+	ONE_BYTE_ANIMID,     			// pst
+	HAS_DPLAYER,         			// not pst
+	HAS_EXPTABLE,        			// iwd, iwd2
+	HAS_BEASTS_INI,      			//pst; also for quests.ini
+	HAS_EE_EFFECTS,       			//ees
+	HAS_PICK_SOUND,      			//pst
+	IWD_MAP_DIMENSIONS,  			//iwd, iwd2
+	AUTOMAP_INI,         			//pst
+	SMALL_FOG,           			//bg1, pst
+	REVERSE_DOOR,        			//pst
+	PROTAGONIST_TALKS,   			//pst
+	HAS_SPELLLIST,       			//iwd2
+	IWD2_SCRIPTNAME,     			//iwd2, iwd, how
+	DIALOGUE_SCROLLS,    			//pst
+	KNOW_WORLD,          			//iwd2
+	REVERSE_TOHIT,       			//all except iwd2
+	SAVE_FOR_HALF,       			//pst
+	CHARNAMEISGABBER,   				//iwd2
+	MAGICBIT,            			//iwd, iwd2
+	CHECK_ABILITIES,     			//bg2 (others?)
+	CHALLENGERATING,     			//iwd2
+	SPELLBOOKICONHACK,   			//bg2
+	ENHANCED_EFFECTS,    			//iwd2 (maybe iwd/how too)
+	DEATH_ON_ZERO_STAT,  			//not in iwd2
+	SPAWN_INI,           			//pst, iwd, iwd2
+	IWD2_DEATHVARFORMAT,  			//iwd branch (maybe pst)
+	RESDATA_INI,         			//pst
+	OVERRIDE_CURSORPOS,  			//pst, iwd2
+	BREAKABLE_WEAPONS,     			//only bg1
+	RULES_3ED,              			//iwd2
+	LEVELSLOT_PER_CLASS,    			//iwd2
+	SELECTIVE_MAGIC_RES,    			//bg2, iwd2, (how)
+	HAS_HIDE_IN_SHADOWS,    			// bg2, iwd2
+	AREA_VISITED_VAR,    			//iwd, iwd2
+	PROPER_BACKSTAB,     			//bg2, iwd2, how?
+	ONSCREEN_TEXT,       			//pst
+	SPECIFIC_DMG_BONUS,				//how, iwd2
+	STRREF_SAVEGAME,       			//iwd2
+	SIMPLE_DISRUPTION,      			// ToBEx: simplified disruption
+	BIOGRAPHY_RES,               	//iwd branch
+	NO_BIOGRAPHY,                	//pst
+	STEAL_IS_ATTACK,             	//bg2 for sure
+	CUTSCENE_AREASCRIPTS,			//bg1, maybe more
+	FLEXIBLE_WMAP,               	//iwd
+	AUTOSEARCH_HIDDEN,           	//all except iwd2
+	PST_STATE_FLAGS,             	//pst complicates this
+	NO_DROP_CAN_MOVE,            	//bg1
+	JOURNAL_HAS_SECTIONS,        	//bg2
+	CASTING_SOUNDS,              	//all except pst and bg1
+	CASTING_SOUNDS2,             	//bg2
+	FORCE_AREA_SCRIPT,           	//how and iwd2 (maybe iwd1)
+	AREA_OVERRIDE,               	//pst maze and other hardcode
+	NO_NEW_VARIABLES,            	//pst
+	SOUNDS_INI,                  	//iwd/how/iwd2
+	USEPOINT_400,                	//all except pst and iwd2
+	USEPOINT_200,                	//iwd2
+	HAS_FLOAT_MENU,              	//pst
+	RARE_ACTION_VB,              	//pst
+	NO_UNDROPPABLE,              	//iwd,how
+	START_ACTIVE,                	//bg1
+	INFOPOINT_DIALOGS,           	//pst, but only bg1 has garbage there
+	IMPLICIT_AREAANIM_BACKGROUND,	//idw,how,iwd2
+	HEAL_ON_100PLUS,             	//bg1, bg2, pst
+	IN_PARTY_ALLOWS_DEAD,			//all except bg2
+	ZERO_TIMER_IS_VALID,         	// how, not bg2, other unknown
+	SHOP_RECHARGE,               	// all?
+	MELEEHEADER_USESPROJECTILE,  	// minimally bg2
+	FORCE_DIALOGPAUSE,           	// all except if using v1.04 DLG files (bg2, special)
+	RANDOM_BANTER_DIALOGS,       	// bg1
+	FIXED_MORALE_OPCODE,         	// bg2
+	HAPPINESS,                   	// all except pst and iwd2
+	EFFICIENT_OR,                	// does the OR trigger shortcircuit on success or not? Only in iwd2
+	LAYERED_WATER_TILES,				// TileOverlay for water has an extra half transparent layer (all but BG1)
+	CLEARING_ACTIONOVERRIDE,         // bg2, not iwd2
+	DAMAGE_INNOCENT_REP,             // not bg1
+	HAS_WEAPON_SETS,             	// iwd2
 
-	GF_COUNT // sentinal count
+	count // must be last
 };
 
 //the number of item usage fields (used in CREItem and STOItem)

--- a/gemrb/includes/globals.h
+++ b/gemrb/includes/globals.h
@@ -275,6 +275,14 @@ inline T Clamp(const T& n, const T& lower, const T& upper)
 	return std::max(lower, std::min(n, upper));
 }
 
+// this is like static_cast, but clamps to the range supported by DST instead of turning large positive numbers negative and large negatives 0
+template <typename DST, typename SRC>
+inline DST Clamp(const SRC& n)
+{
+	static_assert(sizeof(DST) <= sizeof(SRC), "Clamping a SRC smaller than DST has no effect.");
+	return static_cast<DST>(Clamp<SRC>(n, std::numeric_limits<DST>::min(), std::numeric_limits<DST>::max()));
+}
+
 template <>
 inline Point Clamp(const Point& p, const Point& lower, const Point& upper)
 {

--- a/gemrb/includes/strrefs.h
+++ b/gemrb/includes/strrefs.h
@@ -35,7 +35,7 @@
 namespace GemRB {
 
 enum class HCStrings : TableMgr::index_t {
-	Scattered,
+	Scattered = 0,
 	WholeParty,
 	DoorLocked,
 	Ambush,
@@ -226,7 +226,7 @@ enum class HCStrings : TableMgr::index_t {
 	TrapFound,
 	BackstabDouble,
 
-	StringCount
+	count,
 };
 
 }

--- a/gemrb/includes/strrefs.h
+++ b/gemrb/includes/strrefs.h
@@ -30,9 +30,11 @@
 #ifndef IE_STRINGS_H
 #define IE_STRINGS_H
 
+#include "TableMgr.h"
+
 namespace GemRB {
 
-enum class HCStrings {
+enum class HCStrings : TableMgr::index_t {
 	Scattered,
 	WholeParty,
 	DoorLocked,

--- a/gemrb/plugins/AREImporter/AREImporter.cpp
+++ b/gemrb/plugins/AREImporter/AREImporter.cpp
@@ -342,7 +342,7 @@ bool AREImporter::Import(DataStream* str)
 	str->ReadDword(TileOffset);
 	str->ReadDword(SongHeader);
 	str->ReadDword(RestHeader);
-	if (core->HasFeature(GF_AUTOMAP_INI) ) {
+	if (core->HasFeature(GFFlags::AUTOMAP_INI) ) {
 		str->ReadDword(tmp); //skipping unknown in PST
 	}
 	str->ReadDword(NoteOffset);
@@ -597,7 +597,7 @@ void AREImporter::GetInfoPoint(DataStream* str, int idx, Map* map) const
 		str->Seek(36, GEM_CURRENT_POS);
 	}
 
-	if (core->HasFeature(GF_INFOPOINT_DIALOGS)) {
+	if (core->HasFeature(GFFlags::INFOPOINT_DIALOGS)) {
 		str->ReadResRef(wavResRef);
 		str->ReadPoint(talkPos);
 		str->ReadStrRef(dialogName);
@@ -673,7 +673,7 @@ void AREImporter::GetInfoPoint(DataStream* str, int idx, Map* map) const
 
 	// these appear only in PST, but we could support them everywhere
 	// HOWEVER they did not use them as witnessed in ar0101 (0101prt1 and 0101prt2) :(
-	if (core->HasFeature(GF_PST_STATE_FLAGS)) {
+	if (core->HasFeature(GFFlags::PST_STATE_FLAGS)) {
 		talkPos = ip->Pos;
 	}
 	ip->TalkPos = talkPos;
@@ -860,7 +860,7 @@ void AREImporter::GetDoor(DataStream* str, int idx, Map* map, PluginHolder<TileM
 	str->ReadPoint(toOpen[0]);
 	str->ReadPoint(toOpen[1]);
 	str->ReadStrRef(openStrRef);
-	if (core->HasFeature(GF_AUTOMAP_INI) ) {
+	if (core->HasFeature(GFFlags::AUTOMAP_INI) ) {
 		char tmp[25];
 		str->Read(tmp, 24);
 		tmp[24] = 0;
@@ -870,7 +870,7 @@ void AREImporter::GetDoor(DataStream* str, int idx, Map* map, PluginHolder<TileM
 	}
 	str->ReadStrRef(nameStrRef); // trigger name
 	str->ReadResRef(dialog);
-	if (core->HasFeature(GF_AUTOMAP_INI)) {
+	if (core->HasFeature(GFFlags::AUTOMAP_INI)) {
 		// maybe this is important? but seems not
 		str->Seek(8, GEM_CURRENT_POS);
 	}
@@ -900,7 +900,7 @@ void AREImporter::GetDoor(DataStream* str, int idx, Map* map, PluginHolder<TileM
 	// Getting Door Information from the WED File
 	bool baseClosed;
 	auto indices = tmm->GetDoorIndices(shortName, baseClosed);
-	if (core->HasFeature(GF_REVERSE_DOOR)) {
+	if (core->HasFeature(GFFlags::REVERSE_DOOR)) {
 		baseClosed = !baseClosed;
 	}
 
@@ -1014,7 +1014,7 @@ void AREImporter::GetSpawnPoint(DataStream* str, int idx, Map* map) const
 
 bool AREImporter::GetActor(DataStream* str, PluginHolder<ActorMgr> actorMgr, Map* map) const
 {
-	static int pst = core->HasFeature(GF_AUTOMAP_INI);
+	static int pst = core->HasFeature(GFFlags::AUTOMAP_INI);
 
 	ieVariable defaultName;
 	ResRef creResRef;
@@ -1063,7 +1063,7 @@ bool AREImporter::GetActor(DataStream* str, PluginHolder<ActorMgr> actorMgr, Map
 	str->ReadResRef(scripts[SCR_AREA]);
 	str->Seek(120, GEM_CURRENT_POS);
 	// not iwd2, this field is garbage
-	if (!core->HasFeature(GF_IWD2_SCRIPTNAME)) {
+	if (!core->HasFeature(GFFlags::IWD2_SCRIPTNAME)) {
 		scripts[SCR_AREA].Reset();
 	}
 
@@ -1098,11 +1098,11 @@ bool AREImporter::GetActor(DataStream* str, PluginHolder<ActorMgr> actorMgr, Map
 	act->appearance = schedule;
 	// copying the scripting name into the actor
 	// if the CreatureAreaFlag was set to 8
-	if ((flags & AF_NAME_OVERRIDE) || core->HasFeature(GF_IWD2_SCRIPTNAME)) {
+	if ((flags & AF_NAME_OVERRIDE) || core->HasFeature(GFFlags::IWD2_SCRIPTNAME)) {
 		act->SetScriptName(defaultName);
 	}
 	// IWD2 specific hacks
-	if (core->HasFeature(GF_3ED_RULES)) {
+	if (core->HasFeature(GFFlags::RULES_3ED)) {
 		// This flag is used for something else in IWD2
 		if (flags & AF_NAME_OVERRIDE) {
 			act->BaseStats[IE_EA] = EA_EVILCUTOFF;
@@ -1153,7 +1153,7 @@ void AREImporter::GetAreaAnimation(DataStream* str, Map* map) const
 	str->ReadDword(anim.Flags);
 	anim.originalFlags = anim.Flags;
 	str->ReadScalar(anim.height);
-	if (core->HasFeature(GF_IMPLICIT_AREAANIM_BACKGROUND)) {
+	if (core->HasFeature(GFFlags::IMPLICIT_AREAANIM_BACKGROUND)) {
 		anim.height = ANI_PRI_BACKGROUND;
 		anim.Flags |= A_ANI_NO_WALL;
 	}
@@ -1174,7 +1174,7 @@ void AREImporter::GetAreaAnimation(DataStream* str, Map* map) const
 	// 0x4a holds the height
 	str->ReadDword(anim.unknown48);
 
-	static int pst = core->HasFeature(GF_AUTOMAP_INI);
+	static int pst = core->HasFeature(GFFlags::AUTOMAP_INI);
 	if (pst) {
 		AdjustPSTFlags(anim);
 	}
@@ -1223,7 +1223,7 @@ void AREImporter::GetAmbient(DataStream* str, std::vector<Ambient*>& ambients) c
 
 void AREImporter::GetAutomapNotes(DataStream* str, Map* map) const
 {
-	static int pst = core->HasFeature(GF_AUTOMAP_INI);
+	static int pst = core->HasFeature(GFFlags::AUTOMAP_INI);
 	Point point;
 
 	if (!pst) {
@@ -1454,7 +1454,7 @@ Map* AREImporter::GetMap(const ResRef& resRef, bool day_or_night)
 	
 	//if the Script field is empty, the area name will be copied into it on first load
 	//this works only in the iwd branch of the games
-	if (Script.IsEmpty() && core->HasFeature(GF_FORCE_AREA_SCRIPT)) {
+	if (Script.IsEmpty() && core->HasFeature(GFFlags::FORCE_AREA_SCRIPT)) {
 		Script = resRef;
 	}
 
@@ -1472,7 +1472,7 @@ Map* AREImporter::GetMap(const ResRef& resRef, bool day_or_night)
 	// reverb to match against reverb.2da or iwd reverb.ids
 	// (if the 2da doesn't exist - which we provide for all; they use the same values)
 	ieDword reverbID = EFX_PROFILE_REVERB_INVALID; // non PST data has it at 0, so we don't bother reading
-	if (core->HasFeature(GF_PST_STATE_FLAGS)) {
+	if (core->HasFeature(GFFlags::PST_STATE_FLAGS)) {
 		str->ReadDword(reverbID);
 	}
 
@@ -1740,7 +1740,7 @@ int AREImporter::GetStoredFileSize(Map *map)
 	headersize += TrapCount * 0x1c;
 	NoteOffset = headersize;
 
-	int pst = core->HasFeature( GF_AUTOMAP_INI );
+	int pst = core->HasFeature( GFFlags::AUTOMAP_INI );
 	NoteCount = map->GetMapNoteCount();
 	headersize += NoteCount * (pst?0x214: 0x34);
 	SongHeader = headersize;
@@ -1755,7 +1755,7 @@ int AREImporter::GetStoredFileSize(Map *map)
 int AREImporter::PutHeader(DataStream *stream, const Map *map) const
 {
 	char Signature[9];
-	int pst = core->HasFeature( GF_AUTOMAP_INI );
+	int pst = core->HasFeature( GFFlags::AUTOMAP_INI );
 
 	strlcpy(Signature, "AREAV1.0", 9);
 	if (map->version==16) {
@@ -1913,14 +1913,14 @@ int AREImporter::PutDoors(DataStream *stream, const Map *map, ieDword &VertIndex
 		stream->WritePoint(d->toOpen[0]);
 		stream->WritePoint(d->toOpen[1]);
 		stream->WriteStrRef(d->OpenStrRef);
-		if (core->HasFeature(GF_AUTOMAP_INI) ) {
+		if (core->HasFeature(GFFlags::AUTOMAP_INI) ) {
 			stream->WriteString(d->LinkedInfo, 24);
 		} else {
 			stream->WriteVariable(d->LinkedInfo);
 		}
 		stream->WriteStrRef(d->NameStrRef);
 		stream->WriteResRef( d->GetDialog());
-		if (core->HasFeature(GF_AUTOMAP_INI) ) {
+		if (core->HasFeature(GFFlags::AUTOMAP_INI) ) {
 			stream->WriteFilling(8);
 		}
 	}
@@ -2207,7 +2207,7 @@ int AREImporter::PutAnimations(DataStream *stream, const Map *map) const
 		stream->WriteWord(an->sequence);
 		stream->WriteWord(an->frame);
 
-		if (core->HasFeature(GF_AUTOMAP_INI)) {
+		if (core->HasFeature(GFFlags::AUTOMAP_INI)) {
 			/* PST toggles the active bit only, and we need to keep the rest. */
 			ieDword flags = (an->originalFlags & ~A_ANI_ACTIVE) | (an->Flags & A_ANI_ACTIVE);
 			stream->WriteDword(flags);
@@ -2292,7 +2292,7 @@ int AREImporter::PutAmbients(DataStream *stream, const Map *map) const
 int AREImporter::PutMapnotes(DataStream *stream, const Map *map) const
 {
 	//different format
-	int pst = core->HasFeature( GF_AUTOMAP_INI );
+	int pst = core->HasFeature( GFFlags::AUTOMAP_INI );
 
 	for (unsigned int i=0;i<NoteCount;i++) {
 		const MapNote& mn = map->GetMapNote(i);

--- a/gemrb/plugins/CHUImporter/CHUImporter.cpp
+++ b/gemrb/plugins/CHUImporter/CHUImporter.cpp
@@ -86,7 +86,7 @@ static void GetButton(DataStream* str, Control*& ctrl, const Region& ctrlFrame, 
 	if (noImage) {
 		btn->SetFlags(IE_GUI_BUTTON_NO_IMAGE, BitOp::OR);
 	}
-	if (core->HasFeature(GF_UPPER_BUTTON_TEXT)) {
+	if (core->HasFeature(GFFlags::UPPER_BUTTON_TEXT)) {
 		btn->SetFlags(IE_GUI_BUTTON_CAPS, BitOp::OR);
 	}
 
@@ -114,7 +114,7 @@ static void GetButton(DataStream* str, Control*& ctrl, const Region& ctrlFrame, 
 	// work around several controls not setting all the indices
 	AnimationFactory::index_t cycleSize = bam->GetCycleSize(cycle);
 	bool resetIndex = false;
-	if (core->HasFeature(GF_IGNORE_BUTTON_FRAMES) && (cycleSize == 3 || cycleSize == 4)) {
+	if (core->HasFeature(GFFlags::IGNORE_BUTTON_FRAMES) && (cycleSize == 3 || cycleSize == 4)) {
 		resetIndex = true;
 	}
 	if (resetIndex) {

--- a/gemrb/plugins/CREImporter/CREImporter.cpp
+++ b/gemrb/plugins/CREImporter/CREImporter.cpp
@@ -442,7 +442,7 @@ static void InitSpellbook()
 		return;
 	}
 
-	if (core->HasFeature(GF_HAS_SPELLLIST)) {
+	if (core->HasFeature(GFFlags::HAS_SPELLLIST)) {
 		GetSpellTable("listinnt", innlist);
 		GetSpellTable("listsong", snglist);
 		GetSpellTable("listshap", shplist);
@@ -1922,7 +1922,7 @@ int CREImporter::PutInventory(DataStream *stream, const Actor *actor, unsigned i
 		stream->WriteWord(it->Usages[2]);
 		ieDword tmpDword = it->Flags;
 		//IWD uses this bit differently
-		if (core->HasFeature(GF_MAGICBIT)) {
+		if (core->HasFeature(GFFlags::MAGICBIT)) {
 			if (it->Flags&IE_INV_ITEM_MAGICAL) {
 				tmpDword|=IE_INV_ITEM_UNDROPPABLE;
 			} else {

--- a/gemrb/plugins/DLGImporter/DLGImporter.cpp
+++ b/gemrb/plugins/DLGImporter/DLGImporter.cpp
@@ -60,7 +60,7 @@ bool DLGImporter::Import(DataStream* str)
 		// some games default to unpaused, while others don't
 		// iwd/how relies on this for ar2112 dialog with arundel
 		//  after returning from dragon's eye (double dialog break)
-		Flags = !core->HasFeature(GF_FORCE_DIALOGPAUSE);
+		Flags = !core->HasFeature(GFFlags::FORCE_DIALOGPAUSE);
 	}
 	return true;
 }

--- a/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
+++ b/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
@@ -946,7 +946,7 @@ static inline void HandleMainStatBonus(const Actor *target, int stat, Effect *fx
 	EffectRef mainStatRefs[] = { fx_str_ref, fx_str_ref, fx_int_ref, fx_wis_ref, fx_dex_ref, fx_con_ref, fx_chr_ref };
 
 	int bonus = fx->Parameter1;
-	if (!core->HasFeature(GF_3ED_RULES) || fx->Parameter2 != MOD_ADDITIVE) return;
+	if (!core->HasFeature(GFFlags::RULES_3ED) || fx->Parameter2 != MOD_ADDITIVE) return;
 
 	if (fx->TimingMode == FX_DURATION_INSTANT_PERMANENT) {
 		// don't touch it, so eg. potion of holy transference still works 00POTN89
@@ -1121,7 +1121,7 @@ int fx_set_berserk_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 {
 	// print("fx_set_berserk_state(%2d): Mod: %d, Type: %d", fx->Opcode, fx->Parameter1, fx->Parameter2);
 	// atleast how and bg2 allow this to only work on pcs
-	if (!core->HasFeature(GF_3ED_RULES) && !target->InParty) {
+	if (!core->HasFeature(GFFlags::RULES_3ED) && !target->InParty) {
 		return FX_NOT_APPLIED;
 	}
 
@@ -1435,7 +1435,7 @@ int fx_damage (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 		}
 	}
 
-	if (core->HasFeature(GF_3ED_RULES) && target->GetStat(IE_MC_FLAGS) & MC_INVULNERABLE) {
+	if (core->HasFeature(GFFlags::RULES_3ED) && target->GetStat(IE_MC_FLAGS) & MC_INVULNERABLE) {
 		Log(DEBUG, "fx_damage", "Attacking invulnerable target, skipping!");
 		return FX_NOT_APPLIED;
 	}
@@ -1758,7 +1758,7 @@ int fx_set_invisible_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 {
 	switch (fx->Parameter2) {
 	case 0:
-		if (core->HasFeature(GF_PST_STATE_FLAGS)) {
+		if (core->HasFeature(GFFlags::PST_STATE_FLAGS)) {
 			STATE_SET( STATE_PST_INVIS );
 		} else {
 			STATE_SET( STATE_INVISIBLE );
@@ -1848,7 +1848,7 @@ int fx_morale_modifier (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 
 	// EEs toggle this with fx->Special, but 0 stands for bg2, so we can't use it
 	// they will just use the same game flag instead
-	if (core->HasFeature(GF_FIXED_MORALE_OPCODE)) {
+	if (core->HasFeature(GFFlags::FIXED_MORALE_OPCODE)) {
 		BASE_SET(IE_MORALE, 10);
 		return FX_NOT_APPLIED;
 	}
@@ -1881,7 +1881,7 @@ int fx_set_panic_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	} else {
 		STATE_SET( STATE_PANIC );
 	}
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_PANIC);
 	}
 	return FX_PERMANENT;
@@ -1937,7 +1937,7 @@ int fx_set_poisoned_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	switch(fx->Parameter2) {
 	case RPD_ROUNDS:
 		tmp = core->Time.round_sec;
-		damage = core->HasFeature(GF_HAS_EE_EFFECTS) ? fx->Parameter3 : fx->Parameter1;
+		damage = core->HasFeature(GFFlags::HAS_EE_EFFECTS) ? fx->Parameter3 : fx->Parameter1;
 		break;
 	case RPD_TURNS:
 		tmp = core->Time.turn_sec;
@@ -2194,7 +2194,7 @@ int fx_set_unconscious_state (Scriptable* Owner, Actor* target, Effect* fx)
 		BASE_STATE_SET( STATE_HELPLESS | STATE_SLEEP ); //don't awaken on damage
 	} else {
 		STATE_SET( STATE_HELPLESS | STATE_SLEEP ); //don't awaken on damage
-		if (fx->Parameter2 || !core->HasFeature(GF_HAS_EE_EFFECTS)) {
+		if (fx->Parameter2 || !core->HasFeature(GFFlags::HAS_EE_EFFECTS)) {
 			target->SetSpellState(SS_NOAWAKE);
 		}
 		if (fx->IsVariable) {
@@ -2361,7 +2361,7 @@ int fx_set_stun_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 		}
 	}
 	STATE_SET( STATE_STUNNED );
-	if (core->HasFeature(GF_IWD2_SCRIPTNAME)) { // all iwds
+	if (core->HasFeature(GFFlags::IWD2_SCRIPTNAME)) { // all iwds
 		target->AddPortraitIcon(PI_STUN_IWD);
 	} else {
 		target->AddPortraitIcon(PI_STUN);
@@ -2391,7 +2391,7 @@ int fx_cure_invisible_state (Scriptable* /*Owner*/, Actor* target, Effect* /*fx*
 	// print("fx_cure_invisible_state(%2d): Mod: %d, Type: %d", fx->Opcode, fx->Parameter1, fx->Parameter2);
 	const Game *game = core->GetGame();
 	if (!STATE_GET(STATE_NONDET) && !game->StateOverrideFlag && !game->StateOverrideTime) {
-		if (core->HasFeature(GF_PST_STATE_FLAGS)) {
+		if (core->HasFeature(GFFlags::PST_STATE_FLAGS)) {
 			BASE_STATE_CURE( STATE_PST_INVIS );
 		} else {
 			BASE_STATE_CURE( STATE_INVISIBLE | STATE_INVIS2 );
@@ -2749,7 +2749,7 @@ int fx_set_blur_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 		STATE_SET( STATE_BLUR );
 	}
 	//iwd2 specific
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_BLUR);
 	}
 	return FX_PERMANENT;
@@ -2997,7 +2997,7 @@ int fx_set_blind_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	}
 
 	//don't do this effect twice (bug exists in BG2, but fixed in IWD2)
-	static bool reverse = core->HasFeature(GF_REVERSE_TOHIT);
+	static bool reverse = core->HasFeature(GFFlags::REVERSE_TOHIT);
 	if (!STATE_GET(STATE_BLIND)) {
 		STATE_SET( STATE_BLIND );
 		//the feat normally exists only in IWD2, but won't hurt
@@ -3039,7 +3039,7 @@ int fx_set_feebleminded_state (Scriptable* /*Owner*/, Actor* target, Effect* /*f
 	// print("fx_set_feebleminded_state(%2d): Mod: %d, Type: %d", fx->Opcode, fx->Parameter1, fx->Parameter2);
 	STATE_SET( STATE_FEEBLE );
 	STAT_SET( IE_INT, 3);
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_FEEBLEMIND);
 	}
 	//This state is better off with always stored, because of the portrait icon and the int stat
@@ -3118,7 +3118,7 @@ int fx_set_diseased_state(Scriptable* Owner, Actor* target, Effect* fx)
 		STAT_SUB(IE_CHR, fx->Parameter1 ? fx->Parameter1 : 2);
 		//fall through
 	case RPD_SLOW: //slow
-		if (core->HasFeature(GF_3ED_RULES)) {
+		if (core->HasFeature(GFFlags::RULES_3ED)) {
 			if (target->HasSpellState(SS_FREEACTION)) return FX_NOT_APPLIED;
 			if (target->HasSpellState(SS_AEGIS)) return FX_NOT_APPLIED;
 			STAT_SUB(IE_ARMORCLASS, 2);
@@ -3197,7 +3197,7 @@ int fx_set_deaf_state (Scriptable* /*Owner*/, Actor* target, Effect* /*fx*/)
 	if (target->SetSpellState(SS_DEAF)) return FX_APPLIED;
 
 	EXTSTATE_SET(EXTSTATE_DEAF); //iwd1/how needs this
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_DEAFNESS);
 	}
 	return FX_APPLIED;
@@ -3454,7 +3454,7 @@ int fx_set_regenerating_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 
 	// different in iwd2 only?
 	// x hp per 1 round
-	if (fx->Parameter2 == RPD_ROUNDS && core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (fx->Parameter2 == RPD_ROUNDS && core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		damage = fx->Parameter1;
 		fx->Parameter5 = gameTime + core->Time.round_sec * static_cast<ieDword>(timeStep);
 	}
@@ -3547,7 +3547,7 @@ int fx_gold_modifier (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	//for party members, the gold is stored in the game object
 	switch( fx->Parameter2) {
 		case MOD_ADDITIVE:
-			if (core->HasFeature(GF_FIXED_MORALE_OPCODE)) {
+			if (core->HasFeature(GFFlags::FIXED_MORALE_OPCODE)) {
 				gold = - signed(fx->Parameter1);
 			} else {
 				gold = fx->Parameter1;
@@ -4037,7 +4037,7 @@ int fx_movement_modifier (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	if (core->InCutSceneMode()) return FX_APPLIED;
 
 	// bg1 crashes on 13+, 9&10 are equal to 8 and 11 (boots of speed) equals to roughly 15.6 #129
-	if (core->HasFeature(GF_BREAKABLE_WEAPONS) && fx->Parameter2 == MOD_ABSOLUTE) {
+	if (core->HasFeature(GFFlags::BREAKABLE_WEAPONS) && fx->Parameter2 == MOD_ABSOLUTE) {
 		switch (fx->Parameter1) {
 			case 9:
 			case 10:
@@ -4137,7 +4137,7 @@ int fx_set_confused_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	//for permanent confusion
 	//the portrait icon cannot be made common because rigid thinking uses a different icon
 	//in bg2/how
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_CONFUSED);
 	}
 	return FX_PERMANENT;
@@ -4168,7 +4168,7 @@ int fx_set_aid_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	//bless effect too?
 	target->ToHit.HandleFxBonus(fx->Parameter1, fx->TimingMode==FX_DURATION_INSTANT_PERMANENT);
 	STAT_ADD( IE_DAMAGEBONUS, fx->Parameter1);
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_AID);
 		target->SetColorMod(0xff, RGBModifier::ADD, 30, Color(50, 50, 50, 0));
 	}
@@ -4193,7 +4193,7 @@ int fx_set_bless_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	target->ToHit.HandleFxBonus(fx->Parameter1, fx->TimingMode==FX_DURATION_INSTANT_PERMANENT);
 	STAT_ADD( IE_DAMAGEBONUS, fx->Parameter1);
 	if (target->ShouldModifyMorale()) STAT_ADD(IE_MORALE, fx->Parameter1);
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_BLESS);
 		target->SetColorMod(0xff, RGBModifier::ADD, 30, Color(0xc0, 0x80, 0, 0));
 	}
@@ -4225,7 +4225,7 @@ int fx_set_holy_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	STAT_ADD( IE_STR, fx->Parameter1);
 	STAT_ADD( IE_CON, fx->Parameter1);
 	STAT_ADD( IE_DEX, fx->Parameter1);
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_HOLY);
 		target->SetColorMod(0xff, RGBModifier::ADD, 30, Color(0x80, 0x80, 0x80, 0));
 	}
@@ -4395,7 +4395,7 @@ int fx_force_visible (Scriptable* /*Owner*/, Actor* target, Effect* /*fx*/)
 {
 	// print("fx_force_visible(%2d): Mod: %d, Type: %d", fx->Opcode, fx->Parameter1, fx->Parameter2);
 
-	if (core->HasFeature(GF_PST_STATE_FLAGS)) {
+	if (core->HasFeature(GFFlags::PST_STATE_FLAGS)) {
 		BASE_STATE_CURE(STATE_PST_INVIS);
 	} else {
 		BASE_STATE_CURE(STATE_INVISIBLE);
@@ -4894,7 +4894,7 @@ int fx_set_sanctuary_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	STAT_SET(IE_SANCTUARY, fx->Parameter2);
 	//a rare event, but this effect gives more in bg2 than in iwd2
 	//so we use this flag
-	if (!core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (!core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->SetLockedPalette(fullwhite);
 	}
 	return FX_APPLIED;
@@ -4984,7 +4984,7 @@ int fx_mirror_image_modifier (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	if (!fx->Parameter1) {
 		return FX_NOT_APPLIED;
 	}
-	if (core->HasFeature(GF_PST_STATE_FLAGS)) {
+	if (core->HasFeature(GFFlags::PST_STATE_FLAGS)) {
 		STATE_SET( STATE_PST_MIRROR );
 	}
 	else {
@@ -5082,7 +5082,7 @@ int fx_magic_resistance_modifier (Scriptable* /*Owner*/, Actor* target, Effect* 
 	// iwd2 monk's Diamond soul
 	// for some silly reason the +1/level was not handled as a clab
 	// our clab adds the 10 and sets Special to the rate per level
-	if (core->HasFeature(GF_3ED_RULES) && fx->FirstApply) {
+	if (core->HasFeature(GFFlags::RULES_3ED) && fx->FirstApply) {
 		fx->Parameter1 += target->GetMonkLevel() * fx->IsVariable;
 	}
 
@@ -6097,7 +6097,7 @@ int fx_power_word_sleep (Scriptable* Owner, Actor* target, Effect* fx)
 	fx->Duration = core->GetGame()->GameTime+x*core->Time.round_size;
 	fx->TimingMode = FX_DURATION_ABSOLUTE;
 	fx->Opcode = EffectQueue::ResolveEffect(fx_set_sleep_state_ref);
-	if (!core->HasFeature(GF_HAS_EE_EFFECTS)) fx->Parameter2 = 0;
+	if (!core->HasFeature(GFFlags::HAS_EE_EFFECTS)) fx->Parameter2 = 0;
 	return fx_set_unconscious_state(Owner,target,fx);
 }
 
@@ -6117,7 +6117,7 @@ int fx_stoneskin_modifier (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 
 	//this is the bg2 style stoneskin, not normally using spell states
 	//but this way we can support hybrid games
-	if (core->HasFeature(GF_HAS_EE_EFFECTS)) {
+	if (core->HasFeature(GFFlags::HAS_EE_EFFECTS)) {
 		if (fx->Parameter2) {
 			fx->Parameter1 = DICE_ROLL((signed) fx->Parameter1);
 		}
@@ -6816,7 +6816,7 @@ int fx_cure_confused_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 int fx_drain_items (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 {
 	// TODO: ee, optionally use fx->Resource, different draining, add extra gameflag check below
-	if (core->HasFeature(GF_FIXED_MORALE_OPCODE)) return FX_NOT_APPLIED;
+	if (core->HasFeature(GFFlags::FIXED_MORALE_OPCODE)) return FX_NOT_APPLIED;
 
 	// deplete magic items = 0
 	// deplete also magic weapons = 1
@@ -6882,7 +6882,7 @@ int fx_change_bardsong (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	// print("fx_change_bardsong(%2d): %s", fx->Opcode, fx->Resource);
 	// remove any previous song effects, as they are used with permanent timing
 	unsigned int songType = IE_SPL_SONG;
-	if (core->HasFeature(GF_3ED_RULES)) songType = IE_IWD2_SPELL_SONG;
+	if (core->HasFeature(GFFlags::RULES_3ED)) songType = IE_IWD2_SPELL_SONG;
 	unsigned int count = target->fxqueue.CountEffects(fx_change_bardsong_ref, -1, -1);
 	unsigned int songCount = target->spellbook.GetSpellInfoSize(1 << songType);
 	if (count > 0 && songCount > 0) {
@@ -7755,7 +7755,7 @@ int fx_reveal_tracks (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	}
 
 	// iwd tracking is just the area description
-	if (core->HasFeature(GF_IWD2_SCRIPTNAME)) {
+	if (core->HasFeature(GFFlags::IWD2_SCRIPTNAME)) {
 		return FX_NOT_APPLIED;
 	}
 
@@ -8166,7 +8166,7 @@ int fx_set_state(Scriptable* /*Owner*/, Actor* target, Effect* fx)
 {
 	// in IWD2 we have 176 states (original had 256)
 	// ees can toggle between iwd2 and HoW mode
-	if (fx->IsVariable || core->HasFeature(GF_3ED_RULES)) {
+	if (fx->IsVariable || core->HasFeature(GFFlags::RULES_3ED)) {
 		target->SetSpellState(fx->Parameter2);
 	} else {
 		// in HoW this sets only the 10 last bits of extstate (until it runs out of bits)

--- a/gemrb/plugins/GAMImporter/GAMImporter.cpp
+++ b/gemrb/plugins/GAMImporter/GAMImporter.cpp
@@ -64,12 +64,12 @@ bool GAMImporter::Import(DataStream* str)
 		PCSize = 0x340;
 	} else if (strncmp( Signature, "GAMEV1.1", 8 ) == 0) {
 		//iwd, torment, totsc
-		if (core->HasFeature(GF_HAS_KAPUTZ) ) { //pst
+		if (core->HasFeature(GFFlags::HAS_KAPUTZ) ) { //pst
 			PCSize = 0x168;
 			version = GAM_VER_PST;
 			//sound folder name takes up this space,
 			//so it is handy to make this check
-		} else if ( core->HasFeature(GF_SOUNDFOLDERS) ) {
+		} else if ( core->HasFeature(GFFlags::SOUNDFOLDERS) ) {
 			PCSize = 0x180;
 			version = GAM_VER_IWD;
 		} else {
@@ -206,7 +206,7 @@ Game* GAMImporter::LoadGame(Game *newGame, int ver_override)
 	//apparently BG1/IWD2 relies on this, if chapter is unset, it is
 	//set to -1, hopefully it won't break anything
 	//PST has no chapter variable by default, and would crash on one
-	newGame->locals->SetAt("CHAPTER", (ieDword) -1, core->HasFeature(GF_NO_NEW_VARIABLES));
+	newGame->locals->SetAt("CHAPTER", (ieDword) -1, core->HasFeature(GFFlags::NO_NEW_VARIABLES));
 
 	// load initial values from var.var
 	newGame->locals->LoadInitialValues("GLOBAL");
@@ -222,7 +222,7 @@ Game* GAMImporter::LoadGame(Game *newGame, int ver_override)
 		str->Seek( 40, GEM_CURRENT_POS );
 		newGame->locals->SetAt( Name, Value );
 	}
-	if(core->HasFeature(GF_HAS_KAPUTZ) ) {
+	if(core->HasFeature(GFFlags::HAS_KAPUTZ) ) {
 		newGame->kaputz = new Variables();
 		newGame->kaputz->SetType( GEM_VARIABLES_INT );
 		newGame->kaputz->ParseKey( 1 );
@@ -548,7 +548,7 @@ void GAMImporter::GetPCStats (PCStatsStruct *ps, bool extended)
 
 	str->ReadResRef( ps->SoundSet );
 
-	if (core->HasFeature(GF_SOUNDFOLDERS) ) {
+	if (core->HasFeature(GFFlags::SOUNDFOLDERS) ) {
 		str->ReadVariable(ps->SoundFolder);
 	}
 	
@@ -586,7 +586,7 @@ int GAMImporter::GetStoredFileSize(const Game *game)
 
 	//moved this here, so one can disable killvars in a pst style game
 	//or enable them in gemrb
-	if(core->HasFeature(GF_HAS_KAPUTZ) ) {
+	if(core->HasFeature(GFFlags::HAS_KAPUTZ) ) {
 		KillVarsCount = game->kaputz->GetCount();
 	} else {
 		KillVarsCount = 0;
@@ -763,7 +763,7 @@ int GAMImporter::PutVariables(DataStream *stream, const Game *game) const
 		pos=game->locals->GetNextAssoc( pos, name, value);
 
 		/* PST hates to have some variables lowercased. */
-		if (core->HasFeature(GF_NO_NEW_VARIABLES)) {
+		if (core->HasFeature(GFFlags::NO_NEW_VARIABLES)) {
 			/* This is one anomaly that must have a space injected (PST crashes otherwise). */
 			if (strcmp("dictionary_githzerai_hjacknir", name.c_str()) == 0) {
 				tmpname = "DICTIONARY_GITHZERAI_ HJACKNIR";
@@ -1026,7 +1026,7 @@ int GAMImporter::PutActor(DataStream* stream, const Actor* ac, ieDword CRESize, 
 		stream->WriteWord(favCount);
 	}
 	stream->WriteResRefUC(ac->PCStats->SoundSet);
-	if (core->HasFeature(GF_SOUNDFOLDERS) ) {
+	if (core->HasFeature(GFFlags::SOUNDFOLDERS) ) {
 		stream->WriteVariableLC(ac->PCStats->SoundFolder);
 	}
 	if (GAMVersion == GAM_VER_IWD2 || GAMVersion == GAM_VER_GEMRB) {
@@ -1230,7 +1230,7 @@ int GAMImporter::PutGame(DataStream *stream, Game *game) const
 		return ret;
 	}
 
-	if (core->HasFeature(GF_HAS_KAPUTZ) ) {
+	if (core->HasFeature(GFFlags::HAS_KAPUTZ) ) {
 		ret = PutKillVars( stream, game);
 		if (ret) {
 			return ret;

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -234,7 +234,7 @@ static int GetCreatureStat(const Actor *actor, unsigned int StatID, int Mod)
 		return ps->ExtraSettings[StatID];
 	}
 	if (Mod) {
-		if (core->HasFeature(GF_3ED_RULES) && StatIsASkill(StatID)) {
+		if (core->HasFeature(GFFlags::RULES_3ED) && StatIsASkill(StatID)) {
 			return actor->GetSkill(StatID);
 		} else {
 			if (StatID != IE_HITPOINTS || actor->HasVisibleHP()) {
@@ -2948,7 +2948,7 @@ static PyObject* GemRB_CreateMovement(PyObject * /*self*/, PyObject* args)
 	char *entrance;
 	int direction = 0;
 	PARSE_ARGS(args,  "Os|i", &area, &entrance, &direction);
-	if (core->HasFeature(GF_TEAM_MOVEMENT) ) {
+	if (core->HasFeature(GFFlags::TEAM_MOVEMENT) ) {
 		everyone = CT_WHOLE;
 	} else {
 		everyone = CT_GO_CLOSER;
@@ -4825,7 +4825,7 @@ static PyObject* GemRB_TextArea_ListResources(PyObject* self, PyObject* args)
 			dirit.SetFilterPredicate(new EndsWithFilter(suffix), true);
 			break;
 		case DIRECTORY_CHR_SOUNDS:
-			if (core->HasFeature( GF_SOUNDFOLDERS )) {
+			if (core->HasFeature( GFFlags::SOUNDFOLDERS )) {
 				dirs = true;
 			} else {
 				dirit.SetFilterPredicate(new EndsWithFilter("A"), true);
@@ -6527,7 +6527,7 @@ static PyObject* GemRB_FillPlayerInfo(PyObject * /*self*/, PyObject* args)
 	actor->InitButtons(actor->GetActiveClass(), true); // force re-init of actor's action bar
 
 	//what about multiplayer?
-	if ((globalID == 1) && core->HasFeature(GF_HAS_DPLAYER) ) {
+	if ((globalID == 1) && core->HasFeature(GFFlags::HAS_DPLAYER) ) {
 		actor->SetScript("DPLAYER3", SCR_DEFAULT, false);
 	}
 	Py_RETURN_NONE;
@@ -7041,7 +7041,7 @@ static void OverrideSound(const ResRef& itemRef, ResRef& soundRef, ieDword col)
 		candidate = item->DescriptionIcon;
 	}
 
-	if (core->HasFeature(GF_HAS_PICK_SOUND) && !candidate.IsEmpty()) {
+	if (core->HasFeature(GFFlags::HAS_PICK_SOUND) && !candidate.IsEmpty()) {
 		soundRef = candidate;
 	} else {
 		gamedata->GetItemSound(soundRef, item->ItemType, item->AnimationType, col);
@@ -8791,7 +8791,7 @@ static PyObject* GemRB_MemorizeSpell(PyObject * /*self*/, PyObject* args)
 	}
 
 	// auto-refresh innates (memorisation defaults to depleted)
-	if (core->HasFeature(GF_HAS_SPELLLIST)) {
+	if (core->HasFeature(GFFlags::HAS_SPELLLIST)) {
 		if (SpellType == IE_IWD2_SPELL_INNATE) enabled = 1;
 	} else {
 		if (SpellType == IE_SPELL_TYPE_INNATE) enabled = 1;
@@ -10736,7 +10736,7 @@ static PyObject* GemRB_Window_SetupEquipmentIcons(PyObject* self, PyObject* args
 static bool CanUseActionButton(const Actor *pcc, int type)
 {
 	int capability = -1;
-	if (core->HasFeature(GF_3ED_RULES)) {
+	if (core->HasFeature(GFFlags::RULES_3ED)) {
 		switch (type) {
 		case ACT_STEALTH:
 			capability = pcc->GetSkill(IE_STEALTH) + pcc->GetSkill(IE_HIDEINSHADOWS);
@@ -11739,7 +11739,7 @@ static PyObject* GemRB_UseItem(PyObject * /*self*/, PyObject* args)
 	int count = 1;
 	switch (forcetarget) {
 		case TARGET_SELF:
-			if (core->HasFeature(GF_TEAM_MOVEMENT)) count += 1000; // pst inventory workaround to avoid another parameter
+			if (core->HasFeature(GFFlags::TEAM_MOVEMENT)) count += 1000; // pst inventory workaround to avoid another parameter
 			gc->SetupItemUse(itemdata.slot, itemdata.headerindex, actor, GA_NO_DEAD, count);
 			gc->TryToCast(actor, actor);
 			break;
@@ -11960,7 +11960,7 @@ static PyObject* GemRB_RestParty(PyObject * /*self*/, PyObject* args)
 	bool cannotRest = !game->CanPartyRest(noareacheck, &err);
 	// fall back to the generic: you may not rest at this time
 	if (err == ieStrRef::INVALID) {
-		if (core->HasFeature(GF_AREA_OVERRIDE)) {
+		if (core->HasFeature(GFFlags::AREA_OVERRIDE)) {
 			err = DisplayMessage::GetStringReference(HCStrings::MayNotRest);
 		} else {
 			err = ieStrRef::NO_REST;
@@ -12301,7 +12301,7 @@ static PyObject* GemRB_StealFailed(PyObject * /*self*/, PyObject* /*args*/)
 
 	//not sure if this is ok
 	//owner->LastDisarmFailed = attacker->GetGlobalID();
-	if (core->HasFeature(GF_STEAL_IS_ATTACK)) {
+	if (core->HasFeature(GFFlags::STEAL_IS_ATTACK)) {
 		owner->AttackedBy(attacker);
 	}
 	owner->AddTrigger(TriggerEntry(trigger_stealfailed, attacker->GetGlobalID()));
@@ -13032,14 +13032,14 @@ PyDoc_STRVAR( GemRB_SetFeature__doc,
 **Description:** Set GameType flag FEATURE to VALUE, either True or False.\n\
 \n\
 **Parameters:**\n\
-  * FEATURE - GF_xxx constant defined in GUIDefines.py and globals.h\n\
+  * FEATURE - GFFlags::xxx constant defined in GUIDefines.py and globals.h\n\
   * VALUE - value to set the feature to. Either True or False\n\
 \n\
 **Return value:** N/A\n\
 \n\
 **Examples:**\n\
 \n\
-    GemRB.SetFeature(GF_ALL_STRINGS_TAGGED, True)\n\
+    GemRB.SetFeature(GFFlags::ALL_STRINGS_TAGGED, True)\n\
 \n\
 **See also:** [SetVar](SetVar.md)"
 );
@@ -13047,13 +13047,17 @@ PyDoc_STRVAR( GemRB_SetFeature__doc,
 static PyObject* GemRB_SetFeature(PyObject* /*self*/, PyObject* args)
 {
 	unsigned int feature;
-	bool value;
+	bool set;
 
-	if (!PyArg_ParseTuple(args, "ib", &feature, &value)) {
+	if (!PyArg_ParseTuple(args, "ib", &feature, &set)) {
 		return NULL;
 	}
 
-	core->SetFeature(value, feature);
+	if (set) {
+		core->SetFeature(EnumIndex<GFFlags>(feature));
+	} else {
+		core->ClearFeature(EnumIndex<GFFlags>(feature));
+	}
 	Py_RETURN_NONE;
 }
 

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -9606,7 +9606,7 @@ static PyObject* GemRB_DropDraggedItem(PyObject * /*self*/, PyObject* args)
 	} else if ( Slot >= 0 ) {
 		//swapping won't cure this
 		HCStrings msg = actor->inventory.WhyCantEquip(Slot, slotitem->Flags & IE_INV_ITEM_TWOHANDED, ranged);
-		if (msg != HCStrings::StringCount) {
+		if (msg != HCStrings::count) {
 			displaymsg->DisplayConstantString(msg, GUIColors::WHITE);
 			return PyLong_FromLong(ASI_FAILED);
 		}
@@ -11340,7 +11340,7 @@ static PyObject* GemRB_SetEquippedQuickSlot(PyObject * /*self*/, PyObject* args)
 		displaymsg->DisplayConstantString(HCStrings::Cursed, GUIColors::WHITE);
 	} else {
 		HCStrings ret = actor->SetEquippedQuickSlot(slot, ability);
-		if (ret != HCStrings::StringCount) {
+		if (ret != HCStrings::count) {
 			displaymsg->DisplayConstantString(ret, GUIColors::WHITE);
 		}
 	}

--- a/gemrb/plugins/ITMImporter/ITMImporter.cpp
+++ b/gemrb/plugins/ITMImporter/ITMImporter.cpp
@@ -314,7 +314,7 @@ void ITMImporter::GetExtHeader(const Item *s, ITMExtHeader* eh)
 		eh->ProjectileAnimation--;
 	}
 	// bg2 ignored the projectile for melee weapons (rarely set, but gives staf13 AOE effects)
-	if (!core->HasFeature(GF_MELEEHEADER_USESPROJECTILE) && eh->AttackType == ITEM_AT_MELEE) {
+	if (!core->HasFeature(GFFlags::MELEEHEADER_USESPROJECTILE) && eh->AttackType == ITEM_AT_MELEE) {
 		// HACK: use invtrav, so the effects are still applied on the attack target
 		eh->ProjectileAnimation = 78;
 	}

--- a/gemrb/plugins/IWDOpcodes/IWDOpcodes.cpp
+++ b/gemrb/plugins/IWDOpcodes/IWDOpcodes.cpp
@@ -593,7 +593,7 @@ int fx_chill_touch_panic (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	} else {
 		STATE_SET(state);
 	}
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_PANIC);
 	}
 	return FX_PERMANENT;
@@ -896,7 +896,7 @@ int fx_blinding_orb (Scriptable* Owner, Actor* target, Effect* fx)
 	}
 	//check saving throw
 	bool st;
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		st = target->GetSavingThrow(2, 0, fx); // fortitude
 	} else {
 		st = target->GetSavingThrow(0, 0, fx); // spell
@@ -1564,7 +1564,7 @@ int fx_shroud_of_flame2 (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 
 	EXTSTATE_SET(EXTSTATE_SHROUD); //just for compatibility
 
-	if(core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if(core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->SetColorMod(0xff, RGBModifier::ADD, 1, Color(0xa0, 0, 0, 0));
 	}
 
@@ -2042,7 +2042,7 @@ static int fx_armor_of_faith (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	STAT_ADD(IE_RESISTPOISON, fx->Parameter1);
 	STAT_ADD(IE_RESISTMAGICCOLD, fx->Parameter1);
 	STAT_ADD(IE_RESISTMAGICFIRE, fx->Parameter1);
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_FAITHARMOR);
 	}
 	return FX_APPLIED;
@@ -2123,7 +2123,7 @@ int fx_holy_power (Scriptable* /*Owner*/, Actor* target, Effect* /*fx*/)
 	// print("fx_holy_power(%2d)", fx->Opcode);
 	if (target->SetSpellState( SS_HOLYPOWER)) return FX_APPLIED;
 
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_HOLYPOWER);
 		target->SetColorMod(0xff, RGBModifier::ADD, 20, Color(0x80, 0x80, 0x80, 0));
 	}
@@ -2145,7 +2145,7 @@ int fx_righteous_wrath (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 		if (target->SetSpellState( SS_RIGHTEOUS)) return FX_APPLIED;
 		//
 	}
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_RIGHTEOUS);
 		target->SetColorMod(0xff, RGBModifier::ADD, 30, Color(0xd7, 0xb6, 0, 0));
 	}
@@ -2331,7 +2331,7 @@ int fx_resilient_sphere (Scriptable* /*Owner*/, Actor* target, Effect* /*fx*/)
 	// print("fx_resilient_sphere(%2d)", fx->Opcode);
 	target->SetSpellState(SS_HELD|SS_RESILIENT);
 	STATE_SET(STATE_HELPLESS);
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_RESILIENT);
 		target->SetOverlay(OV_RESILIENT);
 	}
@@ -2356,7 +2356,7 @@ int fx_barkskin (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	}
 	target->AC.HandleFxBonus(bonus, fx->TimingMode==FX_DURATION_INSTANT_PERMANENT);
 
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_BARKSKIN);
 		target->SetGradient(2);
 	}
@@ -2467,7 +2467,7 @@ int fx_free_action_iwd2 (Scriptable* /*Owner*/, Actor* target, Effect* /*fx*/)
 	// 0x6d State:Hold3             ok
 	// 0x28 State:Slowed            ok
 	// 0xb0 MovementRateModifier2   ok
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_FREEACTION);
 		target->SetColorMod(0xff, RGBModifier::ADD, 30, Color(0x80, 0x60, 0x60, 0));
 	}
@@ -2484,7 +2484,7 @@ int fx_unconsciousness (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 		target->SetSpellState(SS_NOAWAKE);
 	}
 	//
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_UNCONSCIOUS);
 	}
 	return FX_APPLIED;
@@ -2505,7 +2505,7 @@ int fx_entropy_shield (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	for (auto pro : *EntropyProjectileList) {
 		target->AddProjectileImmunity(pro);
 	}
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_ENTROPY);
 		//entropy shield overlay
 		target->SetOverlay(OV_ENTROPY);
@@ -2523,7 +2523,7 @@ int fx_storm_shell (Scriptable* /*Owner*/, Actor* target, Effect* /*fx*/)
 	STAT_ADD(IE_RESISTCOLD, 15);
 	STAT_ADD(IE_RESISTELECTRICITY, 15);
 
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->SetOverlay(OV_STORMSHELL);
 	}
 	return FX_APPLIED;
@@ -2543,7 +2543,7 @@ int fx_protection_from_elements (Scriptable* /*Owner*/, Actor* target, Effect* /
 	STAT_ADD(IE_RESISTMAGICFIRE, 15);
 	STAT_ADD(IE_RESISTMAGICCOLD, 15);
 
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->SetColorMod(0xff, RGBModifier::ADD, 0x4f, Color(0, 0, 0xc0, 0));
 	}
 	return FX_APPLIED;
@@ -2593,7 +2593,7 @@ int fx_aegis (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 		STAT_SET(IE_STONESKINS, fx->Parameter1);
 	}
 
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_AEGIS);
 		target->SetColorMod(0xff, RGBModifier::ADD, 30, Color(0x80, 0x60, 0x60, 0));
 		target->SetGradient(14);
@@ -2611,7 +2611,7 @@ int fx_executioner_eyes (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	STAT_ADD(IE_CRITICALHITBONUS, 4);
 	target->ToHit.HandleFxBonus(4, fx->TimingMode==FX_DURATION_INSTANT_PERMANENT);
 
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_EXECUTIONER);
 		target->SetGradient(8);
 	}
@@ -2703,7 +2703,7 @@ int fx_tortoise_shell (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	}
 
 	if (target->SetSpellState( SS_TORTOISE)) return FX_NOT_APPLIED;
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_TORTOISE);
 		target->SetOverlay(OV_TORTOISE);
 	}
@@ -2957,7 +2957,7 @@ int fx_tenser_transformation (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	STAT_ADD(IE_STR, fx->Parameter4);
 	STAT_ADD(IE_CON, fx->Parameter5);
 
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_TENSER);
 		target->SetGradient(0x3e);
 	}
@@ -3018,7 +3018,7 @@ int fx_alicorn_lance (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	////target->AddPortraitIcon(PI_ALICORN); //no portrait icon
 	target->AC.HandleFxBonus(-2, fx->TimingMode==FX_DURATION_INSTANT_PERMANENT);
 	//color glow
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->SetColorMod(0xff, RGBModifier::ADD, 1, Color(0xb9, 0xb9, 0xb9, 0));
 	}
 	return FX_APPLIED;
@@ -3133,7 +3133,7 @@ int fx_globe_invulnerability (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	if (target->SetSpellState( state)) return FX_APPLIED;
 
 	STAT_BIT_OR(IE_MINORGLOBE, value);
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(icon);
 		target->SetOverlay(overlay);
 	}
@@ -3189,7 +3189,7 @@ int fx_bane (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	//do this once
 	if (fx->FirstApply)
 		target->fxqueue.RemoveAllEffects(fx_bless_ref);
-	if (core->HasFeature(GF_ENHANCED_EFFECTS)) {
+	if (core->HasFeature(GFFlags::ENHANCED_EFFECTS)) {
 		target->AddPortraitIcon(PI_BANE);
 		target->SetColorMod(0xff, RGBModifier::ADD, 20, Color(0, 0, 0x80, 0));
 	}

--- a/gemrb/plugins/SPLImporter/SPLImporter.cpp
+++ b/gemrb/plugins/SPLImporter/SPLImporter.cpp
@@ -65,12 +65,12 @@ static int GetCGSound(ieDword CastingGraphics)
 		return -1;
 	}
 	int ret = -1;
-	if (core->HasFeature(GF_CASTING_SOUNDS) ) {
+	if (core->HasFeature(GFFlags::CASTING_SOUNDS) ) {
 		ret = gamedata->castingSounds[CastingGraphics];
-		if (core->HasFeature(GF_CASTING_SOUNDS2) ) {
+		if (core->HasFeature(GFFlags::CASTING_SOUNDS2) ) {
 			ret |= 0x100;
 		}
-	} else if (!core->HasFeature(GF_CASTING_SOUNDS2)) {
+	} else if (!core->HasFeature(GFFlags::CASTING_SOUNDS2)) {
 		ret = gamedata->castingSounds[CastingGraphics];
 	}
 	return ret;
@@ -123,7 +123,7 @@ Spell* SPLImporter::GetSpell(Spell *s, bool /*silent*/)
 	str->ReadWord(s->unknown5);
 	str->ReadResRef( s->SpellbookIcon );
 	//this hack is needed in ToB at least
-	if (!s->SpellbookIcon.IsEmpty() && core->HasFeature(GF_SPELLBOOKICONHACK)) {
+	if (!s->SpellbookIcon.IsEmpty() && core->HasFeature(GFFlags::SPELLBOOKICONHACK)) {
 		*s->SpellbookIcon.rbegin() = 'c'; // replace last character
 	}
 

--- a/gemrb/plugins/TISImporter/TISImporter.cpp
+++ b/gemrb/plugins/TISImporter/TISImporter.cpp
@@ -56,7 +56,7 @@ bool TISImporter::Open(DataStream* stream)
 			hasPVRData = true;
 		}
 	} else {
-		if (core->HasFeature(GF_HAS_EE_EFFECTS)) { // hack!
+		if (core->HasFeature(GFFlags::HAS_EE_EFFECTS)) { // hack!
 			hasPVRData = true;
 			TilesSectionLen = 0xc;
 		}

--- a/gemrb/plugins/TLKImporter/TLKImporter.cpp
+++ b/gemrb/plugins/TLKImporter/TLKImporter.cpp
@@ -43,7 +43,7 @@ TLKImporter::TLKImporter(void)
 	gtmap.RemoveAll(NULL);
 	gtmap.SetType(GEM_VARIABLES_POINTER);
 
-	if (core->HasFeature(GF_CHARNAMEISGABBER)) {
+	if (core->HasFeature(GFFlags::CHARNAMEISGABBER)) {
 		charname=-1;
 	}
 

--- a/gemrb/plugins/WEDImporter/WEDImporter.cpp
+++ b/gemrb/plugins/WEDImporter/WEDImporter.cpp
@@ -345,7 +345,7 @@ void WEDImporter::ReadWallPolygons()
 			if (flags&WF_BASELINE) {
 				polygonTable[i]->SetBaseline(base0, base1);
 			}
-			if (core->HasFeature(GF_PST_STATE_FLAGS)) {
+			if (core->HasFeature(GFFlags::PST_STATE_FLAGS)) {
 				flags |= WF_COVERANIMS;
 			}
 			polygonTable[i]->SetPolygonFlag(flags);

--- a/gemrb/plugins/WMPImporter/WMPImporter.cpp
+++ b/gemrb/plugins/WMPImporter/WMPImporter.cpp
@@ -173,7 +173,7 @@ WMPAreaEntry WMPImporter::GetAreaEntry(DataStream *str) const
 	str->ReadStrRef(ae.LocTooltipName);
 	str->ReadResRef(ae.LoadScreenResRef);
 
-	for (unsigned int dir = 0; dir < 4; dir++) {
+	for (WMPDirection dir : EnumIterator<WMPDirection>()) {
 		str->ReadDword(ae.AreaLinksIndex[dir]);
 		str->ReadDword(ae.AreaLinksCount[dir]);
 	}
@@ -302,7 +302,7 @@ int WMPImporter::PutAreas(DataStream *stream, const WorldMap *wmap) const
 		stream->WriteStrRef(ae->LocTooltipName);
 		stream->WriteResRef( ae->LoadScreenResRef );
 
-		for (unsigned int dir = 0; dir < 4; dir++) {
+		for (WMPDirection dir : EnumIterator<WMPDirection>()) {
 			stream->WriteDword(ae->AreaLinksIndex[dir]);
 			stream->WriteDword(ae->AreaLinksCount[dir]);
 		}

--- a/platforms/apple/GemRB.xcodeproj/project.pbxproj
+++ b/platforms/apple/GemRB.xcodeproj/project.pbxproj
@@ -405,6 +405,7 @@
 		A2A6A45C146893CC000F1688 /* TTFFontManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2A6A459146893CC000F1688 /* TTFFontManager.cpp */; };
 		A2AAF33A13A14A4500AE8402 /* SDLVideo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A27B875A139F0A7D0002DC13 /* SDLVideo.cpp */; };
 		A2AF8FC714DDCE47005CAC5D /* Vorbis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2AF8FC614DDCE47005CAC5D /* Vorbis.framework */; };
+		A2AFB0DB29CA276D00771698 /* EnumIndex.h in Headers */ = {isa = PBXBuildFile; fileRef = A2AFB0DA29CA276D00771698 /* EnumIndex.h */; };
 		A2B0CCD51486FF710074E54B /* FontManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A28D2498143BEA4200A27897 /* FontManager.cpp */; };
 		A2B67A6B16B1DFC100577415 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2B67A6816B1DF6500577415 /* CoreFoundation.framework */; };
 		A2BC43392822246400BD4D73 /* BlitRGBA.glsl in Resources */ = {isa = PBXBuildFile; fileRef = A2BC43372822246400BD4D73 /* BlitRGBA.glsl */; };
@@ -1532,6 +1533,7 @@
 		A2AAF38D13A150D700AE8402 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		A2AAF39313A150F900AE8402 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		A2AF8FC614DDCE47005CAC5D /* Vorbis.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Vorbis.framework; path = /Library/Frameworks/Vorbis.framework; sourceTree = "<absolute>"; };
+		A2AFB0DA29CA276D00771698 /* EnumIndex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EnumIndex.h; sourceTree = "<group>"; };
 		A2B67A6816B1DF6500577415 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = /System/Library/Frameworks/CoreFoundation.framework; sourceTree = "<absolute>"; };
 		A2BC43372822246400BD4D73 /* BlitRGBA.glsl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = BlitRGBA.glsl; sourceTree = "<group>"; };
 		A2BC433C28296D5700BD4D73 /* Format.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Format.h; sourceTree = "<group>"; };
@@ -5178,8 +5180,6 @@
 		A2BF9F8C1395FF61006ADC12 /* core */ = {
 			isa = PBXGroup;
 			children = (
-				A29943F4297F2F2100947AA3 /* FogRenderer.cpp */,
-				A29943F5297F2F2100947AA3 /* FogRenderer.h */,
 				A2BF9F8E1395FF61006ADC12 /* ActorMgr.h */,
 				A2BF9F8F1395FF61006ADC12 /* Ambient.cpp */,
 				A2BF9F901395FF61006ADC12 /* Ambient.h */,
@@ -5218,10 +5218,13 @@
 				A2BF9FBC1395FF61006ADC12 /* EffectQueue.cpp */,
 				A2BF9FBD1395FF61006ADC12 /* EffectQueue.h */,
 				A25F91FB269CE6440045F07A /* EnumFlags.h */,
+				A2AFB0DA29CA276D00771698 /* EnumIndex.h */,
 				A2BF9FBE1395FF61006ADC12 /* Factory.cpp */,
 				A2BF9FBF1395FF61006ADC12 /* Factory.h */,
 				A2BF9FC11395FF61006ADC12 /* FactoryObject.h */,
 				A2D33FEA24C203110081AC31 /* FibonacciHeap.h */,
+				A29943F4297F2F2100947AA3 /* FogRenderer.cpp */,
+				A29943F5297F2F2100947AA3 /* FogRenderer.h */,
 				A28D2498143BEA4200A27897 /* FontManager.cpp */,
 				A28D249B143BEA5800A27897 /* FontManager.h */,
 				A2BF9FC41395FF61006ADC12 /* Game.cpp */,
@@ -7920,6 +7923,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A2E6634F139E882900310FC8 /* ActorMgr.h in Headers */,
+				A2AFB0DB29CA276D00771698 /* EnumIndex.h in Headers */,
 				A281CE0F256F11BA00058D76 /* SDLPixelIterator.h in Headers */,
 				A2E66351139E882900310FC8 /* Ambient.h in Headers */,
 				A2E66353139E882900310FC8 /* AmbientMgr.h in Headers */,


### PR DESCRIPTION
I noticed we do this a few times which requires a lot of manual casting. This adds a convenient method for iterating an enum that takes the burden of casting onto itself and does so safely/efficiently by using the underlying type.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
