### PR TITLE
BG1/BG2: fix reputation when importing predefined character templates

### DIFF
--- a/gemrb/GUIScripts/BGCommon.py
+++ b/gemrb/GUIScripts/BGCommon.py
@@ -20,7 +20,7 @@
 import GemRB
 import CommonTables
 import GUICommon
-from ie_stats import IE_RACE, IE_SEX
+from ie_stats import IE_ALIGNMENT, IE_RACE, IE_REPUTATION, IE_SEX
 
 def RefreshPDoll(button, MinorColor, MajorColor, SkinColor, HairColor):
 	MyChar = GemRB.GetVar ("Slot")
@@ -38,3 +38,22 @@ def RefreshPDoll(button, MinorColor, MajorColor, SkinColor, HairColor):
 
 	button.SetPLT (ResRef, 0, MinorColor, MajorColor, SkinColor, 0, 0, HairColor, 0)
 	return
+
+def SetReputation ():
+	MyChar = GemRB.GetVar ("Slot")
+
+	# If Rep > 0 then MyChar is an imported character with a saved reputation,
+	# in which case the reputation shouldn't be overwritten.
+	Rep = GemRB.GetPlayerStat (MyChar, IE_REPUTATION)
+
+	if Rep <= 0:
+		# use the alignment to apply starting reputation
+		Alignment = GemRB.GetPlayerStat (MyChar, IE_ALIGNMENT)
+		AlignmentAbbrev = CommonTables.Aligns.FindValue (3, Alignment)
+		RepTable = GemRB.LoadTable ("repstart")
+		Rep = RepTable.GetValue (AlignmentAbbrev, 0) * 10
+		GemRB.SetPlayerStat (MyChar, IE_REPUTATION, Rep)
+
+	# set the party rep if this is the main char
+	if MyChar == 1:
+		GemRB.GameSetReputation (Rep)

--- a/gemrb/GUIScripts/bg1/CharGenGui.py
+++ b/gemrb/GUIScripts/bg1/CharGenGui.py
@@ -1,3 +1,4 @@
+import BGCommon
 import GemRB
 from GUIDefines import *
 from ie_stats import *
@@ -314,19 +315,7 @@ def setAccept():
 	MyChar = GemRB.GetVar ("Slot")
 
 	#reputation
-	# If Rep > 0 then MyChar is an imported character with a saved reputation,
-	# in which case the reputation shouldn't be overwritten.
-	Rep = GemRB.GetPlayerStat (MyChar, IE_REPUTATION)
-
-	if Rep <= 0:
-		RepTable = GemRB.LoadTable ("repstart")
-		Alignment = GemRB.GetVar ("Alignment")
-		AlignmentAbbrev = CommonTables.Aligns.FindValue (3, Alignment)
-		Rep = RepTable.GetValue (AlignmentAbbrev, 0) * 10
-		GemRB.SetPlayerStat (MyChar, IE_REPUTATION, Rep)
-
-	if MyChar == 1: # only do it once
-		GemRB.GameSetReputation (Rep)
+	BGCommon.SetReputation ()
 
 	# don't reset most stats of imported chars
 	if GemRB.GetVar ("ImportedChar"):

--- a/gemrb/GUIScripts/bg1/CharGenGui.py
+++ b/gemrb/GUIScripts/bg1/CharGenGui.py
@@ -320,7 +320,7 @@ def setAccept():
 
 	if Rep <= 0:
 		AlignID = GemRB.GetPlayerStat (MyChar, IE_ALIGNMENT)
-		TmpTable=GemRB.LoadTable ("repstart")
+		TmpTable = GemRB.LoadTable ("repstart")
 		Rep = TmpTable.GetValue (AlignID, 0) * 10
 		GemRB.SetPlayerStat (MyChar, IE_REPUTATION, Rep)
 

--- a/gemrb/GUIScripts/bg1/CharGenGui.py
+++ b/gemrb/GUIScripts/bg1/CharGenGui.py
@@ -313,6 +313,20 @@ def setAccept():
 	#set my character up
 	MyChar = GemRB.GetVar ("Slot")
 
+	#reputation
+	# If Rep > 0 then MyChar is an imported character with a saved reputation,
+	# in which case the reputation shouldn't be overwritten.
+	Rep = GemRB.GetPlayerStat (MyChar, IE_REPUTATION)
+
+	if Rep <= 0:
+		AlignID = GemRB.GetPlayerStat (MyChar, IE_ALIGNMENT)
+		TmpTable=GemRB.LoadTable ("repstart")
+		Rep = TmpTable.GetValue (AlignID, 0) * 10
+		GemRB.SetPlayerStat (MyChar, IE_REPUTATION, Rep)
+
+	if MyChar == 1: # only do it once
+		GemRB.GameSetReputation (Rep)
+
 	# don't reset most stats of imported chars
 	if GemRB.GetVar ("ImportedChar"):
 		CustomizeChar (MyChar)
@@ -320,14 +334,6 @@ def setAccept():
 		return
 
 	ClassName = GUICommon.GetClassRowName (MyChar)
-	
-	#reputation
-	AlignID = GemRB.GetPlayerStat (MyChar, IE_ALIGNMENT)
-	TmpTable=GemRB.LoadTable ("repstart")
-	t = TmpTable.GetValue (AlignID, 0) * 10
-	GemRB.SetPlayerStat (MyChar, IE_REPUTATION, t)
-	if MyChar == 1: # only do it once
-		GemRB.GameSetReputation( t )
 
 	#lore, thac0, hp, and saves
 	GemRB.SetPlayerStat (MyChar, IE_MAXHITPOINTS, 0)

