### PR TITLE
BG1: fix main menu buttons, #2005

### DIFF
--- a/gemrb/GUIScripts/bg1/Start.py
+++ b/gemrb/GUIScripts/bg1/Start.py
@@ -62,7 +62,7 @@ def SinglePlayerPress():
 		MoviesButton.OnPress (MissionPack)
 		MoviesButton.SetText(24110)
 	else:
-		MoviesButton.SetFlags(IE_GUI_BUTTON_NO_IMAGE, OP_OR)
+		MoviesButton.SetFlags(IE_GUI_BUTTON_NO_IMAGE | IE_GUI_BUTTON_NO_TEXT, OP_SET)
 		MoviesButton.SetStatus(IE_GUI_BUTTON_DISABLED)
 
 	return
@@ -72,14 +72,13 @@ def MultiPlayerPress():
 	SinglePlayerButton.SetText(11825)
 	MultiPlayerButton.SetText(20642)
 	MoviesButton.SetText(15416)
-	ExitButton.SetText("")
 	SinglePlayerButton.OnPress (PregenPress)
 	MultiPlayerButton.OnPress (ConnectPress)
 	MoviesButton.OnPress (BackToMain)
 	MoviesButton.MakeEscape()
 	ExitButton.OnPress (None)
 	ExitButton.SetStatus(IE_GUI_BUTTON_DISABLED)
-	ExitButton.SetFlags(IE_GUI_BUTTON_NO_IMAGE, OP_SET)
+	ExitButton.SetFlags(IE_GUI_BUTTON_NO_IMAGE | IE_GUI_BUTTON_NO_TEXT, OP_SET)
 	return
 
 def ConnectPress():
@@ -153,8 +152,8 @@ def BackToMain():
 	MultiPlayerButton.OnPress (MultiPlayerPress)
 	MoviesButton.OnPress (MoviesPress)
 	ExitButton.OnPress (ExitPress)
-	MoviesButton.SetFlags(IE_GUI_BUTTON_NO_IMAGE, OP_NAND)
-	ExitButton.SetFlags(IE_GUI_BUTTON_NO_IMAGE, OP_NAND)
+	MoviesButton.SetFlags(IE_GUI_BUTTON_NORMAL, OP_SET)
+	ExitButton.SetFlags(IE_GUI_BUTTON_NORMAL, OP_SET)
 	ExitButton.MakeEscape()
 
 	return


### PR DESCRIPTION
## Description

Add IE_GUI_BUTTON_NO_TEXT to the MoviesButton in the single player menu when playing without TotSc expansion, otherwise the menu would show a disabled and borderless button with text "Movies".

Apply it also to the ExitButton in the multi player menu in order to avoid using SetText("").

Also reset the Movies- and ExitButton flags to IE_GUI_BUTTON_NORMAL in BackToMain, otherwise these buttons loose their soundeffect when clicking on them. The ExitButton actually already lost its soundeffect before when going into the multi player menu.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
