### PR TITLE
use integer division for TOOLTIP_DELAY_FACTOR

### DIFF
--- a/gemrb/GUIScripts/GUIOPT.py
+++ b/gemrb/GUIScripts/GUIOPT.py
@@ -301,7 +301,7 @@ def OpenGameplayOptionsWindow ():
 
 def DisplayHelpTooltipDelay ():
 	HelpTextArea.SetText (18017)
-	GemRB.SetTooltipDelay (GemRB.GetVar ("Tooltips") * TOOLTIP_DELAY_FACTOR/10)
+	GemRB.SetTooltipDelay (GemRB.GetVar ("Tooltips") * TOOLTIP_DELAY_FACTOR//10)
 
 def DisplayHelpMouseScrollingSpeed ():
 	HelpTextArea.SetText (18018)


### PR DESCRIPTION
## Description
Fix tooltip delay setting not working #1797.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
