### PR TITLE
cmake: remove -fvisibility=hidden

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,11 +236,7 @@ IF(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 	endif ()
 	# mark chars explicitly signed (ARM defaults to unsigned)
 	string(APPEND CMAKE_CXX_FLAGS " -fsigned-char")
-	# only export symbols explicitly marked to be exported.
-	CHECK_CXX_COMPILER_FLAG("-fvisibility=hidden" VISIBILITY_HIDDEN)
-	IF (VISIBILITY_HIDDEN AND NOT WIN32)
-		string(APPEND CMAKE_CXX_FLAGS " -fvisibility=hidden")
-	ENDIF ()
+	
 	# use a more lenient regex for finding documented switch fallthroughs (gcc7)
 	CHECK_CXX_COMPILER_FLAG("-Wimplicit-fallthrough" FALLTHROUGH)
 	IF (FALLTHROUGH AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")


### PR DESCRIPTION
this shouldn't be required and seems to produce issues with type_info on some systems it was introduced in d7f42e6 and only mentions its pulling options in from autotools so i dont know what problem was being addressed

using a PR to test builds

hopefully this will resolve #1786 