### PR TITLE
Fix predicate EndsWithFilter, ref #2007

### DIFF
--- a/gemrb/core/System/FileFilters.h
+++ b/gemrb/core/System/FileFilters.h
@@ -63,7 +63,7 @@ struct EndsWithFilter : Predicate<path_t> {
 			return false;
 		}
 
-		return stricmp(endMatch.data(), &fname[fpos]) == 0;
+		return strnicmp(endMatch.data(), &fname[fpos], endMatch.length()) == 0;
 	}
 };
 


### PR DESCRIPTION
## Description

Replace stricmp with strnicmp in order to compare only as much characters as the predicate string has. Otherwise the predicate may be never fulfilled.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
