### PR TITLE
RFC: added preliminary .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,176 @@
+---
+# last update based on clang 17 docs
+AccessModifierOffset: -8
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: true
+#AlignConsecutiveShortCaseStatements: false, 17+
+AlignEscapedNewlines: DontAlign
+AlignOperands: false
+AlignTrailingComments: Never
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros: ['__declspec', '__unused', '__attribute__']
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterExternBlock: true
+  AfterFunction: true
+  AfterNamespace: false
+  AfterStruct: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyNamespace: false
+  SplitEmptyRecord: false
+BracedInitializerIndentWidth: 8
+BreakAfterAttributes: Leave
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Allowed
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: BeforeColon
+BreakConstructorInitializersBeforeComma: false
+BreakInheritanceList: AfterComma
+BreakStringLiterals: true
+ColumnLimit: 0
+#CommentPragmas: used to preserve special comments
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: Always
+FixNamespaceComments: false
+IncludeBlocks: Regroup
+IncludeCategories:
+- Priority: 2
+  Regex: '^"(CircularBuffer|defsounds|errors|exports|globals|ie_.*|opcode_params|overlays|Platform|plugindef|Predicates|RGBAColor|SClassID|strrefs|voodooconst|win32def)\.h"'
+  SortPriority: 0
+- Priority: 3
+  Regex: '^"[^/]+"'
+  SortPriority: 0
+- Priority: 4
+  Regex: '^".*/'
+  SortPriority: 0
+- Priority: 5
+  Regex: '^<'
+  SortPriority: 0
+- Priority: 1
+  Regex: '.*'
+  SortPriority: 0
+IncludeIsMainRegex: $
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: true
+IndentCaseLabels: true
+IndentExternBlock: true
+IndentGotoLabels: false
+IndentPPDirectives: BeforeHash
+IndentRequiresClause: true
+IndentWidth: 8
+IndentWrappedFunctionNames: true
+InsertBraces: false
+InsertNewlineAtEOF: true
+#IntegerLiteralSeparator: 0, 17+
+#KeepEmptyLinesAtEOF: false, 17+
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+Language: Cpp
+#LineStyle: LF, 17+
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+#Macros: 17+, for macro hacks
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: Inner
+PPIndentWidth: -1
+PackConstructorInitializers: NextLine
+# not really needed, current values only cause the change of 1 line
+#PenaltyBreakAssignment: 0
+#PenaltyBreakBeforeFirstCallParameter: 21
+#PenaltyBreakComment: 411
+#PenaltyBreakFirstLessLess: 101
+#PenaltyBreakOpenParenthesis:
+#PenaltyBreakString: 460
+#PenaltyBreakTemplateDeclaration: 10
+#PenaltyExcessCharacter: 835460
+#PenaltyReturnTypeOnItsOwnLine: 199
+PointerAlignment: Left
+QualifierAlignment: Leave
+#QualifierOrder
+#RawStringFormats for formatting code in raw strings
+#ReferenceAlignment will use PointerAlignment
+ReflowComments: false
+RemoveBracesLLVM: false
+#RemoveParentheses: Leave, 17+
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+#ShortNamespaceLines: 3, useless without FixNamespaceComments
+SortIncludes: CaseSensitive
+SortUsingDeclarations: Never
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: Never
+SpacesInContainerLiterals: true
+#SpacesInLineCommentPrefix: -1, needs ReflowComments
+#SpacesInParens: Never, 17+
+SpacesInSquareBrackets: false
+Standard: c++14
+#StatementAttributeLikeMacros:
+#StatementMacros
+TabWidth: 8
+#TypeNames: 17+, for special type names
+#TypenameMacros
+UseTab: ForContinuationAndIndentation
+#WhitespaceSensitiveMacros
+---
+Language: ObjC
+ColumnLimit: 0
+UseTab: ForContinuationAndIndentation
+TabWidth: 8
+IndentWidth: 8
+AccessModifierOffset: -8
+ContinuationIndentWidth: 8
+IndentPPDirectives: BeforeHash
+PointerAlignment: Left
+SpaceInEmptyBlock: false
+...

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+# one commit per line to ignore when running git blame/praise/annotate

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,19 +1,13 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Style checks
 
 on:
   pull_request:
