### PR TITLE
Add flag to only highlight outline of doors and containers, ref #2011

### DIFF
--- a/demo/override/gemrb.ini
+++ b/demo/override/gemrb.ini
@@ -138,3 +138,4 @@ StrrefSaveGame = 0
 TeamMovement = 0
 UpperButtonText = 1
 DamageInnocentRep = 1
+HighlightOutlineOnly = 0

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -1376,7 +1376,8 @@ static const EnumArray<GFFlags, StringView> game_flags {
 	"LayeredWaterTiles", // GFFlags::LAYERED_WATER_TILES
 	"ClearingActionOverride", // GFFlags::CLEARING_ACTIONOVERRIDE
 	"DamageInnocentRep", // GFFlags::DAMAGE_INNOCENT_REP
-	"HasWeaponSets" // GFFlags::GF_HAS_WEAPON_SETS
+	"HasWeaponSets", // GFFlags::GF_HAS_WEAPON_SETS
+	"HighlightOutlineOnly", // GFFlags::HIGHLIGHT_OUTLINE_ONLY
 };
 
 /** Loads gemrb.ini */

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -1727,11 +1727,17 @@ void Highlightable::DrawOutline(Point origin) const
 	}
 	origin = outline->BBox.origin - origin;
 
-	if (core->HasFeature(GFFlags::PST_STATE_FLAGS)) {
-		VideoDriver->DrawPolygon(outline.get(), origin, outlineColor, true, BlitFlags::MOD | BlitFlags::HALFTRANS);
-	} else {
-		VideoDriver->DrawPolygon( outline.get(), origin, outlineColor, true, BlitFlags::BLENDED|BlitFlags::HALFTRANS );
-		VideoDriver->DrawPolygon( outline.get(), origin, outlineColor, false );
+	bool highlightOutlineOnly = core->HasFeature(GFFlags::HIGHLIGHT_OUTLINE_ONLY);
+	bool pstStateFlags = core->HasFeature(GFFlags::PST_STATE_FLAGS);
+
+	if (!highlightOutlineOnly) {
+		BlitFlags flag = BlitFlags::HALFTRANS | (pstStateFlags ? BlitFlags::MOD : BlitFlags::BLENDED);
+
+		VideoDriver->DrawPolygon(outline.get(), origin, outlineColor, true, flag);
+	}
+
+	if (highlightOutlineOnly || !pstStateFlags) {
+		VideoDriver->DrawPolygon(outline.get(), origin, outlineColor, false);
 	}
 }
 

--- a/gemrb/docs/en/gemrb_ini.txt
+++ b/gemrb/docs/en/gemrb_ini.txt
@@ -373,6 +373,13 @@ HasWeaponSets = <bool>
 Does the game support several weapon sets, shield slots like iwd2?
 
 
+HighlightOutlineOnly = <bool>
+- - - - - - - - - - - - - - -
+Toggles whether the game highlights only the outline of doors and containers
+(HighlightOutlineOnly=1, in BG1), or highlights the complete surface of the
+object (HighlightOutlineOnly=0, all except BG1).
+
+
 IgnoreButtonFrames = <bool>
 - - - - - - - - - - - - - -
 If set to 1, buttons will ignore frame numbers as set in button CHU

--- a/gemrb/includes/globals.h
+++ b/gemrb/includes/globals.h
@@ -135,6 +135,7 @@ enum class GFFlags : uint32_t {
 	CLEARING_ACTIONOVERRIDE,         // bg2, not iwd2
 	DAMAGE_INNOCENT_REP,             // not bg1
 	HAS_WEAPON_SETS,             	// iwd2
+	HIGHLIGHT_OUTLINE_ONLY,         // all
 
 	count // must be last
 };

--- a/gemrb/tests/minimal/data/gemrb.ini
+++ b/gemrb/tests/minimal/data/gemrb.ini
@@ -85,3 +85,4 @@ SelectiveMagicRes = 1
 HasHideInShadows = 1
 ProperBackstab = 1
 HasSpecificDamageBonus = 0
+HighlightOutlineOnly = 0

--- a/gemrb/unhardcoded/bg1/gemrb.ini
+++ b/gemrb/unhardcoded/bg1/gemrb.ini
@@ -153,3 +153,4 @@ TeamMovement = 0
 UpperButtonText = 0
 ZeroTimerIsValid = 0
 DamageInnocentRep = 0
+HighlightOutlineOnly = 1

--- a/gemrb/unhardcoded/bg2/gemrb.ini
+++ b/gemrb/unhardcoded/bg2/gemrb.ini
@@ -154,3 +154,4 @@ TeamMovement = 0
 UpperButtonText = 1
 ZeroTimerIsValid = 0
 DamageInnocentRep = 1
+HighlightOutlineOnly = 0

--- a/gemrb/unhardcoded/bg2ee/gemrb.ini
+++ b/gemrb/unhardcoded/bg2ee/gemrb.ini
@@ -154,3 +154,4 @@ TeamMovement = 0
 UpperButtonText = 1
 ZeroTimerIsValid = 0
 DamageInnocentRep = 1
+HighlightOutlineOnly = 0

--- a/gemrb/unhardcoded/how/gemrb.ini
+++ b/gemrb/unhardcoded/how/gemrb.ini
@@ -152,3 +152,4 @@ StrrefSaveGame = 0
 TeamMovement = 0
 UpperButtonText = 0
 ZeroTimerIsValid = 1
+HighlightOutlineOnly = 0

--- a/gemrb/unhardcoded/iwd/gemrb.ini
+++ b/gemrb/unhardcoded/iwd/gemrb.ini
@@ -153,3 +153,4 @@ TeamMovement = 0
 UpperButtonText = 0
 ZeroTimerIsValid = 1
 DamageInnocentRep = 1
+HighlightOutlineOnly = 0

--- a/gemrb/unhardcoded/iwd2/gemrb.ini
+++ b/gemrb/unhardcoded/iwd2/gemrb.ini
@@ -154,3 +154,4 @@ TeamMovement = 0
 UpperButtonText = 0
 ZeroTimerIsValid = 1
 DamageInnocentRep = 1
+HighlightOutlineOnly = 0

--- a/gemrb/unhardcoded/pst/gemrb.ini
+++ b/gemrb/unhardcoded/pst/gemrb.ini
@@ -151,3 +151,4 @@ TeamMovement = 1
 UpperButtonText = 0
 ZeroTimerIsValid = 0
 DamageInnocentRep = 1
+HighlightOutlineOnly = 0


### PR DESCRIPTION
## Description

Add the 'HighlightOutlineOnly'-flag, which toggles whether the game highlights only the outline of doors and containers (like in BG1), or highlights the complete surface of the object (all except BG1). In accordance with the original games, this flag is enabled for BG1 and disabled for the other games by default.

HighlightOutlineOnly=0
![outline0](https://github.com/gemrb/gemrb/assets/155195419/e47bd2ae-c9de-4617-99cb-8833a0a2da48)

HighlightOutlineOnly=1
![outline1](https://github.com/gemrb/gemrb/assets/155195419/af9425aa-89a0-4748-910a-87edc750a6e5)

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
