### PR TITLE
Custom menu button fixes for BG2

### DIFF
--- a/gemrb/GUIScripts/bg2/Start2.py
+++ b/gemrb/GUIScripts/bg2/Start2.py
@@ -19,6 +19,7 @@
 #this is essentially Start.py from the SoA game, except for a very small change
 import GemRB
 import GameCheck
+from StartFix import ShiftWindow
 
 def OnLoad():
 	StartWindow = GemRB.LoadWindow (0, "START")
@@ -33,6 +34,12 @@ def OnLoad():
 	MultiPlayerButton = StartWindow.GetControl (1)
 	MoviesButton = StartWindow.GetControl (2)
 	BackButton = StartWindow.GetControl (5)
+
+	# Fix misaligned buttons, see https://github.com/gemrb/gemrb/issues/1991.
+	ShiftWindow(MoviesButton, -1, 0)
+	ShiftWindow(OptionsButton, -1, 0)
+	ShiftWindow(MultiPlayerButton, -1, 0)
+
 	Label = StartWindow.CreateLabel(0x0fff0000, 0,450,640,30, "REALMS", "", IE_FONT_SINGLE_LINE | IE_FONT_ALIGN_CENTER)
 	Label.SetText (GemRB.Version)
 	if GameCheck.HasTOB():
@@ -187,6 +194,10 @@ def ExitPress():
 	QuitTextArea = QuitWindow.GetControl (0)
 	CancelButton = QuitWindow.GetControl (2)
 	ConfirmButton = QuitWindow.GetControl (1)
+
+	# Fix misaligned buttons, see https://github.com/gemrb/gemrb/issues/1991.
+	ShiftWindow(CancelButton, -1, 0)
+
 	QuitTextArea.SetText (19532)
 	CancelButton.SetText (13727)
 	ConfirmButton.SetText (15417)

--- a/gemrb/GUIScripts/bg2/StartFix.py
+++ b/gemrb/GUIScripts/bg2/StartFix.py
@@ -1,0 +1,27 @@
+# GemRB - Infinity Engine Emulator
+# Copyright (C) 2003 The GemRB Project
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+#
+# Custom fixups for wrong menus.
+
+
+def ShiftWindow(window, deltax: int, deltay: int):
+    """
+    Shift window by deltax:deltay px from its current position.
+    """
+    Pos = window.GetPos()
+    window.SetPos(Pos[0] + deltax, Pos[1] + deltay)

--- a/gemrb/GUIScripts/bg2/StartOpt.py
+++ b/gemrb/GUIScripts/bg2/StartOpt.py
@@ -18,6 +18,7 @@
 #
 import GemRB
 import GUIOPT
+from StartFix import ShiftWindow
 
 OptionsWindow = 0
 
@@ -28,6 +29,12 @@ def OnLoad():
 	GameButton = OptionsWindow.GetControl(9)
 	GraphicButton = OptionsWindow.GetControl(7)
 	BackButton = OptionsWindow.GetControl(11)
+
+	# Fix misaligned buttons, see https://github.com/gemrb/gemrb/issues/1991.
+	ShiftWindow(GameButton, -1, 0)
+	ShiftWindow(GraphicButton, -1, 0)
+	ShiftWindow(BackButton, -1, 0)
+
 	SoundButton.SetStatus(IE_GUI_BUTTON_ENABLED)
 	GameButton.SetStatus(IE_GUI_BUTTON_ENABLED)
 	GraphicButton.SetStatus(IE_GUI_BUTTON_ENABLED)


### PR DESCRIPTION
## Description
Menu alignment fixes for BG2:  #1991.

Alignment is correct now, but there's still some barely noticeable twiching on these screens, in these areas:

![a](https://github.com/gemrb/gemrb/assets/1279852/b095096d-5b28-4fb8-9e25-9ed59b76d831)
![b](https://github.com/gemrb/gemrb/assets/1279852/e690621d-8568-4a3f-934a-ea2d95a036a9)

Not sure where it comes from, center art overlay order? Scaling/rendering?
But you need to really look for it to notice.

Anyway, this is better than before.
 
## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
