### PR TITLE
Savegames and encoding

### DIFF
--- a/gemrb/core/Audio.cpp
+++ b/gemrb/core/Audio.cpp
@@ -118,4 +118,11 @@ float Audio::GetReverb(unsigned int channel) const
 	return channels[channel].getReverb();
 }
 
+Holder<SoundHandle> Audio::Play(const String& resource, unsigned int channel, const Point& p, unsigned int flags, tick_t *length) {
+	auto mbString = MBStringFromString(resource);
+	auto mbResource = StringView{mbString.c_str()};
+
+	return Play(mbResource, channel, p, flags, length);
+}
+
 }

--- a/gemrb/core/Audio.cpp
+++ b/gemrb/core/Audio.cpp
@@ -120,7 +120,7 @@ float Audio::GetReverb(unsigned int channel) const
 
 Holder<SoundHandle> Audio::Play(const String& resource, unsigned int channel, const Point& p, unsigned int flags, tick_t *length) {
 	auto mbString = MBStringFromString(resource);
-	auto mbResource = StringView{mbString.c_str()};
+	auto mbResource = StringView{mbString};
 
 	return Play(mbResource, channel, p, flags, length);
 }

--- a/gemrb/core/Audio.h
+++ b/gemrb/core/Audio.h
@@ -105,8 +105,20 @@ public:
 public:
 	Audio(void);
 	virtual bool Init(void) = 0;
-	virtual Holder<SoundHandle> Play(StringView ResRef, unsigned int channel,
-	const Point&, unsigned int flags = 0, tick_t *length = nullptr) = 0;
+	virtual Holder<SoundHandle> Play(
+		StringView ResRef,
+		unsigned int channel,
+		const Point&,
+		unsigned int flags = 0,
+		tick_t *length = nullptr
+	) = 0;
+	Holder<SoundHandle> Play(
+		const String& resource,
+		unsigned int channel,
+		const Point&,
+		unsigned int flags = 0,
+		tick_t *length = nullptr
+	);
 	Holder<SoundHandle> PlayRelative(StringView ResRef, unsigned int channel, tick_t *length = 0)
 			{ return Play(ResRef, channel, Point(), GEM_SND_RELATIVE, length); }
 	

