### PR TITLE
IWD2 identify store button fix

### DIFF
--- a/gemrb/GUIScripts/GUISTORE.py
+++ b/gemrb/GUIScripts/GUISTORE.py
@@ -508,6 +508,8 @@ def InitStoreIdentifyWindow (Window):
 
 	# 8-11 item slots, 0x1000000c-f labels
 	for i in range (ItemButtonCount):
+		Button = Window.GetControlAlias ("IDBTN" + str(i))
+
 		if GameCheck.IsIWD1() or GameCheck.IsIWD2():
 			Button.SetSprites ("GUISTMSC", 0, 1,2,0,3)
 			color = {'r' : 32, 'g' : 32, 'b' : 192, 'a' : 128}
@@ -518,7 +520,6 @@ def InitStoreIdentifyWindow (Window):
 		else:
 			color = {'r' : 0, 'g' : 0, 'b' : 128, 'a' : 160}
 
-		Button = Window.GetControlAlias ("IDBTN" + str(i))
 		Button.SetBorder (0, color, 0, 1)
 		Button.OnPress (lambda: SelectID (Window))
 		Button.OnRightPress (InfoIdentifyWindow)


### PR DESCRIPTION
## Description
See #1873.

`Button` in the first iteration is still the identify button from a few lines above, and that `GUISTMSC` refers to an item box sprite.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
