### PR TITLE
Brightness and contrast

### DIFF
--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -258,9 +258,6 @@ Interface::Interface(CoreSettings&& cfg)
 	Control::ActionRepeatDelay = config.ActionRepeatDelay;
 	GameControl::DebugFlags = config.DebugFlags;
 
-	ieDword brightness = vars.Get("Brightness Correction", 10);
-	ieDword contrast = vars.Get("Gamma Correction", 5);
-
 	Log(MESSAGE, "Core", "Initializing search path...");
 	if (!IsAvailable(PLUGIN_RESOURCE_DIRECTORY)) {
 		throw CIE("no DirectoryImporter!");
@@ -368,24 +365,6 @@ Interface::Interface(CoreSettings&& cfg)
 	Log(MESSAGE, "Core", "Reading Game Options...");
 	LoadGemRBINI();
 
-	// SDL2 driver requires the display to be created prior to sprite creation (opengl context)
-	// we also need the display to exist to create sprites using the display format
-	ieDword fullscreen = vars.Get("Full Screen", 0);
-
-	int createDisplayResult =
-	VideoDriver->CreateDisplay(
-				Size(config.Width, config.Height),
-				config.Bpp,
-				fullscreen,
-				config.GameName.c_str(),
-				config.CapFPS == 0
-		);
-
-	if (createDisplayResult == GEM_ERROR) {
-		throw CIE("Cannot initialize shaders.");
-	}
-	VideoDriver->SetGamma(brightness, contrast);
-
 	// load the game ini (baldur.ini, torment.ini, icewind.ini ...)
 	// read from our version of the config if it is present
 	path_t gemrbINI = "gem-" + INIConfig;
@@ -404,6 +383,27 @@ Interface::Interface(CoreSettings&& cfg)
 	if (!InitializeVarsWithINI(ini_path)) {
 		Log(WARNING, "Core", "Unable to set dictionary default values!");
 	}
+
+	// SDL2 driver requires the display to be created prior to sprite creation (opengl context)
+	// we also need the display to exist to create sprites using the display format
+	ieDword fullscreen = vars.Get("Full Screen", 0);
+	// Brightness and contrast are specified in gem-INICONFIG, so display must be initialized after reading it.
+	ieDword brightness = vars.Get("Brightness Correction", 10);
+	ieDword contrast = vars.Get("Gamma Correction", 5);
+
+	int createDisplayResult =
+	VideoDriver->CreateDisplay(
+				Size(config.Width, config.Height),
+				config.Bpp,
+				fullscreen,
+				config.GameName.c_str(),
+				config.CapFPS == 0
+		);
+
+	if (createDisplayResult == GEM_ERROR) {
+		throw CIE("Cannot initialize shaders.");
+	}
+	VideoDriver->SetGamma(brightness, contrast);
 
 	// We use this for the game's state exclusively
 	ieDword maxRefreshRate = vars.Get("Maximum Frame Rate", 30);

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -388,8 +388,8 @@ Interface::Interface(CoreSettings&& cfg)
 	// we also need the display to exist to create sprites using the display format
 	ieDword fullscreen = vars.Get("Full Screen", 0);
 	// Brightness and contrast are specified in gem-INICONFIG, so display must be initialized after reading it.
-	ieDword brightness = vars.Get("Brightness Correction", 10);
-	ieDword contrast = vars.Get("Gamma Correction", 5);
+	ieDword brightness = vars.Get("Brightness Correction", 0);
+	ieDword contrast = vars.Get("Gamma Correction", 0);
 
 	int createDisplayResult =
 	VideoDriver->CreateDisplay(

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -473,8 +473,8 @@ int SDL20VideoDriver::RenderCopyShaded(SDL_Texture* texture, const SDL_Rect* src
 
 	blitRGBAShader->SetUniformValue("u_greyMode", 1, greyMode);
 
-	blitRGBAShader->SetUniformValue("u_brightness", 1, this->brightness);
-	blitRGBAShader->SetUniformValue("u_contrast", 1, this->contrast);
+	blitRGBAShader->SetUniformValue("u_brightness", 1, brightness);
+	blitRGBAShader->SetUniformValue("u_contrast", 1, contrast);
 
 	GLint channel = 3;
 	if (flags & BlitFlags::STENCIL_RED) {

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -1014,8 +1014,9 @@ bool SDL20VideoDriver::CanDrawRawGeometry() const {
 
 void SDL20VideoDriver::SetGamma(int newBrightness, int newContrast)
 {
-	brightness = 1.0 + (float)newBrightness*0.0015;
-	contrast = 1.0 + (float)newContrast*0.05;
+	// Steps chosen empirically to give ranges close to originals.
+	brightness = 1.0 + (float)newBrightness * 0.0015;
+	contrast = 1.0 + (float)newContrast * 0.05;
 }
 
 bool SDL20VideoDriver::SetFullscreenMode(bool set)

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -1012,10 +1012,10 @@ bool SDL20VideoDriver::CanDrawRawGeometry() const {
 #endif
 }
 
-void SDL20VideoDriver::SetGamma(int new_brightness, int new_contrast)
+void SDL20VideoDriver::SetGamma(int newBrightness, int newContrast)
 {
-	this->brightness = 1.0 + (float)new_brightness*0.0015;
-	this->contrast = 1.0 + (float)new_contrast*0.05;
+	brightness = 1.0 + (float)newBrightness*0.0015;
+	contrast = 1.0 + (float)newContrast*0.05;
 }
 
 bool SDL20VideoDriver::SetFullscreenMode(bool set)

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -286,6 +286,7 @@ void SDL20VideoDriver::SwapBuffers(VideoBuffers& buffers)
 	blitRGBAShader->SetUniformValue("u_dither", 1, 0);
 	blitRGBAShader->SetUniformValue("u_rgba", 1, 1);
 	blitRGBAShader->SetUniformValue("u_brightness", 1, 1);
+	blitRGBAShader->SetUniformValue("u_contrast", 1, 1);
 #endif
 
 	SDL_SetRenderTarget(renderer, NULL);
@@ -473,6 +474,7 @@ int SDL20VideoDriver::RenderCopyShaded(SDL_Texture* texture, const SDL_Rect* src
 	blitRGBAShader->SetUniformValue("u_greyMode", 1, greyMode);
 
 	blitRGBAShader->SetUniformValue("u_brightness", 1, this->brightness);
+	blitRGBAShader->SetUniformValue("u_contrast", 1, this->contrast);
 
 	GLint channel = 3;
 	if (flags & BlitFlags::STENCIL_RED) {
@@ -1010,12 +1012,10 @@ bool SDL20VideoDriver::CanDrawRawGeometry() const {
 #endif
 }
 
-void SDL20VideoDriver::SetGamma(int brightness, int /*contrast*/)
+void SDL20VideoDriver::SetGamma(int brightness, int contrast)
 {
-	// FIXME: hardcoded hack. in in Interface our default brigtness value is 10
-	// so we assume that to be "normal" (1.0) value.
-	// SDL_SetWindowBrightness(window, (float)brightness/10.0);
-	this->brightness = 0.9 + (float)brightness/10.0*0.1;
+	this->brightness = 1.0 + (float)brightness*0.0015;
+	this->contrast = 1.0 + (float)contrast*0.05;
 }
 
 bool SDL20VideoDriver::SetFullscreenMode(bool set)

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -1012,10 +1012,10 @@ bool SDL20VideoDriver::CanDrawRawGeometry() const {
 #endif
 }
 
-void SDL20VideoDriver::SetGamma(int brightness, int contrast)
+void SDL20VideoDriver::SetGamma(int new_brightness, int new_contrast)
 {
-	this->brightness = 1.0 + (float)brightness*0.0015;
-	this->contrast = 1.0 + (float)contrast*0.05;
+	this->brightness = 1.0 + (float)new_brightness*0.0015;
+	this->contrast = 1.0 + (float)new_contrast*0.05;
 }
 
 bool SDL20VideoDriver::SetFullscreenMode(bool set)

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -285,6 +285,7 @@ void SDL20VideoDriver::SwapBuffers(VideoBuffers& buffers)
 	blitRGBAShader->SetUniformValue("u_stencil", 1, 0);
 	blitRGBAShader->SetUniformValue("u_dither", 1, 0);
 	blitRGBAShader->SetUniformValue("u_rgba", 1, 1);
+	blitRGBAShader->SetUniformValue("u_brightness", 1, 1);
 #endif
 
 	SDL_SetRenderTarget(renderer, NULL);
@@ -470,6 +471,8 @@ int SDL20VideoDriver::RenderCopyShaded(SDL_Texture* texture, const SDL_Rect* src
 	}
 
 	blitRGBAShader->SetUniformValue("u_greyMode", 1, greyMode);
+
+	blitRGBAShader->SetUniformValue("u_brightness", 1, this->brightness);
 
 	GLint channel = 3;
 	if (flags & BlitFlags::STENCIL_RED) {
@@ -1011,7 +1014,8 @@ void SDL20VideoDriver::SetGamma(int brightness, int /*contrast*/)
 {
 	// FIXME: hardcoded hack. in in Interface our default brigtness value is 10
 	// so we assume that to be "normal" (1.0) value.
-	SDL_SetWindowBrightness(window, (float)brightness/10.0);
+	// SDL_SetWindowBrightness(window, (float)brightness/10.0);
+	this->brightness = 0.9 + (float)brightness/10.0*0.1;
 }
 
 bool SDL20VideoDriver::SetFullscreenMode(bool set)

--- a/gemrb/plugins/SDLVideo/SDL20Video.h
+++ b/gemrb/plugins/SDLVideo/SDL20Video.h
@@ -222,6 +222,8 @@ private:
 	SDL_GameController* gameController = nullptr;
 
 	GLSLProgram* blitRGBAShader = nullptr;
+	float brightness = 1.0;
+	float contrast = 1.0;
 public:
 	SDL20VideoDriver() noexcept;
 	~SDL20VideoDriver() noexcept override;

--- a/gemrb/plugins/SDLVideo/Shaders/BlitRGBA.glsl
+++ b/gemrb/plugins/SDLVideo/Shaders/BlitRGBA.glsl
@@ -12,10 +12,24 @@ uniform int u_stencil;
 uniform int u_dither;
 uniform int u_rgba;
 uniform float u_brightness;
+uniform float u_contrast;
 
 void main() {
 	vec4 color = texture2D(s_sprite, v_texCoord) * v_color;
-	color.rgb *= u_brightness; // Apply brightness control
+
+	// Additive Brightness
+	color.rgb += (u_brightness-1.0);
+	// Originals call the second parameter "Contrast" in UI and "Gamma Correction" in inis.
+	// Looks like it's neither, just a multiplicator to brightness.
+	color.rgb = color.rgb *= u_contrast;
+
+	// Limit to 1.0
+	color.rgb = clamp(color.rgb, 0.0, 1.0);
+
+	// Actual gamma correction example.
+//	color.rgb = pow(color.rgb, vec3(1.0 / u_contrast));
+	// Actual contrast correction example.
+//	color.rgb = ((color.rgb - 0.5) * max(u_contrast, 0.0)) + 0.5;
 
 	gl_FragColor = color;
 	if (u_rgba == 0) {

--- a/gemrb/plugins/SDLVideo/Shaders/BlitRGBA.glsl
+++ b/gemrb/plugins/SDLVideo/Shaders/BlitRGBA.glsl
@@ -21,7 +21,7 @@ void main() {
 	color.rgb += (u_brightness-1.0);
 	// Originals call the second parameter "Contrast" in UI and "Gamma Correction" in inis.
 	// Looks like it's neither, just a multiplicator to brightness.
-	color.rgb = color.rgb *= u_contrast;
+	color.rgb *= u_contrast;
 
 	// Limit to 1.0
 	color.rgb = clamp(color.rgb, 0.0, 1.0);

--- a/gemrb/plugins/SDLVideo/Shaders/BlitRGBA.glsl
+++ b/gemrb/plugins/SDLVideo/Shaders/BlitRGBA.glsl
@@ -11,9 +11,12 @@ uniform int u_channel;
 uniform int u_stencil;
 uniform int u_dither;
 uniform int u_rgba;
+uniform float u_brightness;
 
 void main() {
 	vec4 color = texture2D(s_sprite, v_texCoord) * v_color;
+	color.rgb *= u_brightness; // Apply brightness control
+
 	gl_FragColor = color;
 	if (u_rgba == 0) {
 		gl_FragColor.a = 1.0;


### PR DESCRIPTION
## Description
Added brightness and contrast to the existing shader #1098.

Actually, there's some confusion about the settings, they called it contrast in the interface and gamma in the configs. But from my testing, it seems that it is also brightness. Just the first one is additive, the other one is multiplicative. (Maybe a better name for 2nd one would be saturation, my color theory is very weak.)

I tried actual contrast formula, as well as actual gamma correction formula, and the results are different, but I can't say that they are better.
There are other options for brightness too, sigmoid and stuff. Maybe worth exploring.

Also fixes brightness not applying on start.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
