### PR TITLE
Disable MultiPlayer button in BG2, cleanup related GUI code. Ref #2017.

### DIFF
--- a/gemrb/GUIScripts/bg2/Start2.py
+++ b/gemrb/GUIScripts/bg2/Start2.py
@@ -44,11 +44,11 @@ def OnLoad():
 	SinglePlayerButton.SetState (IE_GUI_BUTTON_ENABLED)
 	ExitButton.SetState (IE_GUI_BUTTON_ENABLED)
 	OptionsButton.SetState (IE_GUI_BUTTON_ENABLED)
+
+	MultiPlayerButton.SetState (IE_GUI_BUTTON_DISABLED)
 	if GameCheck.IsBG2Demo():
-		MultiPlayerButton.SetState (IE_GUI_BUTTON_DISABLED)
 		MoviesButton.SetState (IE_GUI_BUTTON_DISABLED)
 	else:
-		MultiPlayerButton.SetState (IE_GUI_BUTTON_ENABLED)
 		MultiPlayerButton.SetText (15414)
 		MultiPlayerButton.OnPress (MultiPlayerPress)
 
@@ -103,31 +103,6 @@ def SinglePlayerPress():
 	return
 
 def MultiPlayerPress():
-
-	OptionsButton.SetText ("")
-	SinglePlayerButton.SetText (20642)
-	ExitButton.SetText (15416)
-	MultiPlayerButton.SetText ("")
-	MoviesButton.SetText (11825)
-	MultiPlayerButton.OnPress (None)
-	SinglePlayerButton.OnPress (ConnectPress)
-	MoviesButton.OnPress (PregenPress)
-	ExitButton.OnPress (Restart)
-	MultiPlayerButton.SetState (IE_GUI_BUTTON_DISABLED)
-	OptionsButton.SetState (IE_GUI_BUTTON_DISABLED)
-	return
-
-def ConnectPress():
-#well...
-	#GemRB.SetVar("PlayMode",2)
-	return
-
-def PregenPress():
-	#do not start game after chargen
-	GemRB.SetVar("PlayMode",-1) #will allow export
-	GemRB.SetVar("Slot",1)
-	GemRB.LoadGame(None)
-	GemRB.SetNextScript ("CharGen")
 	return
 
 def LoadSingle():


### PR DESCRIPTION
## Description
Conservatively disabled MultiPlayer button, #2017.


![Captura desde 2024-02-24 19-40-12](https://github.com/gemrb/gemrb/assets/1279852/996eb80f-a78f-446c-94d7-deb568dd9d26)
![Captura desde 2024-02-24 19-40-20](https://github.com/gemrb/gemrb/assets/1279852/8b4525cb-c493-44e3-80ef-6ed18ae361c4)
![Captura desde 2024-02-24 19-40-26](https://github.com/gemrb/gemrb/assets/1279852/ee472647-b65b-4b21-b858-41820c536f00)

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
