### PR TITLE
Make TLKImporter more resilient, ref. #2005

### DIFF
--- a/gemrb/plugins/TLKImporter/TLKImporter.cpp
+++ b/gemrb/plugins/TLKImporter/TLKImporter.cpp
@@ -360,7 +360,9 @@ String TLKImporter::GetString(ieStrRef strref, STRING_FLAGS flags)
 		str->ReadDword(l);
 				
 		if (type & 1) {
-			str->Seek( StrOffset + Offset, GEM_STREAM_START );
+			if (str->Seek(StrOffset + Offset, GEM_STREAM_START) == GEM_ERROR) {
+				return u"";
+			}
 			std::string mbstr(l, '\0');
 			str->Read(&mbstr[0], l);
 			string = StringFromTLK(mbstr);
@@ -397,7 +399,9 @@ StringBlock TLKImporter::GetStringBlock(ieStrRef strref, STRING_FLAGS flags)
 		return StringBlock();
 	}
 	ieWord type;
-	str->Seek( 18 + (ieDword(strref) * 0x1A), GEM_STREAM_START );
+	if (str->Seek(18 + (ieDword(strref) * 0x1A), GEM_STREAM_START) == GEM_ERROR) {
+		return StringBlock();
+	}
 	str->ReadWord(type);
 	ResRef soundRef;
 	str->ReadResRef( soundRef );


### PR DESCRIPTION
## Description

Do not process invalid seek results. These are garbage anyway and can slow down the subsequent processing considerably.

This affects mostly mods, e.g. Baldurdash's GameTextUpdate for BG1.

#2005

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
