### PR TITLE
Remove old Fullscreen option from GemRB.cfg, update docs. Ref #1989.

### DIFF
--- a/gemrb.6.in
+++ b/gemrb.6.in
@@ -147,10 +147,6 @@ Game window height (in pixels).
 Color depth of the game window (in bits per pixel).
 
 .TP
-.BR Fullscreen =(0|1)
-Whether the game should run in fullscreen mode.
-
-.TP
 .BR CapFPS =(-1|0|n)
 Set FPS handling:
   -1: no limit

--- a/gemrb/GemRB.cfg.noinstall.sample
+++ b/gemrb/GemRB.cfg.noinstall.sample
@@ -54,9 +54,6 @@ Height=480
 # Bits per pixel [Integer:16,32]
 Bpp=32
 
-# Fullscreen [Boolean]
-Fullscreen=0
-
 # Cap FPS, 0 = request VSync (SDL2 only, default), -1 = no limit, 30+ = cap value
 #CapFPS=0
 

--- a/gemrb/GemRB.cfg.sample.in
+++ b/gemrb/GemRB.cfg.sample.in
@@ -54,9 +54,6 @@ Height=480
 # Bits per pixel [Integer:16,32]
 Bpp=32
 
-# Fullscreen [Boolean]
-Fullscreen=0
-
 # Cap FPS, 0 = request VSync (SDL2 only, default), -1 = no limit, 30+ = cap value
 #CapFPS=0
 

--- a/gemrb/core/GUI/WindowManager.cpp
+++ b/gemrb/core/GUI/WindowManager.cpp
@@ -324,9 +324,13 @@ void WindowManager::CloseAllWindows() const
 bool WindowManager::HotKey(const Event& event) const
 {
 	if (event.type == Event::KeyDown && event.keyboard.repeats == 1) {
+		auto& vars = core->GetDictionary();
+		bool fullscreen;
 		switch (event.keyboard.keycode) {
 			case 'f':
 				video->ToggleFullscreenMode();
+				fullscreen = (bool) vars.Get("Full Screen", 0);
+				vars.Set("Full Screen", !fullscreen);
 				return true;
 			case GEM_GRAB:
 				video->ToggleGrabInput();

--- a/gemrb/core/Video/Video.cpp
+++ b/gemrb/core/Video/Video.cpp
@@ -20,6 +20,8 @@
 
 #include "Video.h"
 
+#include "Interface.h"
+
 #include "Palette.h"
 #include "Sprite2D.h"
 
@@ -169,6 +171,8 @@ void Video::SetScreenClip(const Region* clip)
 
 bool Video::ToggleFullscreenMode()
 {
+	auto& vars = core->GetDictionary();
+	vars.Set("Full Screen", !fullscreen);
 	return SetFullscreenMode(!fullscreen);
 }
 

--- a/gemrb/core/Video/Video.cpp
+++ b/gemrb/core/Video/Video.cpp
@@ -20,8 +20,6 @@
 
 #include "Video.h"
 
-#include "Interface.h"
-
 #include "Palette.h"
 #include "Sprite2D.h"
 
@@ -171,8 +169,6 @@ void Video::SetScreenClip(const Region* clip)
 
 bool Video::ToggleFullscreenMode()
 {
-	auto& vars = core->GetDictionary();
-	vars.Set("Full Screen", !fullscreen);
 	return SetFullscreenMode(!fullscreen);
 }
 

--- a/platforms/apple/CocoaWrapper/mac/nibs/GemRB.xib
+++ b/platforms/apple/CocoaWrapper/mac/nibs/GemRB.xib
@@ -513,17 +513,6 @@
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="990">
-                                    <rect key="frame" x="15" y="94" width="80" height="18"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    <buttonCell key="cell" type="check" title="Full Screen" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="991">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="smallSystem"/>
-                                    </buttonCell>
-                                    <connections>
-                                        <binding destination="882" name="value" keyPath="values.Fullscreen" id="993"/>
-                                    </connections>
-                                </button>
                                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1140">
                                     <rect key="frame" x="15" y="22" width="92" height="18"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>

--- a/platforms/apple/defaults.plist
+++ b/platforms/apple/defaults.plist
@@ -12,8 +12,6 @@
 	<true/>
 	<key>EnableCheatKeys</key>
 	<true/>
-	<key>Fullscreen</key>
-	<false/>
 	<key>Width</key>
 	<integer>640</integer>
 	<key>Height</key>

--- a/platforms/apple/ios/GemRB.cfg.newinstall
+++ b/platforms/apple/ios/GemRB.cfg.newinstall
@@ -85,9 +85,6 @@ NumFingInfo=2
 #Bits per pixel [Integer:16,32]
 Bpp=32
 
-#Fullscreen [Boolean]
-Fullscreen=1
-
 #####################################################
 #  Paths                                            #
 #####################################################

--- a/platforms/vita/README.Vita.md
+++ b/platforms/vita/README.Vita.md
@@ -68,7 +68,7 @@ Keyboard input is done with D-Pad (on character creation and game saves. 'a-z', 
 
 Pointer movement speed can be changed with 'GamepadPointerSpeed' parameter in GemRB.cfg.
 
-Use "Fullscreen=1" to scale game area to native Vita resolution or "Fullscreen=0" to keep game area at the center of the screen.
+Use `Full Screen = 1` in game ini config (e.g. `gem-baldur.ini`) to scale game area to native Vita resolution or `Full Screen = 0` to keep game area at the center of the screen.
 
 VitaKeepAspectRatio=1 keeps aspect ratio of original image when scaling. VitaKeepAspectRatio=0 just scales it to 960x544.
 

--- a/platforms/vita/README.Vita.md
+++ b/platforms/vita/README.Vita.md
@@ -68,7 +68,7 @@ Keyboard input is done with D-Pad (on character creation and game saves. 'a-z', 
 
 Pointer movement speed can be changed with 'GamepadPointerSpeed' parameter in GemRB.cfg.
 
-Use `Full Screen = 1` in game ini config (e.g. `gem-baldur.ini`) to scale game area to native Vita resolution or `Full Screen = 0` to keep game area at the center of the screen.
+Use `Full Screen = 1` in game ini config (e.g. `baldur.ini`) to scale game area to native Vita resolution or `Full Screen = 0` to keep game area at the center of the screen.
 
 VitaKeepAspectRatio=1 keeps aspect ratio of original image when scaling. VitaKeepAspectRatio=0 just scales it to 960x544.
 


### PR DESCRIPTION
## Description
Remove old Fullscreen option from GemRB.cfg, update docs. Ref #1989.

Other video options are still read from cfg, though. Can be confusing too. Not sure why they were duplicated in the first place.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
