### PR TITLE
Fix build for certain SDL Video versions

### DIFF
--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -589,7 +589,7 @@ void SDL20VideoDriver::DrawRawGeometry(
 		SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
 	}
 
-	static_assert(sizeof(int) == sizeof(SDL_Color));
+	static_assert(sizeof(int) == sizeof(SDL_Color), "Incompatible types to cast");
 
 	SDL_RenderGeometryRaw(
 		renderer,

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -589,7 +589,9 @@ void SDL20VideoDriver::DrawRawGeometry(
 		SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
 	}
 
+	#if !SDL_VERSION_ATLEAST(2, 0, 22)
 	static_assert(sizeof(int) == sizeof(SDL_Color), "Incompatible types to cast");
+	#endif
 
 	SDL_RenderGeometryRaw(
 		renderer,

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -589,6 +589,8 @@ void SDL20VideoDriver::DrawRawGeometry(
 		SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
 	}
 
+	static_assert(sizeof(int) == sizeof(SDL_Color));
+
 	SDL_RenderGeometryRaw(
 		renderer,
 		nullptr,

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -594,7 +594,11 @@ void SDL20VideoDriver::DrawRawGeometry(
 		nullptr,
 		vertices.data(),
 		2 * sizeof(float),
+		#if SDL_VERSION_ATLEAST(2, 0, 22)
 		reinterpret_cast<const SDL_Color*>(colors.data()),
+		#else
+		reinterpret_cast<const int*>(colors.data()),
+		#endif
 		sizeof(Color),
 		nullptr,
 		0,


### PR DESCRIPTION
## Description
Project fails to build with SDL Video for versions between  >2.0.18 and <2.0.22.

When trying to build with SDL 2.0.18 I get the following error:
```
lcc: "gemrb/gemrb/plugins/SDLVideo/SDL20Video.cpp", line 597: error #167:
          argument of type "const SDL_Color *" is incompatible with parameter
          of type "const int *"
    reinterpret_cast<const SDL_Color*>(colors.data()),
    ^
``` 

This happens because prior to libsdl-org/SDL@b7885abc449250fc733a756239d670394d01fe62 `SDL_RenderGeometryRaw()` passes colors as `int*` instead of `SDL_Color*`.

We could simply change the check in `SDL20VideoDriver::DrawRawGeometry()` from 
`#if SDL_VERSION_ATLEAST(2, 0, 18)`
to
`#if SDL_VERSION_ATLEAST(2, 0, 22)`
or check the specific way we pass color based on SDL Video version.

Big thanks to @a1batross for figuring this out!

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
