### PR TITLE
Formalize DISABLE_WERROR as a CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ OPTION(USE_LIBVLC "Enable LibVLC support" ON)
 OPTION(USE_FREETYPE "Enable FreeType support" ON)
 OPTION(USE_PNG "Enable LibPNG support" ON)
 OPTION(USE_VORBIS "Enable Vorbis support" ON)
+OPTION(DISABLE_WERROR "Do not treat warnings as errors" OFF)
 
 OPTION(USE_SDL_CONTROLLER_API "Enable SDL controller APIs. (disable if you plan on handling controller input in an external program like gptokeyb)" ON)
 OPTION(SDL_RESOLUTION_INDEPENDANCE "Scale the window to the size of the screen with pixel scaling." OFF)


### PR DESCRIPTION
## Description
Just a QoL thing for people using ccmake or IDEs such as VScode's cmake extension. Options show up on the list of cache variables to be turned on and off.

Still defaults to disabled, so behavior is unchanged

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [X] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