-    branches: [ master, subviews ]
+    branches: [ master ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
@@ -28,3 +22,19 @@ jobs:
         git fetch origin
         pip install pycodestyle &&
         git diff -u origin/${{github.base_ref}}... -- gemrb/GUIScripts | pycodestyle --select=E1,E201,E202,E203,E225 --diff --show-source
+
+    - uses: cpp-linter/cpp-linter-action@v2
+      id: linter
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        style: file
+        tidy-checks: '-*'
+        version: 17
+        lines-changed-only: true
+        ignore: "gemrb/include/fmt|platforms"
+        step-summary: true
+
+    - name: Fail if there is not conformance with clang-format
+      if: steps.linter.outputs.checks-failed > 0
+      run: exit 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,12 @@ if(APPIMAGE)
 endif()
 
 CHECK_IS_RELEASE_VERSION()
+# install pre-commit hook and set up git blame
+IF(IS_DIRECTORY "${CMAKE_SOURCE_DIR}/.git" AND NOT EXISTS "${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit")
+  message(STATUS "Installing git pre-commit hook and .git-blame-ignore-revs file")
+  file(COPY admin/pre-commit DESTINATION "${CMAKE_SOURCE_DIR}/.git/hooks")
+  execute_process(COMMAND git "config" "--add" "blame.ignoreRevsFile" ".git-blame-ignore-revs")
+ENDIF()
 
 IF(NOT STATIC_LINK)
 	# prevent static libraries from being selected by FIND_LIBRARY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,12 +115,9 @@ so we can improve our process and documentation!
 ## Axioms of Style
 
 1. When in doubt, follow the style of the existing function or file.
-   - When creating a new file, follow the style of existing files, pe. Game.h/.cpp.
-     - Do not forget to include the license header.
-2. Code indentation is done with single tabulators.
-3. Spaces around operators (foo += bar;).
-4. Try to avoid creating very long lines. There is no set maximum.
-5. Sort includes by type (module, project, system) and alphabetically.
+2. Clang-format is enforced as a pre-commit hook. It's best if you
+configure your editor to run it for you. If you need to do it manually,
+check out `git clang-format`.
 
 
 ## Useful links
@@ -153,6 +150,16 @@ Check out `admin/enable-ie-git-diff` if you want `git log` and others to be able
 to display diffs of included binary files (spells and other overrides).
 
 - `make test` will run the core test suite if you built with googletest installed
+
+- `git blame` ignoring reformatting commits
+
+The `.git-blame-ignore-revs` specifies which commits git should ignore when
+finding the last time a line was changed. Many tools use it by default,
+except git itself, so you need to run:
+
+   git config --add blame.ignoreRevsFile .git-blame-ignore-revs
+
+If you're using cmake, this has been done for you.
 
 
 ## Version tracking

--- a/admin/pre-commit
+++ b/admin/pre-commit
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+import re
+import sys
+import shutil
+import subprocess as sp
+
+# Copy this file to .git/hooks if you're not using cmake
+minVersion = 17
+binary = "clang-format"
+
+# ensure clang-format is there
+cf = shutil.which(binary)
+if cf is None:
+	cf = shutil.which(binary + "-" + str(minVersion))
+if cf is None:
+	print("Bailing out, make sure clang-format is installed!")
+	sys.exit(1)
+
+# ensure it's of sufficient version
+args = [binary, "--version"]
+test = sp.run(args, stdout=sp.PIPE, stderr=sp.PIPE)
+version = str(test.stdout, encoding="utf-8")
+regex = r"clang-format version ((?:\d+\.)+[\d+_\+\-a-z]+)"
+search = re.search(regex, version)
+if not search:
+	print("Error determining clang-format version, bailing out!")
+	sys.exit(2)
+version = search.group(1).split(".")[0]
+if int(version) < minVersion:
+	print("Too old clang-format version, bailing out!")
+	sys.exit(3)
+
+# test both the working tree and staged tree
+args0 = ["git", binary, "--extensions", "c,cpp,h", "--diff"]
+for suffix in "", "--staged":
+	if suffix: # sp can't handle empty params
+		args = args0 + [suffix]
+	else:
+		args = args0
+	test = sp.run(args, stdout=sp.PIPE, stderr=sp.STDOUT)
+	if test.returncode != 0:
+		print(test.stdout.decode())
+		print("\nTrying to commit unformatted changes, bailing out!")
+		print("Use `git clang-format -f {}` to fix it and/or configure your editor to use clang-format!".format(suffix))
+		sys.exit(3)

--- a/gemrb/docs/en/CodingStyle.txt
+++ b/gemrb/docs/en/CodingStyle.txt
@@ -1,9 +1,0 @@
-Header file include order.
-
-- Header file associated to cpp file, or plugin base class header.
-- Additional plugin headers.
-- Headers in includes.
-- Headers in core followed by subdirectories.
-- System and library headers.
-
-Each item should be sorted in ascii order, and separated by blank lines.

--- a/gemrb/includes/CocoaWrapper.h
+++ b/gemrb/includes/CocoaWrapper.h
@@ -18,14 +18,6 @@
  *
  */
 
-#ifdef GCC_VERSION
-#if GCC_VERSION < 40200
-#warning You may need to disable wanings as errors or unused warnings to compile on this system.
-#undef __unused
-#define __unused
-#endif
-#endif
-
 /*
  !!!:
  Because this file is shared between the CocoaWrapper object and plugins extending it we need to keep it

--- a/gemrb/includes/fmt/.clang-format
+++ b/gemrb/includes/fmt/.clang-format
@@ -1,0 +1,2 @@
+---
+DisableFormat: true

--- a/gemrb/plugins/BIKPlayer/binkdata.h
+++ b/gemrb/plugins/BIKPlayer/binkdata.h
@@ -22,6 +22,7 @@
 #ifndef AVCODEC_BINKDATA_H
 #define AVCODEC_BINKDATA_H
 
+// clang-format off
 /** Bink DCT and residue 8x8 block scan order */
 static const uint8_t bink_scan[64] = {
      0,  1,  8,  9,  2,  3, 10, 11,
@@ -608,6 +609,6 @@ static const uint32_t bink_inter_quant[16][64] = {
  0x282F0E, 0x1F927D, 0x16C2FF, 0x127AD9, 0x168D83, 0x0B7F50, 0x0CBAAA, 0x06E86E,
 },
 };
-
+// clang-format on
 
 #endif /* AVCODEC_BINKDATA_H */


### PR DESCRIPTION
Started working on #161. I've updated a previous draft to version 17 (just about to be released), but 16 is fine as well.

The rule file is in the commit, while the effect of `clang-format -i gemrb/**/*.[ch] gemrb/**/*.cpp` can be seen here: https://gist.github.com/lynxlynxlynx/87ca0bb6dec4633ef07d4b9a523078a6
As expected some things are not ideal (eg. when to inline functions), but in general it looks ok to me.

TODO:
- [x] .clang-format: set a max column width at all?
  - [x] move some of the comments, so they don't cause silly wrapping
- [x] exclude fmt
- [x] ~pass  --Wno-error=unknown so it doesn't choke if ran by older version~
- [x] test the difference between 16 (currently available runners) and 17 (current rules)

Infra stuff mentioned in the bug
  - [x] PRs: write runner
    - use https://github.com/marketplace/actions/c-c-linter disabling tidy and only checking changed lines
      - fallback: https://github.com/marketplace/actions/git-clang-format-check-per-commit
    - git clang-format, clang-format-diff are shipped with clang
  - [x] write a pre-commit hook
    - [x] have cmake install it
  - [x] add blame ignore file
    - [x] document use: git config --add blame.ignoreRevsFile some_ignore_file
    - [x] add to cmake target
    - [ ] add reformatting sha together with the reformatting commit
 
Docs:
  - [x] update CONTRIBUTING
  - [x] remove gemrb/docs/en/CodingStyle.txt
  - [ ] update website
