### PR TITLE
(effectively) disable tooltips on max delay setting, like description says

### DIFF
--- a/gemrb/GUIScripts/GUIOPT.py
+++ b/gemrb/GUIScripts/GUIOPT.py
@@ -301,7 +301,11 @@ def OpenGameplayOptionsWindow ():
 
 def DisplayHelpTooltipDelay ():
 	HelpTextArea.SetText (18017)
-	GemRB.SetTooltipDelay (GemRB.GetVar ("Tooltips") * TOOLTIP_DELAY_FACTOR//10)
+	delay_var = GemRB.GetVar ("Tooltips")
+	# BG2 disables tooltips on max setting, we just set it to an extremely high value for simplicity
+	if delay_var == 100:
+		delay_var = 10000000
+	GemRB.SetTooltipDelay (delay_var * TOOLTIP_DELAY_FACTOR//10)
 
 def DisplayHelpMouseScrollingSpeed ():
 	HelpTextArea.SetText (18018)


### PR DESCRIPTION
## Description
Set delay tooltip to a very high value on max setting ("disable" it).
Ref #1797

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
