### PR TITLE
set lower limit for invisibility opacity, decrease pulse interval

### DIFF
--- a/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
+++ b/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
@@ -1789,16 +1789,16 @@ int fx_set_invisible_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 	}
 	ieDword Trans = fx->Parameter4;
 	if (fx->Parameter3) {
-		if (Trans>=240) {
+		if (Trans >= 240) {
 			fx->Parameter3 = 0;
 		} else {
-			Trans+=4;
+			Trans += 4;
 		}
 	} else {
-		if (Trans<=160) {
+		if (Trans <= 160) {
 			fx->Parameter3 = 1;
 		} else {
-			Trans-=4;
+			Trans -= 4;
 		}
 	}
 	fx->Parameter4 = Trans;

--- a/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
+++ b/gemrb/plugins/FXOpcodes/FXOpcodes.cpp
@@ -1792,13 +1792,13 @@ int fx_set_invisible_state (Scriptable* /*Owner*/, Actor* target, Effect* fx)
 		if (Trans>=240) {
 			fx->Parameter3 = 0;
 		} else {
-			Trans+=16;
+			Trans+=4;
 		}
 	} else {
-		if (Trans<=32) {
+		if (Trans<=160) {
 			fx->Parameter3 = 1;
 		} else {
-			Trans-=16;
+			Trans-=4;
 		}
 	}
 	fx->Parameter4 = Trans;


### PR DESCRIPTION
## Description
Fix invisibility opacity limits and pulse interval (#1810)

Original


https://github.com/gemrb/gemrb/assets/1279852/1eddec3e-87d8-4b23-b595-f2f171ae0061


New GemRB

https://github.com/gemrb/gemrb/assets/1279852/5a2f4f1e-477f-4fd4-b42f-94a27c6fc7b3


I'm struggling to match original exactly, because of [brightness/contrast differences](#1098), as well as avatar/color differences.
However, it's closer than current master.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