--- a/gemrb/GUIScripts/bg1/CharGenGui.py
+++ b/gemrb/GUIScripts/bg1/CharGenGui.py
@@ -319,9 +319,10 @@ def setAccept():
 	Rep = GemRB.GetPlayerStat (MyChar, IE_REPUTATION)
 
 	if Rep <= 0:
-		AlignID = GemRB.GetPlayerStat (MyChar, IE_ALIGNMENT)
-		TmpTable = GemRB.LoadTable ("repstart")
-		Rep = TmpTable.GetValue (AlignID, 0) * 10
+		RepTable = GemRB.LoadTable ("repstart")
+		Alignment = GemRB.GetVar ("Alignment")
+		AlignmentAbbrev = CommonTables.Aligns.FindValue (3, Alignment)
+		Rep = RepTable.GetValue (AlignmentAbbrev, 0) * 10
 		GemRB.SetPlayerStat (MyChar, IE_REPUTATION, Rep)
 
 	if MyChar == 1: # only do it once

--- a/gemrb/GUIScripts/bg2/CharGenEnd.py
+++ b/gemrb/GUIScripts/bg2/CharGenEnd.py
@@ -32,6 +32,22 @@ def OnLoad():
 	# set my character up
 	MyChar = GemRB.GetVar ("Slot")
 
+	#reputation
+	# If Rep > 0 then MyChar is an imported character with a saved reputation,
+	# in which case the reputation shouldn't be overwritten.
+	Rep = GemRB.GetPlayerStat (MyChar, IE_REPUTATION)
+
+	if Rep <= 0:
+		# use the alignment to apply starting reputation
+		RepTable = GemRB.LoadTable ("repstart")
+		AlignmentAbbrev = CommonTables.Aligns.FindValue (3, Alignment)
+		Rep = RepTable.GetValue (AlignmentAbbrev, 0) * 10
+		GemRB.SetPlayerStat (MyChar, IE_REPUTATION, Rep)
+
+	# set the party rep if this in the main char
+	if MyChar == 1:
+		GemRB.GameSetReputation (Rep)
+
 	# don't reset most stats of imported chars
 	if GemRB.GetVar ("ImportedChar"):
 		CustomizeChar (MyChar)

--- a/gemrb/GUIScripts/bg2/CharGenEnd.py
+++ b/gemrb/GUIScripts/bg2/CharGenEnd.py
@@ -16,6 +16,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # character generation end
+import BGCommon
 import GemRB
 import GameCheck
 import GUICommon
@@ -33,21 +34,7 @@ def OnLoad():
 	MyChar = GemRB.GetVar ("Slot")
 
 	#reputation
-	# If Rep > 0 then MyChar is an imported character with a saved reputation,
-	# in which case the reputation shouldn't be overwritten.
-	Rep = GemRB.GetPlayerStat (MyChar, IE_REPUTATION)
-
-	if Rep <= 0:
-		# use the alignment to apply starting reputation
-		RepTable = GemRB.LoadTable ("repstart")
-		Alignment = GemRB.GetVar ("Alignment")
-		AlignmentAbbrev = CommonTables.Aligns.FindValue (3, Alignment)
-		Rep = RepTable.GetValue (AlignmentAbbrev, 0) * 10
-		GemRB.SetPlayerStat (MyChar, IE_REPUTATION, Rep)
-
-	# set the party rep if this in the main char
-	if MyChar == 1:
-		GemRB.GameSetReputation (Rep)
+	BGCommon.SetReputation ()
 
 	# don't reset most stats of imported chars
 	if GemRB.GetVar ("ImportedChar"):

--- a/gemrb/GUIScripts/bg2/CharGenEnd.py
+++ b/gemrb/GUIScripts/bg2/CharGenEnd.py
@@ -40,6 +40,7 @@ def OnLoad():
 	if Rep <= 0:
 		# use the alignment to apply starting reputation
 		RepTable = GemRB.LoadTable ("repstart")
+		Alignment = GemRB.GetVar ("Alignment")
 		AlignmentAbbrev = CommonTables.Aligns.FindValue (3, Alignment)
 		Rep = RepTable.GetValue (AlignmentAbbrev, 0) * 10
 		GemRB.SetPlayerStat (MyChar, IE_REPUTATION, Rep)

--- a/gemrb/GUIScripts/bg2/GUICG3.py
+++ b/gemrb/GUIScripts/bg2/GUICG3.py
@@ -93,20 +93,8 @@ def NextPress():
 		AlignmentWindow.Close ()
 	# save previous stats:
 	#       alignment
-	#       reputation
-	#       alignment abilities
 	Alignment = GemRB.GetVar ("Alignment")
 	GemRB.SetPlayerStat (MyChar, IE_ALIGNMENT, Alignment)
-
-	# use the alignment to apply starting reputation
-	RepTable = GemRB.LoadTable ("repstart")
-	AlignmentAbbrev = CommonTables.Aligns.FindValue (3, Alignment)
-	Rep = RepTable.GetValue (AlignmentAbbrev, 0) * 10
-	GemRB.SetPlayerStat (MyChar, IE_REPUTATION, Rep)
-
-	# set the party rep if this in the main char
-	if MyChar == 1:
-		GemRB.GameSetReputation (Rep)
 
 	GemRB.SetNextScript("CharGen5") #appearance
 	return


### PR DESCRIPTION
## Description

Put calculation of reputation before running the game when importing a character. Otherwise imported characters without a preset reputation (i.e. the predefined character templates cleric, fighter, mage, etc.) have reputation 0.

![imp0](https://github.com/gemrb/gemrb/assets/155195419/97eeaab3-3ab2-453a-8a96-4453e12b66d5)
![imp1](https://github.com/gemrb/gemrb/assets/155195419/ca620b9b-f00e-4e67-ad04-ae1f2361c1c0)

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
