### PR TITLE
VSync, FPS capping, Game state update

### DIFF
--- a/gemrb.6.in
+++ b/gemrb.6.in
@@ -146,6 +146,13 @@ Color depth of the game window (in bits per pixel).
 Whether the game should run in fullscreen mode.
 
 .TP
+.BR CapFPS =(-1|0|n)
+Set FPS handling:
+  -1: no limit
+   0: VSync (SDL2), 30 (SDL1)
+   n: cap to n FPS
+
+.TP
 .BR SkipIntroVideos =(0|1)
 If set to
 .IR 1 ,

--- a/gemrb/GemRB.cfg.noinstall.sample
+++ b/gemrb/GemRB.cfg.noinstall.sample
@@ -75,6 +75,9 @@ Bpp=32
 #Fullscreen [Boolean]
 Fullscreen=0
 
+# Cap FPS, 0 = request VSync (SDL2 only, default), -1 = no limit, 30+ = cap value
+#CapFPS=0
+
 # Use sprited fog of war [Boolean]. For nostalgia. By
 # default it looks more like accelerated FoW in BG2.
 

--- a/gemrb/GemRB.cfg.sample.in
+++ b/gemrb/GemRB.cfg.sample.in
@@ -81,6 +81,9 @@ Bpp=32
 #Fullscreen [Boolean]
 Fullscreen=0
 
+# Cap FPS, 0 = request VSync (SDL2 only, default), -1 = no limit, 30+ = cap value
+#CapFPS=0
+
 # Use sprited fog of war [Boolean]. For nostalgia. By
 # default it looks more like accelerated FoW in BG2.
 

--- a/gemrb/core/Interface.h
+++ b/gemrb/core/Interface.h
@@ -341,6 +341,7 @@ struct CFGConfigData {
 	int Height = 480;
 	int Bpp = 32;
 	bool DrawFPS = false;
+	int CapFPS = 0;
 	bool SpriteFoW = false;
 	int debugMode = 0;
 	bool CheatFlag = false; /** Cheats enabled? */

--- a/gemrb/core/Video/Video.h
+++ b/gemrb/core/Video/Video.h
@@ -118,7 +118,7 @@ private:
 	virtual VideoBuffer* NewVideoBuffer(const Region&, BufferFormat)=0;
 	virtual void SwapBuffers(VideoBuffers&)=0;
 	virtual int PollEvents() = 0;
-	virtual int CreateDriverDisplay(const char* title) = 0;
+	virtual int CreateDriverDisplay(const char* title, bool vsync) = 0;
 
 	// the actual drawing implementations
 	virtual void DrawRectImp(const Region& rgn, const Color& color, bool fill, BlitFlags flags) = 0;
@@ -136,7 +136,7 @@ public:
 
 	virtual int Init(void) = 0;
 
-	int CreateDisplay(const Size&, int bpp, bool fullscreen, const char* title);
+	int CreateDisplay(const Size&, int bpp, bool fullscreen, const char* title, bool vsync);
 	virtual void SetWindowTitle(const char *title) = 0;
 
 	/** Toggles GemRB between fullscreen and windowed mode. */
@@ -144,7 +144,7 @@ public:
 	virtual bool SetFullscreenMode(bool set) = 0;
 	bool GetFullscreenMode() const;
 	/** Swaps displayed and back buffers */
-	int SwapBuffers(unsigned int fpscap = 30);
+	int SwapBuffers(int fpscap = 30);
 	VideoBufferPtr CreateBuffer(const Region&, BufferFormat = BufferFormat::DISPLAY);
 	void PushDrawingBuffer(const VideoBufferPtr&);
 	void PopDrawingBuffer();
@@ -153,6 +153,8 @@ public:
 	virtual bool ToggleGrabInput() = 0;
 	virtual void CaptureMouse(bool enabled) = 0;
 	const Size& GetScreenSize() const { return screenSize; }
+	virtual int GetDisplayRefreshRate() const = 0;
+	virtual int GetVirtualRefreshCap() const = 0;
 
 	virtual void StartTextInput() = 0;
 	virtual void StopTextInput() = 0;

--- a/gemrb/includes/globals.h
+++ b/gemrb/includes/globals.h
@@ -149,9 +149,6 @@ enum class GFFlags : uint32_t {
 //the number of item usage fields (used in CREItem and STOItem)
 #define CHARGE_COUNTERS  3
 
-/////AI global defines
-#define AI_UPDATE_TIME	15
-
 /////globally used functions
 
 class Scriptable;

--- a/gemrb/plugins/SDLVideo/SDL12Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL12Video.cpp
@@ -75,10 +75,11 @@ int SDL12VideoDriver::Init(void)
 	return ret;
 }
 
-int SDL12VideoDriver::CreateSDLDisplay(const char* title)
+int SDL12VideoDriver::CreateSDLDisplay(const char* title, bool vsync)
 {
 	Log(MESSAGE, "SDL 1.2 Driver", "Creating display");
 	ieDword flags = SDL_SWSURFACE;
+	vsyncRequest = vsync;
 
 	Log(MESSAGE, "SDL 1.2 Driver", "SDL_SetVideoMode...");
 	disp = SDL_SetVideoMode(screenSize.w, screenSize.h, bpp, flags );
@@ -556,6 +557,15 @@ void SDL12VideoDriver::SwapBuffers(VideoBuffers& buffers)
 	}
 	
 	if (flip) SDL_Flip( disp );
+}
+
+int SDL12VideoDriver::GetDisplayRefreshRate() const {
+	return 30;
+}
+
+int SDL12VideoDriver::GetVirtualRefreshCap() const {
+	// We don't know the value in SDL1, so have it fixed or unlimited
+	return vsyncRequest ? GetDisplayRefreshRate() : 0;
 }
 
 SDL12VideoDriver::vid_buf_t* SDL12VideoDriver::ScratchBuffer() const

