### PR TITLE
Fix missing intro text, ref #2009

### DIFF
--- a/gemrb/core/GameScript/Actions.cpp
+++ b/gemrb/core/GameScript/Actions.cpp
@@ -1728,8 +1728,9 @@ void GameScript::DisplayString(Scriptable* Sender, Action* parameters)
 
 	int flags = DS_CONSOLE;
 
-	if (Sender->Type != ST_ACTOR)
+	if (Sender->Type != ST_ACTOR) {
 		flags |= DS_AREA;
+	}
 
 	DisplayStringCore(target, ieStrRef(parameters->int0Parameter), flags);
 }

--- a/gemrb/core/GameScript/Actions.cpp
+++ b/gemrb/core/GameScript/Actions.cpp
@@ -1725,11 +1725,13 @@ void GameScript::DisplayString(Scriptable* Sender, Action* parameters)
 	if (!target) {
 		target=Sender;
 	}
-	if (Sender->Type==ST_ACTOR) {
-		DisplayStringCore(target, ieStrRef(parameters->int0Parameter), DS_CONSOLE);
-	} else {
-		DisplayStringCore(target, ieStrRef(parameters->int0Parameter), DS_AREA);
-	}
+
+	int flags = DS_CONSOLE;
+
+	if (Sender->Type != ST_ACTOR)
+		flags |= DS_AREA;
+
+	DisplayStringCore(target, ieStrRef(parameters->int0Parameter), flags);
 }
 
 //DisplayStringHead, but wait until done

--- a/gemrb/core/GameScript/GSUtils.cpp
+++ b/gemrb/core/GameScript/GSUtils.cpp
@@ -475,7 +475,9 @@ void DisplayStringCore(Scriptable* const Sender, ieStrRef Strref, int flags, con
 	// PST does not echo verbal constants in the console, their strings
 	// actually contain development related identifying comments
 	// thus the console flag is unset.
-	if (core->HasFeature(GFFlags::ONSCREEN_TEXT) || !charactersubtitles) {
+	// The console flag is also unset when we get a string from an ACTOR without
+	// subtitles enabled, but e.g. AREA strings should still be displayed.
+	if (core->HasFeature(GFFlags::ONSCREEN_TEXT) || (Sender->Type == ST_ACTOR && !charactersubtitles)) {
 		flags &= ~DS_CONSOLE;
 	}
 


### PR DESCRIPTION
In accordance to similar actions, DisplayString should also emit the DS_CONSOLE flag when not called by an ACTOR.
DisplayStringCore then should not cancel the DS_CONSOLE flag again when not called by an ACTOR.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
