### PR TITLE
Sanitize party pathfinding in narrow spaces

### DIFF
--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -2460,6 +2460,8 @@ PathMapFlags Map::GetBlockedInLine(const Point &s, const Point &d, bool stopOnIm
 		NormalizeDeltas(dx, dy, factor);
 		p.x += dx;
 		p.y += dy;
+		if(ConvertCoordToTile(s) == ConvertCoordToTile(p)) continue;
+
 		PathMapFlags blockStatus = GetBlocked(p);
 		if (stopOnImpassable && blockStatus == PathMapFlags::IMPASSABLE) {
 			return PathMapFlags::IMPASSABLE;

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -2391,7 +2391,7 @@ PathMapFlags Map::GetBlockedTile(const Point& p) const
 {
 	PathMapFlags ret = tileProps.QuerySearchMap(p);
 	if (bool(ret & (PathMapFlags::DOOR_IMPASSABLE|PathMapFlags::ACTOR))) {
-		ret &= ~PathMapFlags::PASSABLE;
+		ret &= ~(PathMapFlags::PASSABLE | PathMapFlags::TRAVEL);
 	}
 	if (bool(ret & PathMapFlags::DOOR_OPAQUE)) {
 		ret = PathMapFlags::SIDEWALL;
@@ -2440,7 +2440,7 @@ PathMapFlags Map::GetBlockedInRadiusTile(const Point &tp, uint16_t size, const b
 	}
 
 	if (bool(ret & (PathMapFlags::DOOR_IMPASSABLE|PathMapFlags::ACTOR|PathMapFlags::SIDEWALL))) {
-		ret &= ~PathMapFlags::PASSABLE;
+		ret &= ~(PathMapFlags::PASSABLE|PathMapFlags::TRAVEL);
 	}
 	if (bool(ret & PathMapFlags::DOOR_OPAQUE)) {
 		ret = PathMapFlags::SIDEWALL;
@@ -2467,7 +2467,7 @@ PathMapFlags Map::GetBlockedInLine(const Point &s, const Point &d, bool stopOnIm
 		ret |= blockStatus;
 	}
 	if (bool(ret & (PathMapFlags::DOOR_IMPASSABLE|PathMapFlags::ACTOR|PathMapFlags::SIDEWALL))) {
-		ret &= ~PathMapFlags::PASSABLE;
+		ret &= ~(PathMapFlags::PASSABLE | PathMapFlags::TRAVEL);
 	}
 	if (bool(ret & PathMapFlags::DOOR_OPAQUE)) {
 		ret = PathMapFlags::SIDEWALL;

--- a/gemrb/core/Map.h
+++ b/gemrb/core/Map.h
@@ -628,7 +628,7 @@ public:
 	PathListNode* GetLine(const Point &start, const Point &dest, int speed, orient_t Orientation, int flags) const;
 	Path GetLinePath(const Point &start, const Point &dest, int speed, orient_t Orientation, int flags) const;
 	/* Finds the path which leads to near d */
-	PathListNode* FindPath(const Point &s, const Point &d, unsigned int size, unsigned int minDistance = 0, int flags = PF_SIGHT, const Actor *caller = NULL) const;
+	PathListNode* FindPath(const Point &s, const Point &d, unsigned int size, unsigned int minDistance = 0, int flags = PF_SIGHT, const Actor *caller = nullptr) const;
 
 	bool IsVisible(const Point &p) const;
 	bool IsExplored(const Point &p) const;


### PR DESCRIPTION
## Description
Current implementation of circle drawing uses a "tweaked" version of the Bresenham algorithm: https://funloop.org/post/2021-03-15-bresenham-circle-drawing-algorithm.html. This leads no nicer circles but they tend to be slightly larger then requested radius. In particular for radius 1 we end up with a square where the corners extend quite a bit outside of the intended circle. By going back to the **not** tweaked version we end up with a cross that leads to reduced collisions.
Please take a look at #1825 to compare the GemRB, BG2 and improved behavior.

The fix amounts to this oneliner:
```
diff --git a/gemrb/core/Geometry.cpp b/gemrb/core/Geometry.cpp
index 927c8bfcc..7f0762427 100644
--- a/gemrb/core/Geometry.cpp
+++ b/gemrb/core/Geometry.cpp
@@ -158,7 +158,7 @@ std::vector<Point> PlotCircle(const Point& origin, uint16_t r, uint8_t octants)
        GenOctants(x, y);
        
        while (x < y) {
-               if (fm <= 0) {
+               if (fm < 0) {
                        fm += de;
                } else {
                        fm += dse;
```

Most of the PR tries to improve on the pathfinding by introducing a heuristic that measures if the calculated path is not to long. It works by returning the path length as an additional element of a tuple and comparing it to the euclidean distance of the start and stop points. It ignores short path to minimise bumping and very long paths that are more likely to be longer then the simple geometric distance.

Please take a look at #1825 for an example of improved algorithm at work.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