--- a/gemrb/core/CMakeLists.txt
+++ b/gemrb/core/CMakeLists.txt
@@ -107,6 +107,7 @@ FILE(GLOB gemrb_core_LIB_SRCS
 	Streams/MemoryStream.cpp
 	Streams/PosixFile.cpp
 	Streams/SlicedStream.cpp
+	Strings/UTF8Comparison.cpp
 	Strings/String.cpp
 	Strings/StringConversion.cpp
 	System/swab.cpp

--- a/gemrb/core/CMakeLists.txt
+++ b/gemrb/core/CMakeLists.txt
@@ -105,6 +105,7 @@ FILE(GLOB gemrb_core_LIB_SRCS
 	Streams/FileCache.cpp
 	Streams/FileStream.cpp
 	Streams/MemoryStream.cpp
+	Streams/PosixFile.cpp
 	Streams/SlicedStream.cpp
 	Strings/String.cpp
 	Strings/StringConversion.cpp
@@ -133,6 +134,7 @@ IF(WIN32)
 		${gemrb_core_LIB_SRCS}
 		../../platforms/windows/CodepageToIconv.cpp
 		../../platforms/windows/CodepageToIconvMap.cpp
+		../../platforms/windows/WindowsFile.cpp
 	)
 	INCLUDE_DIRECTORIES(${Iconv_INCLUDE_DIR})
 ENDIF()

--- a/gemrb/core/CMakeLists.txt
+++ b/gemrb/core/CMakeLists.txt
@@ -152,6 +152,10 @@ else (STATIC_LINK)
 	ENDIF(WIN32)
 endif (STATIC_LINK)
 
+IF(WIN32)
+	TARGET_LINK_LIBRARIES(gemrb_core shlwapi)
+ENDIF()
+
 target_compile_definitions(gemrb_core PRIVATE _USE_MATH_DEFINES)
 
 # make lintian happy

--- a/gemrb/core/GameScript/Actions.cpp
+++ b/gemrb/core/GameScript/Actions.cpp
@@ -6080,14 +6080,15 @@ void GameScript::ExportParty(Scriptable* /*Sender*/, Action* parameters)
 void GameScript::SaveGame(Scriptable* /*Sender*/, Action* parameters)
 {
 	if (core->HasFeature(GFFlags::STRREF_SAVEGAME)) {
-		std::string basename = "Auto-Save";
+		String basename = u"Auto-Save";
 		AutoTable tab = gamedata->LoadTable("savegame");
 		if (tab) {
-			basename = tab->QueryDefault();
+			basename = StringFromCString(tab->QueryDefault().c_str());
 		}
 		String str = core->GetString(ieStrRef(parameters->int0Parameter), STRING_FLAGS::STRREFOFF);
-		std::string FolderName = fmt::format("{} - {}", basename, fmt::WideToChar{str});
-		core->GetSaveGameIterator()->CreateSaveGame(core->GetSaveGameIterator()->GetSaveGame(FolderName), FolderName, true);
+		String FolderName = fmt::format(u"{} - {}", basename, str);
+		auto saveGame = core->GetSaveGameIterator()->GetSaveGame(FolderName);
+		core->GetSaveGameIterator()->CreateSaveGame(saveGame, FolderName);
 	} else {
 		core->GetSaveGameIterator()->CreateSaveGame(parameters->int0Parameter);
 	}

--- a/gemrb/core/GameScript/GSUtils.cpp
+++ b/gemrb/core/GameScript/GSUtils.cpp
@@ -481,7 +481,7 @@ void DisplayStringCoreVC(Scriptable* Sender, size_t vc, int flags)
 		actor->GetVerbalConstantSound(soundRef, vc);
 		std::string sound;
 		if (actor->PCStats && actor->PCStats->SoundFolder[0]) {
-			sound = fmt::format("{}/{}", actor->PCStats->SoundFolder, soundRef);
+			sound = fmt::format("{}{}{}", fmt::WideToChar{actor->PCStats->SoundFolder}, PathDelimiter, soundRef);
 		} else {
 			sound = soundRef.c_str();
 		}

--- a/gemrb/core/InterfaceConfig.cpp
+++ b/gemrb/core/InterfaceConfig.cpp
@@ -139,7 +139,7 @@ static InterfaceConfig LoadDefaultCFG(const char* appName)
 #endif
 	}
 	// if all else has failed try current directory
-	path = PathJoinExt("./", PACKAGE, "cfg");
+	path = PathJoinExt(".", PACKAGE, "cfg");
 	
 	if (cfgStream.Open(path))
 	{

--- a/gemrb/core/KeyMap.cpp
+++ b/gemrb/core/KeyMap.cpp
@@ -122,7 +122,12 @@ bool KeyMap::ResolveKey(unsigned short key, int group) const
 {
 	// FIXME: key is 2 bytes, but we ignore one. Some non english keyboards won't like this.
 	char keystr[2] = {(char)key, 0};
-	Log(MESSAGE, "KeyMap", "Looking up key: {}({}) ", key, keystr);
+	if (key < 128) {
+		Log(MESSAGE, "KeyMap", "Looking up key: {} ({}) ", key, keystr);
+	} else {
+		// We'd have to convert the codepoint into UTF-8 for non-ASCII numbers
+		Log(MESSAGE, "KeyMap", "Looking up key: {}", key);
+	}
 
 	return ResolveName(keystr, group);
 }

--- a/gemrb/core/ResourceManager.cpp
+++ b/gemrb/core/ResourceManager.cpp
@@ -111,6 +111,13 @@ static void PrintPossibleFiles(std::string& buffer, StringView ResRef, const Typ
 	}
 }
 
+bool ResourceManager::Exists(const String& resource, SClass_ID type, bool silent) const {
+		auto mbString = MBStringFromString(resource);
+		auto mbResource = StringView{mbString.c_str()};
+
+		return Exists(mbResource, type, silent);
+}
+
 bool ResourceManager::Exists(StringView ResRef, SClass_ID type, bool silent) const
 {
 	if (ResRef.empty())

--- a/gemrb/core/ResourceManager.cpp
+++ b/gemrb/core/ResourceManager.cpp
@@ -112,10 +112,10 @@ static void PrintPossibleFiles(std::string& buffer, StringView ResRef, const Typ
 }
 
 bool ResourceManager::Exists(const String& resource, SClass_ID type, bool silent) const {
-		auto mbString = MBStringFromString(resource);
-		auto mbResource = StringView{mbString.c_str()};
+	auto mbString = MBStringFromString(resource);
+	auto mbResource = StringView{mbString};
 
-		return Exists(mbResource, type, silent);
+	return Exists(mbResource, type, silent);
 }
 
 bool ResourceManager::Exists(StringView ResRef, SClass_ID type, bool silent) const

--- a/gemrb/core/ResourceManager.h
+++ b/gemrb/core/ResourceManager.h
@@ -50,8 +50,8 @@ public:
 	bool AddSource(const path_t& path, const std::string& description, PluginID type, int flags = 0);
 
 	/** returns true if resource exists */
+	bool Exists(const String& resRef, SClass_ID type, bool silent=false) const;
 	bool Exists(StringView resRef, SClass_ID type, bool silent=false) const;
-	/** returns true if resource exists */
 	bool Exists(StringView resRef, const TypeID *type, bool silent=false) const;
 	/** Returns stream associated to given resource */
 	DataStream* GetResourceStream(StringView resname, SClass_ID type, bool silent = false) const;

--- a/gemrb/core/SaveGame.h
+++ b/gemrb/core/SaveGame.h
@@ -35,7 +35,7 @@ class GEM_EXPORT SaveGame {
 public:
 	static const TypeID ID;
 public:
-	SaveGame(path_t path, path_t name, const ResRef& prefix, std::string slotname, int pCount, int saveID);
+	SaveGame(path_t path, const path_t& name, const ResRef& prefix, std::string slotname, int pCount, int saveID);
 
 	int GetPortraitCount() const
 	{
@@ -45,7 +45,7 @@ public:
 	{
 		return SaveID;
 	}
-	const path_t& GetName() const
+	const String& GetName() const
 	{
 		return Name;
 	}
@@ -74,7 +74,7 @@ public:
 	DataStream* GetSave() const;
 private:
 	path_t Path;
-	path_t Name;
+	String Name;
 	ResRef Prefix;
 	std::string Date;
 	mutable std::string GameDate;

--- a/gemrb/core/SaveGameIterator.h
+++ b/gemrb/core/SaveGameIterator.h
@@ -41,9 +41,10 @@ public:
 	~SaveGameIterator() noexcept = default;
 	const charlist& GetSaveGames();
 	void DeleteSaveGame(const Holder<SaveGame>&) const;
+	int CreateSaveGame(Holder<SaveGame> save, const String& slotname, bool force = false) const;
 	int CreateSaveGame(Holder<SaveGame>, StringView slotname, bool force = false) const;
 	int CreateSaveGame(int index, bool mqs = false) const;
-	Holder<SaveGame> GetSaveGame(StringView slotname);
+	Holder<SaveGame> GetSaveGame(const String& slotname);
 private:
 	bool RescanSaveGames();
 	static Holder<SaveGame> BuildSaveGame(std::string slotname);

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -8606,7 +8606,7 @@ String Actor::GetSoundFolder(int full, const ResRef& overrideSet) const
 	String soundset;
 	if (core->HasFeature(GFFlags::SOUNDFOLDERS)) {
 		if (full) {
-			soundset = fmt::format(u"{}/{}", PCStats->SoundFolder, wSet);
+			soundset = fmt::format(u"{}{}{}", PCStats->SoundFolder, PathDelimiterW, wSet);
 		} else {
 			soundset = fmt::format(u"{}", PCStats->SoundFolder);
 		}

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -3463,8 +3463,8 @@ bool Actor::VerbalConstant(int start, int count, int flags) const
 		do {
 			count--;
 			GetVerbalConstantSound(soundRef, start + count);
-			std::string chrsound = GetSoundFolder(1, soundRef);
-			if (gamedata->Exists(chrsound, IE_WAV_CLASS_ID, true) || gamedata->Exists(chrsound, IE_OGG_CLASS_ID, true)) {
+			auto soundFolder = GetSoundFolder(1, soundRef);
+			if (gamedata->Exists(soundFolder, IE_WAV_CLASS_ID, true) || gamedata->Exists(soundFolder, IE_OGG_CLASS_ID, true)) {
 				DisplayStringCoreVC((Scriptable *) this, start + RAND(0, count), flags|DS_CONST);
 				found = true;
 				break;
@@ -8566,17 +8566,17 @@ void Actor::SetPortrait(const ResRef& portraitRef, int Which)
 	}
 }
 
-void Actor::SetSoundFolder(const ieVariable& soundset) const
+void Actor::SetSoundFolder(const String& soundset) const
 {
 	if (!core->HasFeature(GFFlags::SOUNDFOLDERS)) {
-		PCStats->SoundSet = soundset;
-		PCStats->SoundFolder[0] = 0;
+		PCStats->SoundSet = TLKStringFromString(soundset);
 		return;
 	}
 
 	PCStats->SoundFolder = soundset;
 
-	DirectoryIterator dirIt(PathJoin(core->config.GamePath, "sounds", PCStats->SoundFolder));
+	auto soundFolder = MBStringFromString(PCStats->SoundFolder);
+	DirectoryIterator dirIt(PathJoin(core->config.GamePath, "sounds", soundFolder));
 	dirIt.SetFilterPredicate(std::make_shared<EndsWithFilter>("01"));
 	dirIt.SetFlags(DirectoryIterator::Directories);
 	if (dirIt) {
@@ -8593,7 +8593,7 @@ void Actor::SetSoundFolder(const ieVariable& soundset) const
 	}
 }
 
-std::string Actor::GetSoundFolder(int full, const ResRef& overrideSet) const
+String Actor::GetSoundFolder(int full, const ResRef& overrideSet) const
 {
 	ResRef set;
 	if (overrideSet.IsEmpty()) {
@@ -8602,16 +8602,18 @@ std::string Actor::GetSoundFolder(int full, const ResRef& overrideSet) const
 		set = overrideSet;
 	}
 
-	std::string soundset;
+	String wSet = StringFromResRef(set);
+	String soundset;
 	if (core->HasFeature(GFFlags::SOUNDFOLDERS)) {
 		if (full) {
-			soundset = fmt::format("{}/{}", PCStats->SoundFolder, set);
+			soundset = fmt::format(u"{}/{}", PCStats->SoundFolder, wSet);
 		} else {
-			soundset = fmt::format("{}", PCStats->SoundFolder);
+			soundset = fmt::format(u"{}", PCStats->SoundFolder);
 		}
 	} else {
-		soundset = set.c_str();
+		soundset = wSet;
 	}
+
 	return soundset;
 }
 

--- a/gemrb/core/Scriptable/Actor.h
+++ b/gemrb/core/Scriptable/Actor.h
@@ -594,9 +594,9 @@ public:
 	/** Sets the Icon ResRef */
 	//Which - 0 both, 1 Large, 2 Small
 	void SetPortrait(const ResRef&, int Which=0);
-	void SetSoundFolder(const ieVariable& soundset) const;
+	void SetSoundFolder(const String& soundset) const;
 	/* Use overrideSet to replace PCStats->SoundSet */
-	std::string GetSoundFolder(int flag, const ResRef& overrideSet) const;
+	String GetSoundFolder(int flag, const ResRef& overrideSet) const;
 	
 	/** Gets the Character Long Name/Short Name */
 	const String& GetShortName() const

--- a/gemrb/core/Scriptable/PCStatStruct.h
+++ b/gemrb/core/Scriptable/PCStatStruct.h
@@ -125,7 +125,7 @@ public:
 	ResRef  FavouriteWeapons[MAX_FAVOURITES];
 	std::array<ieWord, MAX_FAVOURITES> FavouriteWeaponsCount {0};
 	ResRef  SoundSet;
-	ieVariable SoundFolder;
+	String SoundFolder;
 	ieDword   ExtraSettings[ES_COUNT] {0};     //iwd2 - expertise, hamstring, arterial strike, etc
 	ResRef    QuickSpells[MAX_QSLOTS]; //iwd2 uses 9, others use only 3
 	ieWord    QuickWeaponSlots[MAX_QUICKWEAPONSLOT] {0xffff}; //iwd2 uses 8, others use only 4

--- a/gemrb/core/Streams/DataStream.h
+++ b/gemrb/core/Streams/DataStream.h
@@ -153,7 +153,7 @@ public:
 	
 	template <typename STR>
 	strret_t WriteString(const STR& src, size_t len) {
-		return Write(src.begin(), len);
+		return Write(src.c_str(), len);
 	}
 	
 	template <typename STR>

--- a/gemrb/core/Streams/File.h
+++ b/gemrb/core/Streams/File.h
@@ -1,0 +1,44 @@
+/* GemRB - Infinity Engine Emulator
+ * Copyright (C) 2023 The GemRB Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef FILE_H
+#define FILE_H
+
+#include "DataStream.h"
+
+namespace GemRB {
+
+// encapsulating file handles + API that fit best on the respective platform
+class File {
+public:
+	virtual ~File() {}
+
+	virtual strpos_t Length() = 0;
+	virtual bool OpenRO(const path_t& name) = 0;
+	virtual bool OpenRW(const path_t& name) = 0;
+	virtual bool OpenNew(const path_t& name) = 0;
+	virtual strret_t Read(void* ptr, size_t length) = 0;
+	virtual strret_t Write(const void* ptr, strpos_t length) = 0;
+	virtual bool SeekStart(stroff_t offset) = 0;
+	virtual bool SeekCurrent(stroff_t offset) = 0;
+	virtual bool SeekEnd(stroff_t offset) = 0;
+};
+
+}
+#endif

--- a/gemrb/core/Streams/FileStream.cpp
+++ b/gemrb/core/Streams/FileStream.cpp
@@ -33,7 +33,7 @@ namespace GemRB {
 
 #endif
 
-FileStream::FileStream(File&& f)
+FileStream::FileStream(FileT&& f)
 : str(std::move(f))
 {}
 
@@ -50,7 +50,7 @@ DataStream* FileStream::Clone() const noexcept
 
 void FileStream::Close()
 {
-	str = File();
+	str = FileT();
 	opened = false;
 	created = false;
 }

--- a/gemrb/core/Streams/FileStream.h
+++ b/gemrb/core/Streams/FileStream.h
@@ -34,6 +34,14 @@
 #include "globals.h"
 #include "SClassID.h"
 
+#ifdef WIN32
+#include "../../platforms/windows/WindowsFile.h"
+using FileT = GemRB::WindowsFile;
+#else
+#include "PosixFile.h"
+using FileT = GemRB::PosixFile;
+#endif
+
 namespace GemRB {
 
 /**
@@ -41,159 +49,13 @@ namespace GemRB {
  * Reads and writes data from/to files on a filesystem
  */
 
-#ifndef WIN32
-struct File {
-private:
-	FILE* file = nullptr;
-public:
-	explicit File(FILE* f) : file(f) {}
-	File() noexcept = default;
-	File(const File&) = delete;
-	File(File&& f) noexcept {
-		file = f.file;
-		f.file = nullptr;
-	}
-	~File() {
-		if (file) fclose(file);
-	}
-	
-	File& operator=(const File&) = delete;
-	File& operator=(File&& f) noexcept {
-		if (&f != this) {
-			std::swap(file, f.file);
-		}
-		return *this;
-	}
-
-	strpos_t Length() {
-		fseek(file, 0, SEEK_END);
-		strpos_t size = ftell(file);
-		fseek(file, 0, SEEK_SET);
-		return size;
-	}
-	bool OpenRO(const path_t& name) {
-		return (file = fopen(name.c_str(), "rb"));
-	}
-	bool OpenRW(const path_t& name) {
-		return (file = fopen(name.c_str(), "r+b"));
-	}
-	bool OpenNew(const path_t& name) {
-		return (file = fopen(name.c_str(), "wb"));
-	}
-	strret_t Read(void* ptr, size_t length) {
-		return fread(ptr, 1, length, file);
-	}
-	strret_t Write(const void* ptr, strpos_t length) {
-		return fwrite(ptr, 1, length, file);
-	}
-	bool SeekStart(stroff_t offset)
-	{
-		return !fseek(file, offset, SEEK_SET);
-	}
-	bool SeekCurrent(stroff_t offset)
-	{
-		return !fseek(file, offset, SEEK_CUR);
-	}
-	bool SeekEnd(stroff_t offset)
-	{
-		return !fseek(file, offset, SEEK_END);
-	}
-};
-#else
-struct File {
-private:
-	HANDLE file = INVALID_HANDLE_VALUE;
-public:
-	explicit File(FILE* f) : file(f) {}
-	File() noexcept = default;
-	File(const File&) = delete;
-	File(File&& f) noexcept {
-		file = f.file;
-		f.file = INVALID_HANDLE_VALUE;
-	}
-	~File() {
-		if (file != INVALID_HANDLE_VALUE) {
-			CloseHandle(file);
-		}
-	}
-
-	File& operator=(const File&) = delete;
-	File& operator=(File&& f) noexcept {
-		if (&f != this) {
-			std::swap(file, f.file);
-		}
-		return *this;
-	}
-
-	strpos_t Length() {
-		LARGE_INTEGER fileSize;
-		GetFileSizeEx(file, &fileSize);
-
-		return fileSize.QuadPart;
-	}
-	bool OpenRO(const path_t& name) {
-		file = _OpenFile(name, GENERIC_READ, OPEN_EXISTING);
-		return file != INVALID_HANDLE_VALUE;
-	}
-	bool OpenRW(const path_t& name) {
-		file = _OpenFile(name, GENERIC_READ | GENERIC_WRITE, OPEN_EXISTING);
-		return file != INVALID_HANDLE_VALUE;
-	}
-	bool OpenNew(const path_t& name) {
-		file = _OpenFile(name, GENERIC_WRITE, CREATE_ALWAYS);
-		return file != INVALID_HANDLE_VALUE;
-	}
-	strret_t Read(void* ptr, size_t length) {
-		DWORD bytesRead = 0;
-		ReadFile(file, ptr, length, &bytesRead, nullptr);
-		return bytesRead;
-	}
-	strret_t Write(const void* ptr, strpos_t length) {
-		DWORD bytesWritten = 0;
-		WriteFile(file, ptr, length, &bytesWritten, nullptr);
-		return bytesWritten;
-	}
-	bool SeekStart(stroff_t offset) {
-		return _SetFilePointer(offset, FILE_BEGIN);
-	}
-	bool SeekCurrent(stroff_t offset) {
-		return _SetFilePointer(offset, FILE_CURRENT);
-	}
-	bool SeekEnd(stroff_t offset) {
-		return _SetFilePointer(offset, FILE_END);
-	}
-
-private:
-	HANDLE _OpenFile(const path_t& name, DWORD access, DWORD disposition) {
-		auto fileName = StringFromUtf8(name.c_str());
-
-		return CreateFile(
-			reinterpret_cast<const wchar_t*>(fileName.c_str()),
-			access,
-			FILE_SHARE_READ | FILE_SHARE_WRITE, // some files are opened r and r+w in parallel
-			nullptr,
-			disposition,
-			FILE_ATTRIBUTE_NORMAL,
-			nullptr
-		);
-	}
-
-	bool _SetFilePointer(stroff_t offset, DWORD method) {
-		LARGE_INTEGER liOffset;
-		liOffset.QuadPart = offset;
-
-		return SetFilePointerEx(file, liOffset, nullptr, method) != 0;
-	}
-};
-#endif
-
 class GEM_EXPORT FileStream : public DataStream {
 private:
-	File str;
+	FileT str;
 	bool opened = true;
 	bool created = true;
 public:
-	explicit FileStream(File&&);
+	explicit FileStream(FileT&&);
 	FileStream(void);
 
 	DataStream* Clone() const noexcept override;

--- a/gemrb/core/Streams/FileStream.h
+++ b/gemrb/core/Streams/FileStream.h
@@ -41,6 +41,7 @@ namespace GemRB {
  * Reads and writes data from/to files on a filesystem
  */
 
+#ifndef WIN32
 struct File {
 private:
 	FILE* file = nullptr;
@@ -98,6 +99,93 @@ public:
 		return !fseek(file, offset, SEEK_END);
 	}
 };
+#else
+struct File {
+private:
+	HANDLE file = INVALID_HANDLE_VALUE;
+public:
+	explicit File(FILE* f) : file(f) {}
+	File() noexcept = default;
+	File(const File&) = delete;
+	File(File&& f) noexcept {
+		file = f.file;
+		f.file = INVALID_HANDLE_VALUE;
+	}
+	~File() {
+		if (file != INVALID_HANDLE_VALUE) {
+			CloseHandle(file);
+		}
+	}
+
+	File& operator=(const File&) = delete;
+	File& operator=(File&& f) noexcept {
+		if (&f != this) {
+			std::swap(file, f.file);
+		}
+		return *this;
+	}
+
+	strpos_t Length() {
+		LARGE_INTEGER fileSize;
+		GetFileSizeEx(file, &fileSize);
+
+		return fileSize.QuadPart;
+	}
+	bool OpenRO(const path_t& name) {
+		file = _OpenFile(name, GENERIC_READ, OPEN_EXISTING);
+		return file != INVALID_HANDLE_VALUE;
+	}
+	bool OpenRW(const path_t& name) {
+		file = _OpenFile(name, GENERIC_READ | GENERIC_WRITE, OPEN_EXISTING);
+		return file != INVALID_HANDLE_VALUE;
+	}
+	bool OpenNew(const path_t& name) {
+		file = _OpenFile(name, GENERIC_WRITE, CREATE_ALWAYS);
+		return file != INVALID_HANDLE_VALUE;
+	}
+	strret_t Read(void* ptr, size_t length) {
+		DWORD bytesRead = 0;
+		ReadFile(file, ptr, length, &bytesRead, nullptr);
+		return bytesRead;
+	}
+	strret_t Write(const void* ptr, strpos_t length) {
+		DWORD bytesWritten = 0;
+		WriteFile(file, ptr, length, &bytesWritten, nullptr);
+		return bytesWritten;
+	}
+	bool SeekStart(stroff_t offset) {
+		return _SetFilePointer(offset, FILE_BEGIN);
+	}
+	bool SeekCurrent(stroff_t offset) {
+		return _SetFilePointer(offset, FILE_CURRENT);
+	}
+	bool SeekEnd(stroff_t offset) {
+		return _SetFilePointer(offset, FILE_END);
+	}
+
+private:
+	HANDLE _OpenFile(const path_t& name, DWORD access, DWORD disposition) {
+		auto fileName = StringFromUtf8(name.c_str());
+
+		return CreateFile(
+			reinterpret_cast<const wchar_t*>(fileName.c_str()),
+			access,
+			FILE_SHARE_READ | FILE_SHARE_WRITE, // some files are opened r and r+w in parallel
+			nullptr,
+			disposition,
+			FILE_ATTRIBUTE_NORMAL,
+			nullptr
+		);
+	}
+
+	bool _SetFilePointer(stroff_t offset, DWORD method) {
+		LARGE_INTEGER liOffset;
+		liOffset.QuadPart = offset;
+
+		return SetFilePointerEx(file, liOffset, nullptr, method) != 0;
+	}
+};
+#endif
 
 class GEM_EXPORT FileStream : public DataStream {
 private:

--- a/gemrb/core/Streams/PosixFile.cpp
+++ b/gemrb/core/Streams/PosixFile.cpp
@@ -1,0 +1,85 @@
+/* GemRB - Infinity Engine Emulator
+ * Copyright (C) 2023 The GemRB Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include <algorithm>
+
+#include "PosixFile.h"
+
+namespace GemRB {
+
+PosixFile::PosixFile(PosixFile&& other) noexcept {
+	this->file = other.file;
+	other.file = nullptr;
+}
+
+PosixFile::~PosixFile() {
+	if (file) {
+		fclose(file);
+	}
+}
+
+PosixFile& PosixFile::operator=(PosixFile&& other) noexcept {
+	if (&other != this) {
+		std::swap(file, other.file);
+	}
+
+	return *this;
+}
+
+strpos_t PosixFile::Length() {
+	fseek(file, 0, SEEK_END);
+	strpos_t size = ftell(file);
+	fseek(file, 0, SEEK_SET);
+
+	return size;
+}
+
+bool PosixFile::OpenRO(const path_t& name) {
+	return (file = fopen(name.c_str(), "rb"));
+}
+
+bool PosixFile::OpenRW(const path_t& name) {
+	return (file = fopen(name.c_str(), "r+b"));
+}
+
+bool PosixFile::OpenNew(const path_t& name) {
+	return (file = fopen(name.c_str(), "wb"));
+}
+
+strret_t PosixFile::Read(void* ptr, size_t length) {
+	return fread(ptr, 1, length, file);
+}
+
+strret_t PosixFile::Write(const void* ptr, strpos_t length) {
+	return fwrite(ptr, 1, length, file);
+}
+
+bool PosixFile::SeekStart(stroff_t offset) {
+	return !fseek(file, offset, SEEK_SET);
+}
+
+bool PosixFile::SeekCurrent(stroff_t offset) {
+	return !fseek(file, offset, SEEK_CUR);
+}
+
+bool PosixFile::SeekEnd(stroff_t offset) {
+	return !fseek(file, offset, SEEK_END);
+}
+
+}

--- a/gemrb/core/Streams/PosixFile.h
+++ b/gemrb/core/Streams/PosixFile.h
@@ -1,0 +1,53 @@
+/* GemRB - Infinity Engine Emulator
+ * Copyright (C) 2023 The GemRB Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef POSIX_FILE_H
+#define POSIX_FILE_H
+
+#include <cstdio>
+
+#include "File.h"
+
+namespace GemRB {
+
+class GEM_EXPORT PosixFile : public File {
+private:
+	FILE* file = nullptr;
+public:
+	PosixFile() noexcept = default;
+	PosixFile(const File&) = delete;
+	PosixFile(PosixFile&& f) noexcept;
+	~PosixFile() override;
+
+	PosixFile& operator=(const PosixFile&) = delete;
+	PosixFile& operator=(PosixFile&& f) noexcept;
+
+	strpos_t Length() override;
+	bool OpenRO(const path_t& name) override;
+	bool OpenRW(const path_t& name) override;
+	bool OpenNew(const path_t& name) override;
+	strret_t Read(void* ptr, size_t length) override;
+	strret_t Write(const void* ptr, strpos_t length) override;
+	bool SeekStart(stroff_t offset) override;
+	bool SeekCurrent(stroff_t offset) override;
+	bool SeekEnd(stroff_t offset) override;
+};
+
+}
+#endif

--- a/gemrb/core/Strings/StringConversion.cpp
+++ b/gemrb/core/Strings/StringConversion.cpp
@@ -26,46 +26,35 @@
 
 namespace GemRB {
 
-static String StringFromEncodedData(const ieByte* string, const EncodingStruct& encoded)
+static String StringFromEncodedData(const char* in, size_t length, const std::string& encoding)
 {
-	if (!string) return u"";
-
-	char* in = reinterpret_cast<char*>(const_cast<ieByte*>(string));
-	size_t inLen = 0;
-
-	if (encoded.widechar) {
-		inLen = wcslen(reinterpret_cast<const wchar_t*>(in));
-	} else {
-		inLen = strlen(in);
-	}
-
-	if (inLen == 0) {
+	if (!in || length == 0) {
 		return u"";
 	}
 
 	iconv_t cd = nullptr;
 	// Must check since UTF-16 may fall back to UTF-16BE, even if platform is LE
 	if (IsBigEndian()) {
-		cd = iconv_open("UTF-16BE", encoded.encoding.c_str());
+		cd = iconv_open("UTF-16BE", encoding.c_str());
 	} else {
-		cd = iconv_open("UTF-16LE", encoded.encoding.c_str());
+		cd = iconv_open("UTF-16LE", encoding.c_str());
 	}
 
 	if (cd == (iconv_t)-1) {
-		Log(ERROR, "String", "iconv_open(UTF-16, {}) failed with error: {}", encoded.encoding, strerror(errno));
+		Log(ERROR, "String", "iconv_open(UTF-16, {}) failed with error: {}", encoding, strerror(errno));
 		return u"";
 	}
 
-	size_t outLen = inLen * 4;
+	size_t outLen = length * 4;
 	size_t outLenLeft = outLen;
-	std::u16string buffer(inLen * 2, u'\0');
+	std::u16string buffer(length * 2, u'\0');
 	auto outBuf = reinterpret_cast<char*>(const_cast<char16_t*>(buffer.data()));
 
-	size_t ret = iconv(cd, &in, &inLen, &outBuf, &outLenLeft);
+	size_t ret = iconv(cd, const_cast<char**>(&in), &length, &outBuf, &outLenLeft);
 	iconv_close(cd);
 
 	if (ret == static_cast<size_t>(-1)) {
-		Log(ERROR, "String", "iconv failed to convert string {} from {} to UTF-16 with error: {}", reinterpret_cast<const char*>(string), encoded.encoding, strerror(errno));
+		Log(ERROR, "String", "iconv failed to convert string {} from {} to UTF-16 with error: {}", in, encoding, strerror(errno));
 		return u"";
 	}
 
@@ -77,9 +66,26 @@ static String StringFromEncodedData(const ieByte* string, const EncodingStruct& 
 	return buffer;
 }
 
+static String StringFromEncodedData(const char* string, const EncodingStruct& encoding) {
+	size_t inLen = 0;
+
+	if (encoding.widechar) {
+		inLen = wcslen(reinterpret_cast<const wchar_t*>(string));
+	} else {
+		inLen = strlen(string);
+	}
+
+	return StringFromEncodedData(string, inLen, encoding.encoding);
+}
+
 String StringFromCString(const char* string)
 {
-	return StringFromEncodedData((const ieByte*) string, core->TLKEncoding);
+	return StringFromEncodedData(string, core->TLKEncoding);
+}
+
+String StringFromResRef(const ResRef& string)
+{
+	return StringFromEncodedData(string.c_str(), ResRef::Size, core->TLKEncoding.encoding);
 }
 
 String StringFromFSString(const char* string)
@@ -87,7 +93,7 @@ String StringFromFSString(const char* string)
 	EncodingStruct enc;
 	enc.encoding = core->config.SystemEncoding.c_str();
 	enc.multibyte = true; // nobody ever complained so far
-	return StringFromEncodedData((const ieByte*) string, enc);
+	return StringFromEncodedData(string, enc);
 }
 
 String StringFromUtf8(const char* string)
@@ -95,10 +101,10 @@ String StringFromUtf8(const char* string)
 	EncodingStruct enc;
 	enc.encoding = "UTF-8";
 	enc.multibyte = true;
-	return StringFromEncodedData((const ieByte*) string, enc);
+	return StringFromEncodedData(string, enc);
 }
 
-std::string MBStringFromString(const String& string)
+static std::string RecodedStringFromString(const String& string, const std::string& encoding)
 {
 	char* in = reinterpret_cast<char*>(const_cast<char16_t*>(string.c_str()));
 	size_t inLen = string.length() * sizeof(char16_t);
@@ -109,9 +115,9 @@ std::string MBStringFromString(const String& string)
 
 	iconv_t cd = nullptr;
 	if (IsBigEndian()) {
-		cd = iconv_open("UTF-8", "UTF-16BE");
+		cd = iconv_open(encoding.c_str(), "UTF-16BE");
 	} else {
-		cd = iconv_open("UTF-8", "UTF-16LE");
+		cd = iconv_open(encoding.c_str(), "UTF-16LE");
 	}
 
 	size_t outLen = string.length() * 4;
@@ -123,16 +129,34 @@ std::string MBStringFromString(const String& string)
 	iconv_close(cd);
 
 	if (ret == static_cast<size_t>(-1)) {
-		Log(ERROR, "String", "iconv failed to convert string a string from UTF-16 to UTF-8 with error: {}", strerror(errno));
+		Log(ERROR, "String", "iconv failed to convert string a string from UTF-16 to {} with error: {}", strerror(errno), encoding);
 		return "";
 	}
 
-	auto zero = buffer.find('\0');
-	if (zero != decltype(buffer)::npos) {
-		buffer.resize(zero);
+	return buffer;
+}
+
+std::string MBStringFromString(const String& string)
+{
+	auto newString = RecodedStringFromString(string, "UTF-8");
+
+	auto zero = newString.find('\0');
+	if (zero != decltype(newString)::npos) {
+		newString.resize(zero);
 	}
 
-	return buffer;
+	return newString;
+}
+
+std::string TLKStringFromString(const String& string) {
+	auto newString = RecodedStringFromString(string, core->TLKEncoding.encoding);
+
+	auto zero = newString.find('\0');
+	if (zero != decltype(newString)::npos) {
+		newString.resize(zero);
+	}
+
+	return newString;
 }
 
 }

--- a/gemrb/core/Strings/StringConversion.h
+++ b/gemrb/core/Strings/StringConversion.h
@@ -36,9 +36,9 @@ struct EncodingStruct
 // String creators
 GEM_EXPORT char* ConvertCharEncoding(const char * string, const char * from, const char* to);
 GEM_EXPORT String StringFromCString(const char* string);
-GEM_EXPORT String StringFromFSString(const char* string);
 GEM_EXPORT String StringFromResRef(const ResRef& string);
 GEM_EXPORT String StringFromUtf8(const char* string);
+GEM_EXPORT std::string RecodedStringFromWideStringBytes(const char16_t* bytes, size_t bytesLength, const std::string& encoding);
 GEM_EXPORT std::string MBStringFromString(const String& string);
 GEM_EXPORT std::string TLKStringFromString(const String& string);
 

--- a/gemrb/core/Strings/StringConversion.h
+++ b/gemrb/core/Strings/StringConversion.h
@@ -21,6 +21,7 @@
 
 #include "CString.h"
 #include "String.h"
+#include "ie_types.h"
 
 namespace GemRB {
 
@@ -36,8 +37,10 @@ struct EncodingStruct
 GEM_EXPORT char* ConvertCharEncoding(const char * string, const char * from, const char* to);
 GEM_EXPORT String StringFromCString(const char* string);
 GEM_EXPORT String StringFromFSString(const char* string);
+GEM_EXPORT String StringFromResRef(const ResRef& string);
 GEM_EXPORT String StringFromUtf8(const char* string);
 GEM_EXPORT std::string MBStringFromString(const String& string);
+GEM_EXPORT std::string TLKStringFromString(const String& string);
 
 }
 

--- a/gemrb/core/Strings/UTF8Comparison.cpp
+++ b/gemrb/core/Strings/UTF8Comparison.cpp
@@ -1,0 +1,113 @@
+/* GemRB - Infinity Engine Emulator
+ * Copyright (C) 2023 The GemRB Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include <cstdint>
+#include <locale>
+
+#include "UTF8Comparison.h"
+
+namespace GemRB {
+
+#ifdef WIN32
+// `C.UTF-8` isn't guaranteed on any RT here, but we don't need it anyway r/n
+bool UTF8_stricmp(const char*, const char*) {
+	return false;
+}
+
+#else
+static const auto C_LOCALE = std::locale{"C.UTF-8"};
+
+// Returns true if both strings are equal after lower-casing
+bool UTF8_stricmp(const char *a, const char *b) {
+	const unsigned char *itA = reinterpret_cast<const unsigned char*>(a),
+		*itB = reinterpret_cast<const unsigned char*>(b);
+
+	while (*itA != 0) {
+		unsigned char iA = *itA, iB = *itB;
+
+		// a is longer
+		if (iB == 0) {
+			return false;
+		}
+
+		// One is special, the other one isn't
+		if ((iA >= 128 && iB < 128) || (iA < 128 && iB >= 128)) {
+			return false;
+		}
+
+		// ASCII range
+		if (iA < 128) {
+			if (std::tolower(iA) != std::tolower(iB)) {
+				return false;
+			}
+
+			itA++, itB++;
+		} else {
+			// multibyte range (assuming no broken encoding)
+			auto getWidth = [](unsigned char c) -> uint8_t {
+				if ((c & 0xF0) == 0xF0) {
+					return 4;
+				} else if ((c & 0xE0) == 0xE0) {
+					return 3;
+				} else {
+					return 2;
+				}
+			};
+
+			// can't feed utf-8 bytes value into std::locale
+			auto getCodepoint = [](const unsigned char *it, uint8_t length) -> wchar_t {
+				switch (length) {
+					case 4: return ((0x7 | *it) << 24)
+						| ((0x3F | *(it + 1)) << 16)
+						| ((0x3F | *(it + 2)) << 8)
+						| (0x3F | *(it + 3));
+					case 3: return ((0xF | *it) << 16)
+						| ((0x3F | *(it + 1)) << 8)
+						| (0x3F | *(it + 2));
+					default: return ((0x1F | *it) << 8)
+						| (0x3F | *(it + 1));
+				}
+			};
+
+			uint8_t widthA = getWidth(iA), widthB = getWidth(iB);
+
+			wchar_t aL = std::tolower(getCodepoint(itA, widthA), C_LOCALE);
+			wchar_t bL = std::tolower(getCodepoint(itB, widthB), C_LOCALE);
+
+			// They have no lower case and thus remain different, or they are equal now
+			if (aL != bL) {
+				return false;
+			}
+
+			itA += widthA;
+			itB += widthB;
+		}
+	}
+
+	// b is longer
+	if (*itB != 0) {
+		return false;
+	}
+
+	// equal
+	return true;
+}
+#endif
+
+}

--- a/gemrb/core/Strings/UTF8Comparison.h
+++ b/gemrb/core/Strings/UTF8Comparison.h
@@ -1,0 +1,25 @@
+/* GemRB - Infinity Engine Emulator
+ * Copyright (C) 2023 The GemRB Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+namespace GemRB {
+
+// true if equal under C.UTF-8 `tolower` regime
+bool UTF8_stricmp(const char *a, const char *b);
+
+}

--- a/gemrb/core/System/VFS.cpp
+++ b/gemrb/core/System/VFS.cpp
@@ -32,15 +32,19 @@
 #include <cstring>
 #include <cerrno>
 
-#ifndef WIN32
+#ifdef WIN32
+// that's a workaround to live with `NOUSER` in `win32def.h`
+#define LPMSG void*
+#include <shlwapi.h>
+// there is a macro in shlwapi.h that turns `PathAppendW` into `PathAppend`
+#undef PathAppend
+#else
 #include <dirent.h>
 #endif
 
 #ifdef HAVE_MMAP
 #include <sys/mman.h>
 #endif
-
-#include <sys/stat.h>
 
 #ifdef __APPLE__
 // for getting resources inside the bundle
@@ -62,10 +66,20 @@
 using namespace GemRB;
 
 struct dirent {
-	dirent() : buffer(_MAX_PATH, L'\0'), d_name(const_cast<char*>(buffer.data())) {}
+	dirent() : buffer(_MAX_PATH, '\0'), d_name(const_cast<char*>(buffer.data())) {}
 
 	std::string buffer;
-	const char *d_name;
+	char *d_name;
+
+	dirent& operator=(std::string&& entryName) {
+		auto cutOff = entryName.length();
+		buffer = std::move(entryName);
+		buffer.resize(_MAX_PATH);
+		buffer[cutOff] = 0;
+		d_name = const_cast<char*>(buffer.data());
+
+		return *this;
+	}
 };
 
 struct DIR {
@@ -84,14 +98,14 @@ struct DIR {
 static DIR* opendir(const char* filename) {
 	auto dir = new DIR{};
 
-	// consider $PATH\*.*\0 for _wfindfirst
+	// consider $PATH\\*.*\0 for _wfindfirst
 	if (strlen(filename) > _MAX_PATH - 5) {
 		return nullptr;
 	}
 
-	std::wstring buffer(_MAX_PATH, L'\0');
-	mbstowcs(const_cast<wchar_t*>(buffer.data()), filename, buffer.length() - 1);
-	dir->path = fmt::format(L"{}\\*.*", buffer.c_str());
+	auto buffer = StringFromUtf8(filename);
+	buffer.resize(_MAX_PATH);
+	dir->path = fmt::format(L"{}\\*.*", reinterpret_cast<const wchar_t*>(buffer.c_str()));
 
 	return dir;
 }
@@ -110,11 +124,13 @@ static dirent* readdir(DIR *dir) {
 		}
 	}
 
-	auto& de = dir->entry;
-	auto n = wcstombs(const_cast<char*>(de.d_name), c_file.name, de.buffer.length() - 1);
-	de.buffer[n] = 0;
+	char16_t *c = reinterpret_cast<char16_t*>(c_file.name);
+	size_t n = 0;
+	for (; n < _MAX_PATH && *c != u'\0'; ++c, ++n) {}
 
-	return &de;
+	dir->entry = RecodedStringFromWideStringBytes(reinterpret_cast<char16_t*>(c_file.name), n * 2, "UTF-8");
+
+	return &dir->entry;
 }
 
 static void closedir(DIR *dir) {
@@ -167,10 +183,23 @@ static bool DirExists(StringView path)
 	char* end = const_cast<char*>(path.end());
 	std::swap(*end, term); // use swap because end may be a delimiter or a terminator
 
+#ifdef WIN32
+	auto buffer = StringFromUtf8(path.c_str());
+	auto wideChars = reinterpret_cast<const wchar_t*>(buffer.c_str());
+
+	// `stat` does not work reliably with non-ASCII names
+	if (!PathFileExists(wideChars)) {
+		return false;
+	}
+
+	bool ret = (GetFileAttributes(wideChars) & FILE_ATTRIBUTE_DIRECTORY) > 0;
+#else
 	struct stat buf;
 	buf.st_mode = 0;
 	bool ret = stat(path.c_str(), &buf) == 0 && S_ISDIR(buf.st_mode);
 	std::swap(*end, term);
+#endif
+
 	return ret;
 }
 
@@ -182,6 +211,19 @@ bool DirExists(const path_t& path)
 /** Returns true if path is an existing file */
 bool FileExists(const path_t& path)
 {
+#ifdef WIN32
+	auto buffer = StringFromUtf8(path.c_str());
+	auto wideChars = reinterpret_cast<const wchar_t*>(buffer.c_str());
+
+	// `stat` does not work reliably with non-ASCII names
+	if (!PathFileExists(wideChars)) {
+		return false;
+	}
+
+	if (GetFileAttributes(wideChars) & FILE_ATTRIBUTE_DIRECTORY) {
+		return false;
+	}
+#else
 	struct stat buf;
 	buf.st_mode = 0;
 
@@ -191,6 +233,7 @@ bool FileExists(const path_t& path)
 	if (!S_ISREG(buf.st_mode)) {
 		return false;
 	}
+#endif
 
 	return true;
 }

--- a/gemrb/core/System/VFS.h
+++ b/gemrb/core/System/VFS.h
@@ -36,6 +36,8 @@
 #include <memory>
 #include <string>
 
+#include <sys/stat.h>
+
 #ifdef WIN32
 #include "win32def.h"
 #include <direct.h>
@@ -63,9 +65,11 @@ GEM_EXPORT path_t BundlePath(BundleDirectory dir = BUNDLE);
 
 #ifdef WIN32
 const char PathDelimiter = '\\';
+const char16_t PathDelimiterW = u'\\';
 const char PathListSeparator = ';';
 #else
 const char PathDelimiter = '/';
+const char16_t PathDelimiterW = u'/';
 const char PathListSeparator = ':';
 #endif
 const char SPathDelimiter[] = { PathDelimiter, '\0' };

--- a/gemrb/plugins/AREImporter/AREImporter.cpp
+++ b/gemrb/plugins/AREImporter/AREImporter.cpp
@@ -2320,9 +2320,7 @@ int AREImporter::PutMapnotes(DataStream *stream, const Map *map) const
 			size_t len = 0;
 			// limited to 500 *bytes* of text, convert to a multibyte encoding.
 			// we convert to MB because it fits more than if we wrote the wide characters
-			std::string mbstring = MBStringFromString(mn.text);
-			// FIXME: depends on locale blah blah (see MBStringFromString definition)
-			// only care about number of bytes before null so strlen is what we want despite being MB string
+			std::string mbstring = TLKStringFromString(mn.text);
 			len = std::min<size_t>(mbstring.length(), 500);
 			stream->Write(mbstring.c_str(), len);
 

--- a/gemrb/plugins/CREImporter/CREImporter.cpp
+++ b/gemrb/plugins/CREImporter/CREImporter.cpp
@@ -620,7 +620,10 @@ void CREImporter::WriteChrHeader(DataStream *stream, const Actor *act)
 			stream->WriteDword(act->PCStats->QSlots[i+3]);
 		}
 		stream->WriteFilling(26);
-		stream->WriteVariableLC(act->PCStats->SoundFolder);
+		{
+			auto soundFolder = TLKStringFromString(act->PCStats->SoundFolder);
+			stream->WriteStringLC(soundFolder, ieVariable::Size);
+		}
 		stream->WriteResRef(act->PCStats->SoundSet);
 		for (const auto& setting : act->PCStats->ExtraSettings) {
 			stream->WriteDword(setting);
@@ -698,7 +701,11 @@ void CREImporter::ReadChrHeader(Actor *act)
 			act->PCStats->QSlots[i+3] = (ieByte) tmpDword;
 		}
 		str->Seek(26, GEM_CURRENT_POS);
-		str->ReadVariable(act->PCStats->SoundFolder);
+		{
+			ieVariable soundFolder;
+			str->ReadVariable(soundFolder);
+			act->PCStats->SoundFolder = StringFromCString(soundFolder.c_str());
+		}
 		str->ReadResRef(act->PCStats->SoundSet);
 		for (auto& setting : act->PCStats->ExtraSettings) {
 			str->ReadDword(setting);

--- a/gemrb/plugins/CREImporter/CREImporter.cpp
+++ b/gemrb/plugins/CREImporter/CREImporter.cpp
@@ -565,7 +565,7 @@ void CREImporter::WriteChrHeader(DataStream *stream, const Actor *act)
 			return;
 	}
 	stream->Write( Signature, 8);
-	std::string tmpstr = MBStringFromString(act->GetShortName());
+	std::string tmpstr = TLKStringFromString(act->GetShortName());
 	stream->WriteVariable(ieVariable(tmpstr));
 	stream->WriteDword(hdrSize); //cre offset (chr header size)
 	stream->WriteDword(CRESize);  //cre size

--- a/gemrb/plugins/GAMImporter/GAMImporter.cpp
+++ b/gemrb/plugins/GAMImporter/GAMImporter.cpp
@@ -984,7 +984,7 @@ int GAMImporter::PutActor(DataStream* stream, const Actor* ac, ieDword CRESize, 
 	}
 
 	if (ac->LongStrRef == ieStrRef::INVALID) {
-		std::string tmpstr = MBStringFromString(ac->GetLongName());
+		std::string tmpstr = TLKStringFromString(ac->GetLongName());
 		stream->WriteVariable(ieVariable(tmpstr));
 	} else {
 		std::string tmpstr = core->GetMBString(ac->LongStrRef, STRING_FLAGS::STRREFOFF);

--- a/gemrb/plugins/GAMImporter/GAMImporter.cpp
+++ b/gemrb/plugins/GAMImporter/GAMImporter.cpp
@@ -544,7 +544,9 @@ void GAMImporter::GetPCStats (PCStatsStruct *ps, bool extended)
 	str->ReadResRef( ps->SoundSet );
 
 	if (core->HasFeature(GFFlags::SOUNDFOLDERS) ) {
-		str->ReadVariable(ps->SoundFolder);
+		ieVariable soundFolder;
+		str->ReadVariable(soundFolder);
+		ps->SoundFolder = StringFromCString(soundFolder.c_str());
 	}
 	
 	//iwd2 has some PC only stats that the player can set (this can be done via a guiscript interface)
@@ -1012,7 +1014,8 @@ int GAMImporter::PutActor(DataStream* stream, const Actor* ac, ieDword CRESize, 
 	}
 	stream->WriteResRefUC(ac->PCStats->SoundSet);
 	if (core->HasFeature(GFFlags::SOUNDFOLDERS) ) {
-		stream->WriteVariableLC(ac->PCStats->SoundFolder);
+		auto soundFolder = TLKStringFromString(ac->PCStats->SoundFolder);
+		stream->WriteStringLC(soundFolder, ieVariable::Size);
 	}
 	if (GAMVersion == GAM_VER_IWD2 || GAMVersion == GAM_VER_GEMRB) {
 		//I don't know how many fields are actually used in IWD2 saved game

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -4481,8 +4481,9 @@ static PyObject* GemRB_SaveGame_GetName(PyObject * /*self*/, PyObject* args)
 	PARSE_ARGS(args, "O", &Slot);
 
 	Holder<SaveGame> save = CObject<SaveGame>(Slot);
-	const std::string& name = save->GetName();
-	return PyUnicode_Decode(name.c_str(), name.length(), core->config.SystemEncoding.c_str(), "strict");
+	auto name = save->GetName();
+
+	return PyString_FromStringObj(name);
 }
 
 PyDoc_STRVAR( GemRB_SaveGame_GetDate__doc,
@@ -4701,7 +4702,7 @@ static PyObject* GemRB_TextArea_ListResources(PyObject* self, PyObject* args)
 			if (name[0] == '.' || dirit.IsDirectory() != dirs)
 				continue;
 
-			String string = StringFromFSString(name.c_str());
+			String string = StringFromUtf8(name.c_str());
 
 			if (dirs == false) {
 				size_t pos = string.find_last_of(u'.');

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -3779,7 +3779,7 @@ static PyObject* GemRB_VerbalConstant(PyObject * /*self*/, PyObject* args)
 	}
 
 	//get soundset based string constant
-	std::string sound = fmt::format("{}/{}{:02d}", actor->PCStats->SoundFolder, actor->PCStats->SoundSet, str);
+	std::string sound = fmt::format("{}{}{}{:02d}", fmt::WideToChar{actor->PCStats->SoundFolder}, PathDelimiter, actor->PCStats->SoundSet, str);
 	channel = actor->InParty ? SFX_CHAN_CHAR0 + actor->InParty - 1 : SFX_CHAN_DIALOG;
 	core->GetAudioDrv()->Play(sound, channel, Point(), GEM_SND_RELATIVE|GEM_SND_SPEECH);
 	Py_RETURN_NONE;
@@ -3834,7 +3834,11 @@ static PyObject* GemRB_PlaySound(PyObject * /*self*/, PyObject* args)
 			channel = core->GetAudioDrv()->GetChannel(channel_name);
 		}
 
-		core->GetAudioDrv()->Play(PyString_AsStringView(pyref), channel, pos, flags);
+		if (PyUnicode_Check(pyref)) {
+			core->GetAudioDrv()->Play(PyString_AsStringObj(pyref), channel, pos, flags);
+		} else {
+			core->GetAudioDrv()->Play(PyString_AsStringView(pyref), channel, pos, flags);
+		}
 	}
 
 	Py_RETURN_NONE;
@@ -3978,7 +3982,7 @@ static PyObject* GemRB_SetToken(PyObject * /*self*/, PyObject* args)
 	PyObject* value;
 	PARSE_ARGS(args, "OO", &Variable, &value);
 
-	if(PyUnicode_Check(value)) {
+	if (PyUnicode_Check(value)) {
 		core->GetTokenDictionary()[ieVariableFromPy(Variable)] = PyString_AsStringObj(value);
 	} else {
 		core->GetTokenDictionary()[ieVariableFromPy(Variable)] = StringFromCString(PyBytes_AsString(value));
@@ -4752,7 +4756,7 @@ static PyObject* GemRB_TextArea_SetOptions(PyObject* self, PyObject* args)
 	for (int i = 0; i < PyList_Size(list); i++) {
 		item = PyList_GetItem(list, i);
 		String string;
-		if(!PyUnicode_Check(item)) {
+		if (!PyUnicode_Check(item)) {
 			if (PyLong_Check(item)) {
 				string = String(core->GetString(StrRefFromPy(item)));
 			} else {
@@ -5571,13 +5575,13 @@ PyDoc_STRVAR( GemRB_SetPlayerSound__doc,
 
 static PyObject* GemRB_SetPlayerSound(PyObject * /*self*/, PyObject* args)
 {
-	const char *Sound=NULL;
+	PyObject *Sound = nullptr;
 	int globalID;
-	PARSE_ARGS( args,  "is", &globalID, &Sound );
+	PARSE_ARGS(args,  "iO", &globalID, &Sound);
 	GET_GAME();
 	GET_ACTOR_GLOBAL();
 
-	actor->SetSoundFolder(ieVariable(Sound));
+	actor->SetSoundFolder(PyString_AsStringObj(Sound));
 	Py_RETURN_NONE;
 }
 
@@ -5606,17 +5610,9 @@ static PyObject* GemRB_GetPlayerSound(PyObject * /*self*/, PyObject* args)
 	GET_ACTOR_GLOBAL();
 
 	ResRef ignore;
-	std::string sound = actor->GetSoundFolder(flag, ignore);
+	auto sound = actor->GetSoundFolder(flag, ignore);
 
-	// System encoding may fail if there is a save game loaded from the original
-	// game that uses TLK encoding for the path
-	PyObject* playerSound = PyString_FromSystemStringObj(sound);
-	if (playerSound == nullptr) {
-		PyErr_Clear();
-		playerSound = PyString_FromStringObj(sound);
-	}
-
-	return playerSound;
+	return PyString_FromStringObj(sound);
 }
 
 PyDoc_STRVAR( GemRB_GetSlotType__doc,
@@ -10458,7 +10454,13 @@ static PyObject* GemRB_HasResource(PyObject * /*self*/, PyObject* args)
 	int ResType;
 	int silent = 0;
 	PARSE_ARGS( args,  "Oi|i", &ResRef, &ResType, &silent );
-	RETURN_BOOL(gamedata->Exists(PyString_AsStringView(ResRef), ResType, silent));
+
+	if (PyUnicode_Check(ResRef)) {
+		// This may be checking of IWD2 sound folders
+		RETURN_BOOL(gamedata->Exists(PyString_AsStringObj(ResRef), ResType, silent));
+	} else {
+		RETURN_BOOL(gamedata->Exists(PyString_AsStringView(ResRef), ResType, silent));
+	}
 }
 
 PyDoc_STRVAR( GemRB_Window_SetupEquipmentIcons__doc,

--- a/gemrb/plugins/GUIScript/PythonConversions.cpp
+++ b/gemrb/plugins/GUIScript/PythonConversions.cpp
@@ -137,11 +137,6 @@ PyObject* PyString_FromStringObj(const std::string& s)
 	return PyUnicode_Decode(s.c_str(), s.length(), core->TLKEncoding.encoding.c_str(), "strict");
 }
 
-PyObject* PyString_FromSystemStringObj(const std::string& s)
-{
-	return PyUnicode_Decode(s.c_str(), s.length(), core->config.SystemEncoding.c_str(), "strict");
-}
-	
 PyObject* PyString_FromStringObj(const String& s)
 {
 	return PyUnicode_Decode(reinterpret_cast<const char*>(s.c_str()), s.length() * sizeof(char16_t), "UTF-16", "strict");

--- a/gemrb/plugins/GUIScript/PythonConversions.h
+++ b/gemrb/plugins/GUIScript/PythonConversions.h
@@ -236,7 +236,6 @@ PyObject* PyString_FromResRef(const ResRef& resRef);
 PyObject* PyString_FromString(const char* s);
 PyObject* PyString_FromStringView(StringView sv);
 PyObject* PyString_FromStringObj(const std::string&);
-PyObject* PyString_FromSystemStringObj(const std::string&);
 PyObject* PyString_FromStringObj(const String&);
 
 String PyString_AsStringObj(PyObject *obj);

--- a/gemrb/plugins/TLKImporter/TlkOverride.cpp
+++ b/gemrb/plugins/TLKImporter/TlkOverride.cpp
@@ -149,8 +149,7 @@ ieStrRef CTlkOverride::UpdateString(ieStrRef strref, const String& string)
 		assert(strref != ieStrRef::INVALID);
 	}
 
-	// FIXME: newvalue could be a multibyte string in an encoding incompatible with ASCII
-	std::string newvalue = MBStringFromString(string);
+	std::string newvalue = TLKStringFromString(string);
 	size_t length = std::min<size_t>(newvalue.length(), std::numeric_limits<uint16_t>::max());
 
 	//set the backpointer of the first string segment

--- a/platforms/windows/WindowsFile.cpp
+++ b/platforms/windows/WindowsFile.cpp
@@ -1,0 +1,109 @@
+/* GemRB - Infinity Engine Emulator
+ * Copyright (C) 2023 The GemRB Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "WindowsFile.h"
+
+namespace GemRB {
+
+WindowsFile::WindowsFile(WindowsFile&& f) noexcept {
+	this->file = f.file;
+	f.file = INVALID_HANDLE_VALUE;
+}
+
+WindowsFile::~WindowsFile() {
+	if (file != INVALID_HANDLE_VALUE) {
+		CloseHandle(file);
+	}
+}
+
+WindowsFile& WindowsFile::operator=(WindowsFile&& f) noexcept {
+	if (&f != this) {
+		std::swap(file, f.file);
+	}
+	return *this;
+}
+
+strpos_t WindowsFile::Length() {
+	LARGE_INTEGER fileSize;
+	GetFileSizeEx(file, &fileSize);
+
+	return fileSize.QuadPart;
+}
+
+bool WindowsFile::OpenRO(const path_t& name) {
+	this->file = _OpenFile(name, GENERIC_READ, OPEN_EXISTING);
+	return file != INVALID_HANDLE_VALUE;
+}
+
+bool WindowsFile::OpenRW(const path_t& name) {
+	this->file = _OpenFile(name, GENERIC_READ | GENERIC_WRITE, OPEN_EXISTING);
+	return file != INVALID_HANDLE_VALUE;
+}
+
+bool WindowsFile::OpenNew(const path_t& name) {
+	this->file = _OpenFile(name, GENERIC_WRITE, CREATE_ALWAYS);
+	return file != INVALID_HANDLE_VALUE;
+}
+
+strret_t WindowsFile::Read(void* ptr, size_t length) {
+	DWORD bytesRead = 0;
+	ReadFile(file, ptr, length, &bytesRead, nullptr);
+	return bytesRead;
+}
+
+strret_t WindowsFile::Write(const void* ptr, strpos_t length) {
+	DWORD bytesWritten = 0;
+	WriteFile(file, ptr, length, &bytesWritten, nullptr);
+	return bytesWritten;
+}
+
+bool WindowsFile::SeekStart(stroff_t offset) {
+	return _SetFilePointer(offset, FILE_BEGIN);
+}
+
+bool WindowsFile::SeekCurrent(stroff_t offset) {
+	return _SetFilePointer(offset, FILE_CURRENT);
+}
+
+bool WindowsFile::SeekEnd(stroff_t offset) {
+	return _SetFilePointer(offset, FILE_END);
+}
+
+HANDLE WindowsFile::_OpenFile(const path_t& name, DWORD access, DWORD disposition) {
+	auto fileName = StringFromUtf8(name.c_str());
+
+	return CreateFile(
+		reinterpret_cast<const wchar_t*>(fileName.c_str()),
+		access,
+		FILE_SHARE_READ | FILE_SHARE_WRITE, // some files are opened r and r+w in parallel
+		nullptr,
+		disposition,
+		FILE_ATTRIBUTE_NORMAL,
+		nullptr
+	);
+}
+
+bool WindowsFile::_SetFilePointer(stroff_t offset, DWORD method) {
+	LARGE_INTEGER liOffset;
+	liOffset.QuadPart = offset;
+
+	return SetFilePointerEx(file, liOffset, nullptr, method) != 0;
+}
+
+}

--- a/platforms/windows/WindowsFile.h
+++ b/platforms/windows/WindowsFile.h
@@ -1,0 +1,56 @@
+/* GemRB - Infinity Engine Emulator
+ * Copyright (C) 2023 The GemRB Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef WINDOWS_FILE_H
+#define WINDOWS_FILE_H
+
+#include "../../gemrb/core/Streams/File.h"
+
+namespace GemRB {
+
+class GEM_EXPORT WindowsFile : public File {
+private:
+	HANDLE file = INVALID_HANDLE_VALUE;
+public:
+	WindowsFile() noexcept = default;
+	WindowsFile(const WindowsFile&) = delete;
+	WindowsFile(WindowsFile&& f) noexcept;
+	~WindowsFile() override;
+
+	WindowsFile& operator=(const WindowsFile&) = delete;
+	WindowsFile& operator=(WindowsFile&& f) noexcept;
+
+	strpos_t Length() override;
+	bool OpenRO(const path_t& name) override;
+	bool OpenRW(const path_t& name) override;
+	bool OpenNew(const path_t& name) override;
+	strret_t Read(void* ptr, size_t length) override;
+	strret_t Write(const void* ptr, strpos_t length) override;
+	bool SeekStart(stroff_t offset) override;
+	bool SeekCurrent(stroff_t offset) override;
+	bool SeekEnd(stroff_t offset) override;
+
+private:
+	HANDLE _OpenFile(const path_t& name, DWORD access, DWORD disposition);
+	bool _SetFilePointer(stroff_t offset, DWORD method);
+};
+
+}
+
+#endif


### PR DESCRIPTION
## Description

Actually this was somewhat painful but it works. What did I do here:

* Make sound sets of IWD2 work with non-ASCII characters, so it's the first time I hear the PCs talking in savegames
* Throwing out some `mbstowcs` and some direct C I/O stuff by realizing it doesn't work this way on Windows for non-ASCII paths.
* Creating save games that work across the original and GemRB. This _may_ break compatibility for non-English savegames.
* By-fixing stuff that crashed or needed rework by now.

Interestingly I noticed how I was unable to type in non-ASCII chars in the originals so some things needed testing over hex-editing game data.

Some rationale over the worst-possible scenario by example: sound sets, as they are directories that may contain language-specific stuff:

* We need to get their name from the FS, over C API (multi byte) or Windows API (wide char)
* We probably want to emit logging here and there (multi byte)
* We need them displayed in Python (Python-encoding)
* We need them for sound playback among the resources (...)
* We need to store them in save games (TLK-encoding)

So my decisions were roughly like:
* Let path handling remain `path_t == std::string` and deal with Windows' `wchar_t*` bytes only at the very end.
* Handle all the game data strings (not `ResRef`, `ieVariable`) as `String == std::u16string` so let the importers deal with TLK encoding.
* Keep Python API out of automatically converting anything for us, `GUIScript` is supposed to feed explicit conversions into both directions.
* There is some interference between the concepts when it comes to some sound files that are game data, paths and resources all at once so I've put conversions there. This shouldn't be too hot of a code path.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
