### PR TITLE
Fix segfault on shutdown

### DIFF
--- a/gemrb/GemRB.cpp
+++ b/gemrb/GemRB.cpp
@@ -70,6 +70,7 @@ int main(int argc, char* argv[])
 		return GEM_ERROR;
 	}
 
+	VideoDriver.reset();
 	PluginMgr::Get()->RunCleanup();
 
 	return GEM_OK;

--- a/gemrb/plugins/SDLAudio/SDLAudio.cpp
+++ b/gemrb/plugins/SDLAudio/SDLAudio.cpp
@@ -81,12 +81,14 @@ SDLAudio::~SDLAudio(void)
 	Mix_HookMusic(NULL, NULL);
 	FreeBuffers();
 	Mix_ChannelFinished(NULL);
+
+	SDL_QuitSubSystem(SDL_INIT_AUDIO);
 }
 
 bool SDLAudio::Init(void)
 {
-	// TODO: we assume SDLVideo already got loaded
 	if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0) {
+		Log(ERROR, "SDLAudio", "InitSubSystem failed: {}", SDL_GetError());
 		return false;
 	}
 #ifdef RPI

--- a/gemrb/plugins/SDLVideo/SDL12Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL12Video.cpp
@@ -55,13 +55,6 @@ int SDL12VideoDriver::Init(void)
 		// this may limit people actually using very old single button mice, but who cares :)
 		setenv("SDL_HAS3BUTTONMOUSE", "SDL_HAS3BUTTONMOUSE", 1);
 #endif
-		if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) == -1) {
-			Log(ERROR, "SDLJoystick", "InitSubSystem failed: {}", SDL_GetError());
-		} else {
-			if (SDL_NumJoysticks() > 0) {
-				gameController = SDL_JoystickOpen(0);
-			}
-		}
 	}
 
 	if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) == -1) {

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -82,6 +82,10 @@ SDL20VideoDriver::SDL20VideoDriver() noexcept
 
 SDL20VideoDriver::~SDL20VideoDriver() noexcept
 {
+#if USE_OPENGL_BACKEND
+	delete blitRGBAShader;
+#endif
+
 	if (SDL_GameControllerGetAttached(gameController)) {
 		SDL_GameControllerClose(gameController);
 	}
@@ -93,10 +97,6 @@ SDL20VideoDriver::~SDL20VideoDriver() noexcept
 
 	SDL_DestroyRenderer(renderer);
 	SDL_DestroyWindow(window);
-
-#if USE_OPENGL_BACKEND
-	delete blitRGBAShader;
-#endif
 }
 
 int SDL20VideoDriver::Init()

--- a/gemrb/plugins/SDLVideo/SDLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDLVideo.cpp
@@ -28,12 +28,12 @@ using namespace GemRB;
 
 SDLVideoDriver::~SDLVideoDriver(void)
 {
-	SDL_Quit();
+	SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER | SDL_INIT_JOYSTICK | SDL_INIT_VIDEO);
 }
 
 int SDLVideoDriver::Init(void)
 {
-	if (SDL_InitSubSystem( SDL_INIT_VIDEO ) == -1) {
+	if (SDL_InitSubSystem(SDL_INIT_VIDEO) == -1) {
 		Log(ERROR, "SDLVideo", "InitSubSystem failed: {}", SDL_GetError());
 		return GEM_ERROR;
 	}

--- a/platforms/android/GemRB.cpp
+++ b/platforms/android/GemRB.cpp
@@ -81,5 +81,7 @@ int main(int argc, char* argv[])
 		return GEM_ERROR;
 	}
 
+	VideoDriver.reset();
+
 	return GEM_OK;
 }

--- a/platforms/vita/GemRB.cpp
+++ b/platforms/vita/GemRB.cpp
@@ -138,6 +138,8 @@ int main(int argc, char* argv[])
 		SDL_SetVideoModeScaling(vitaDestRect.x, vitaDestRect.y, vitaDestRect.w, vitaDestRect.h);
 	}
 #endif
+	VideoDriver.reset();
+
 	ToggleLogging(false);
 
 	return sceKernelExitProcess(0);

--- a/platforms/windows/GemRB.cpp
+++ b/platforms/windows/GemRB.cpp
@@ -66,6 +66,7 @@ int main(int argc, char* argv[])
 		ret = GEM_ERROR;
 	}
 
+	VideoDriver.reset();
 	PluginMgr::Get()->RunCleanup();
 
 	ToggleLogging(false); // Windows build will hang if we leave the logging thread running


### PR DESCRIPTION
## Description

Ensure destruction of OpenGL and SDL resources before quitting SDL and use
SDL_QuitSubSystem instead of SDL_Quit in case unloading a shared library
still depends on SDL. The subsystems audio, joystick and gamecontroller
are quitted explicitely now.

Ref. #2004

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
