### PR TITLE
Projectiles: decoupling state from drawing

### DIFF
--- a/gemrb/core/GlobalTimer.cpp
+++ b/gemrb/core/GlobalTimer.cpp
@@ -161,6 +161,8 @@ bool GlobalTimer::Update()
 	if (!gc->InDialog() || !(gc->GetDialogueFlags() & DF_FREEZE_SCRIPTS)) {
 		map->UpdateFog();
 		map->UpdateEffects();
+		map->UpdateProjectiles();
+
 		if (thisTime) {
 			//this measures in-world time (affected by effects, actions, etc)
 			game->AdvanceTime(1);

--- a/gemrb/core/Map.h
+++ b/gemrb/core/Map.h
@@ -444,6 +444,7 @@ public:
 	ResRef ResolveTerrainSound(const ResRef &sound, const Point &pos) const;
 	void DoStepForActor(Actor *actor, ieDword time) const;
 	void UpdateEffects();
+	void UpdateProjectiles();
 	/* removes empty heaps and returns total itemcount */
 	int ConsolidateContainers();
 	/* transfers all ever visible piles (loose items) to the specified position */


### PR DESCRIPTION
## Description
See #2037. It's rewritten to the extent that _most_ of the state transition are now left in `::Update()`, with some expiry requests left.

Feel free to test, I checked arrows and a bunch of spells.


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
