### PR TITLE
Fix textscreen not playing chapter music

### DIFF
--- a/gemrb/GUIScripts/TextScreen.py
+++ b/gemrb/GUIScripts/TextScreen.py
@@ -99,10 +99,12 @@ def StartTextScreen ():
 		ID = GemRB.GetGameVar("CHAPTER") & 0x7fffffff
 		Chapter = ID + 1
 
+	# Textscreen should always stop currently playing music before starting
+	# to play any chapter music.
+	GemRB.HardEndPL ()
+
 	if MusicName != "*":
 		GemRB.LoadMusicPL (MusicName + ".mus")
-	else:
-		GemRB.HardEndPL ()
 
 	TextScreen = GemRB.LoadWindow (ID, "GUICHAP")
 	TextArea = TextScreen.GetControl (2)


### PR DESCRIPTION
## Description

Use HardEndPL in order to stop the currently playing music when entering the chapter introductions. This allows the actual chapter music to play.


This doesn't fix the underlying issues with music not playing or stopping properly (e.g. #2008), it merely covers up the symptoms in this special case. But I think that using HardEndPL in this case is actual the right thing to do regardless, especially when it's called already if `MusicName == "*"` (e.g. demo) and the experience with the original games is the same.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
