### PR TITLE
Fix tooltips max setting on game restart, ref #2010.

### DIFF
--- a/gemrb/GUIScripts/GUIOPT.py
+++ b/gemrb/GUIScripts/GUIOPT.py
@@ -300,11 +300,7 @@ def OpenGameplayOptionsWindow ():
 
 def DisplayHelpTooltipDelay ():
 	GemRB.GetView ("OPTHELP").SetText (18017)
-	delay_var = GemRB.GetVar ("Tooltips")
-	# BG2 disables tooltips on max setting, we just set it to an extremely high value for simplicity
-	if delay_var == 100:
-		delay_var = 10000000
-	GemRB.SetTooltipDelay (delay_var * TOOLTIP_DELAY_FACTOR//10)
+	GemRB.SetTooltipDelay (GemRB.GetVar ("Tooltips") * TOOLTIP_DELAY_FACTOR//10)
 
 def DisplayHelpMouseScrollingSpeed ():
 	GemRB.GetView ("OPTHELP").SetText (18018)

--- a/gemrb/core/GUI/WindowManager.cpp
+++ b/gemrb/core/GUI/WindowManager.cpp
@@ -22,7 +22,6 @@
 #include "GameData.h"
 #include "Interface.h"
 #include "ImageMgr.h"
-#include "Tooltip.h"
 #include "Window.h"
 #include "GUI/GameControl.h"
 #include "GUI/GUIFactory.h"
@@ -43,7 +42,8 @@ Holder<Sprite2D> WindowManager::CursorMouseDown;
 void WindowManager::SetTooltipDelay(int delay)
 {
 	// Max setting disables tooltips in originals, we just set it to an extremely high value for simplicity.
-	ToolTipDelay = (delay == 10 * Tooltip::DELAY_FACTOR) ? 1e7 : delay;
+	// Tooltip::DELAY_FACTOR = 250; 250 * 10 = 2500.
+	ToolTipDelay = delay == 2500 ? 1e7 : delay;
 }
 
 WindowManager::WindowManager(PluginHolder<Video> vid, std::shared_ptr<GUIFactory> fact)

--- a/gemrb/core/GUI/WindowManager.cpp
+++ b/gemrb/core/GUI/WindowManager.cpp
@@ -22,6 +22,7 @@
 #include "GameData.h"
 #include "Interface.h"
 #include "ImageMgr.h"
+#include "Tooltip.h"
 #include "Window.h"
 #include "GUI/GameControl.h"
 #include "GUI/GUIFactory.h"
@@ -42,8 +43,7 @@ Holder<Sprite2D> WindowManager::CursorMouseDown;
 void WindowManager::SetTooltipDelay(int delay)
 {
 	// Max setting disables tooltips in originals, we just set it to an extremely high value for simplicity.
-	// Tooltip::DELAY_FACTOR = 250; 250 * 10 = 2500.
-	ToolTipDelay = delay == 2500 ? 1e7 : delay;
+	ToolTipDelay = (delay == 10 * Tooltip::DELAY_FACTOR) ? 10000000 : delay;
 }
 
 WindowManager::WindowManager(PluginHolder<Video> vid, std::shared_ptr<GUIFactory> fact)

--- a/gemrb/core/GUI/WindowManager.cpp
+++ b/gemrb/core/GUI/WindowManager.cpp
@@ -22,6 +22,7 @@
 #include "GameData.h"
 #include "Interface.h"
 #include "ImageMgr.h"
+#include "Tooltip.h"
 #include "Window.h"
 #include "GUI/GameControl.h"
 #include "GUI/GUIFactory.h"
@@ -41,7 +42,8 @@ Holder<Sprite2D> WindowManager::CursorMouseDown;
 
 void WindowManager::SetTooltipDelay(int delay)
 {
-	ToolTipDelay = delay;
+	// Max setting disables tooltips in originals, we just set it to an extremely high value for simplicity.
+	ToolTipDelay = (delay == 10 * Tooltip::DELAY_FACTOR) ? 1e7 : delay;
 }
 
 WindowManager::WindowManager(PluginHolder<Video> vid, std::shared_ptr<GUIFactory> fact)


### PR DESCRIPTION
## Description

GUIopt.py increase only applies if you played around in Options windows.
With cold start, delay setting would pass directly to WindowManager and never get the multiplier.
This moves the final multiplier into WindowManager so it would apply on game start as well.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