--- a/gemrb/plugins/SDLVideo/SDL12Video.h
+++ b/gemrb/plugins/SDLVideo/SDL12Video.h
@@ -31,6 +31,7 @@ private:
 	bool inTextInput;
 	SDL_Joystick* gameController = nullptr;
 	DPadSoftKeyboard dPadSoftKeyboard;
+	bool vsyncRequest;
 
 public:
 	SDL12VideoDriver() noexcept;
@@ -59,9 +60,11 @@ public:
 private:
 	VideoBuffer* NewVideoBuffer(const Region& rgn, BufferFormat fmt) override;
 
-	int CreateSDLDisplay(const char* title) override;
+	int CreateSDLDisplay(const char* title, bool vsync) override;
 	void SwapBuffers(VideoBuffers&) override;
-	
+	int GetDisplayRefreshRate() const override;
+	int GetVirtualRefreshCap() const override;
+
 	SDLVideoDriver::vid_buf_t* ScratchBuffer() const override;
 	SDLVideoDriver::vid_buf_t* CurrentRenderBuffer() const override;
 	SDLVideoDriver::vid_buf_t* CurrentStencilBuffer() const override;

--- a/gemrb/plugins/SDLVideo/SDL20Video.h
+++ b/gemrb/plugins/SDLVideo/SDL20Video.h
@@ -252,7 +252,7 @@ private:
 
 	int ProcessEvent(const SDL_Event & event) override;
 
-	int CreateSDLDisplay(const char* title) override;
+	int CreateSDLDisplay(const char* title, bool vsync) override;
 	void SwapBuffers(VideoBuffers& buffers) override;
 
 	SDLVideoDriver::vid_buf_t* ScratchBuffer() const override;

--- a/gemrb/plugins/SDLVideo/SDLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDLVideo.cpp
@@ -41,9 +41,9 @@ int SDLVideoDriver::Init(void)
 	return GEM_OK;
 }
 
-int SDLVideoDriver::CreateDriverDisplay(const char* title)
+int SDLVideoDriver::CreateDriverDisplay(const char* title, bool vsync)
 {
-	int ret = CreateSDLDisplay(title);
+	int ret = CreateSDLDisplay(title, vsync);
 	scratchBuffer = CreateBuffer(Region(Point(), screenSize), BufferFormat::DISPLAY_ALPHA);
 	scratchBuffer->Clear();
 	return ret;

--- a/gemrb/plugins/SDLVideo/SDLVideo.h
+++ b/gemrb/plugins/SDLVideo/SDLVideo.h
@@ -74,6 +74,8 @@ public:
 	void BlitSprite(const Holder<Sprite2D>& spr, const Region& src, Region dst,
 					BlitFlags flags, Color tint = Color()) override;
 	void BlitGameSprite(const Holder<Sprite2D>& spr, const Point& p, BlitFlags flags, Color tint = Color()) override;
+	int GetDisplayRefreshRate() const override { return refreshRate; }
+	int GetVirtualRefreshCap() const override { return 0; }
 
 protected:
 #if SDL_VERSION_ATLEAST(1,3,0)
@@ -85,8 +87,9 @@ protected:
 	using SDL_Point = Point;
 #endif
 	VideoBufferPtr scratchBuffer; // a buffer that the driver can do with as it pleases for intermediate work
+	int refreshRate = 30;
 
-	int CreateDriverDisplay(const char* title) override;
+	int CreateDriverDisplay(const char* title, bool vsync) override;
 
 	virtual vid_buf_t* ScratchBuffer() const = 0;
 	virtual inline vid_buf_t* CurrentRenderBuffer() const=0;
@@ -103,7 +106,7 @@ protected:
 	void Wait(uint32_t w) override { SDL_Delay(w); }
 
 private:
-	virtual int CreateSDLDisplay(const char* title) = 0;
+	virtual int CreateSDLDisplay(const char* title, bool vsync) = 0;
 	virtual void DrawSDLPoints(const std::vector<SDL_Point>& points, const SDL_Color& color, BlitFlags flags = BlitFlags::NONE)=0;
 
 	void DrawEllipseImp(const Region& rect, const Color& color, BlitFlags flags) override;


### PR DESCRIPTION
## Description

I wanted to give it a try and like to invite you for testing. Since it was suspiciously easy for now:

* `CapFPS` is a new tech setting that allows the user to switch between VSync (on SDL2), some custom frame rate limit and no limit.
* I did a simple approach for handling game state and drawing: Assuming refresh rates are much more frequent than game updates. So don't touch the game state for a while and just draw in the meantime.
* Half the value of `Maximum Frame Rate` is now `ai_update_time`, and that's the frequency of the game state's update.
* There is some annoying workaround for SDL1 to work like it did so far, since it appears to lack VSync handling.
* Some logic to prevent scrolling around the map linearly to the fps, thus becoming too fast and while preventing the current relationship.

Benefits:
* On my 144Hz display, the cursor no longer feels like being dragged through water on windowed mode, since SDL gives me 144 fps.
* Moving around the map is now smoother.
* Not sure about scrollbars and texts, but some things appear to look smoother (journal).

See #144, #1746 for previous discussion.


## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
