### PR TITLE
Report and set SDL_FOUND when -DSDL_BACKEND specified

### DIFF
--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -184,6 +184,11 @@ FUNCTION(CONFIGURE_SDL SDL_BACKEND)
             SET_INTERNAL(SDL_MIXER_FOUND ${SDL_MIXER_FOUND})
         ENDIF()
 
+        IF(SDL_FOUND)
+            MESSAGE(STATUS "Found SDL 1.2, switching to SDL backend.")
+            SET_INTERNAL(SDL_FOUND ${SDL_FOUND})
+        ENDIF()
+
         SET_INTERNAL(SDL_INCLUDE_DIR "${SDL_INCLUDE_DIRS}")
         SET_INTERNAL(SDL_LIBRARY "${SDL_LIBRARIES}")
     ENDIF()
@@ -198,6 +203,12 @@ FUNCTION(CONFIGURE_SDL SDL_BACKEND)
         ELSE()
             FIND_PACKAGE(SDL2 REQUIRED)
         ENDIF()
+
+        IF(SDL2_FOUND)
+            MESSAGE(STATUS "Found SDL 2.0, switching to SDL2 backend.")
+            SET_INTERNAL(SDL_FOUND ${SDL2_FOUND})
+        ENDIF()
+
         # unify SDL variables, so we don't have to differentiate later
         UNSET(SDL_INCLUDE_DIR CACHE)
         UNSET(SDL_LIBRARY CACHE)


### PR DESCRIPTION
## Description
<!-- Describe the overall purpose of this pull request (PR). If applicable also add bug references and screenshots.-->

1. Report the SDL version and handle the `SDL_FOUND` only happen in the default path.
2. When using `-DSDL_BACKEND=SDL2`, cmake goes to the findSDL2 path and it does not set `SDL_FOUND` but `SDL2_FOUND`, so we need to handle that.

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [X] I have tested the proposed changes
- [X] The proposed change builds also on our build bots (check after submission)
