### PR TITLE
Size of colors token may be 3

### DIFF
--- a/gemrb/core/GUI/TextSystem/GemMarkup.cpp
+++ b/gemrb/core/GUI/TextSystem/GemMarkup.cpp
@@ -25,11 +25,11 @@ namespace GemRB {
 static Color ParseColor(const String& colorString)
 {
 	Color color = ColorWhite;
-	uint8_t values[4] = {0, 0, 0, 0};
+	uint8_t values[4] = { 0, 0, 0, 0xff };
 
 	// That's a short way to interpret 4 groups of %02hhx,
 	// since `swscanf` does not work on our string type unless converting first
-	for (uint8_t i = 0; i < 4; ++i) {
+	for (uint8_t i = 0; i < colorString.size() / 2; ++i) {
 		uint8_t value = 0;
 
 		for (uint8_t j = 0; j < 2; ++j) {


### PR DESCRIPTION
## Description
Size of colors token may be 3. Caught an overflow in BG2.

![Screenshot 2023-11-27 212447](https://github.com/gemrb/gemrb/assets/119408536/213988f4-0758-41f3-a7bc-0bbf08f68867)
![Screenshot 2023-11-27 213741](https://github.com/gemrb/gemrb/assets/119408536/3d75e36d-e601-4077-b43c-db4a3e8144dd)
