### PR TITLE
Fix SoA logo flipping to ToB on Options screen, ref #2003.

### DIFF
--- a/gemrb/GUIScripts/bg2/StartOpt.py
+++ b/gemrb/GUIScripts/bg2/StartOpt.py
@@ -25,7 +25,7 @@ OptionsWindow = 0
 def OnLoad():
 	global OptionsWindow
 	OptionsWindow = GemRB.LoadWindow(13, "GUIOPT")
-	if GameCheck.HasTOB() and GemRB.GetVar("oldgame")==1:
+	if GameCheck.HasTOB() and GemRB.GetVar("oldgame") == 1:
 		OptionsWindow.SetBackground("STARTOLD")
 	Label = OptionsWindow.CreateLabel(0x0fff0000, 0,450,640,30, "REALMS", "", IE_FONT_SINGLE_LINE | IE_FONT_ALIGN_CENTER)
 	Label.SetText (GemRB.Version)

--- a/gemrb/GUIScripts/bg2/StartOpt.py
+++ b/gemrb/GUIScripts/bg2/StartOpt.py
@@ -18,12 +18,17 @@
 #
 import GemRB
 import GUIOPT
+import GameCheck
 
 OptionsWindow = 0
 
 def OnLoad():
 	global OptionsWindow
 	OptionsWindow = GemRB.LoadWindow(13, "GUIOPT")
+	if GameCheck.HasTOB() and GemRB.GetVar("oldgame")==1:
+		OptionsWindow.SetBackground("STARTOLD")
+	Label = OptionsWindow.CreateLabel(0x0fff0000, 0,450,640,30, "REALMS", "", IE_FONT_SINGLE_LINE | IE_FONT_ALIGN_CENTER)
+	Label.SetText (GemRB.Version)
 	SoundButton = OptionsWindow.GetControl(8)
 	GameButton = OptionsWindow.GetControl(9)
 	GraphicButton = OptionsWindow.GetControl(7)


### PR DESCRIPTION
## Description
Fix SoA logo flipping to ToB on Options screen, ref #2003.

By the power of ctrl-c/ctrl-v:
![Captura desde 2024-02-22 19-59-08](https://github.com/gemrb/gemrb/assets/1279852/db5aead3-b5f1-42db-ba3d-8babb03a6fde)


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
