### PR TITLE
Add ScaleQuality option, ref #1973

### DIFF
--- a/gemrb.6.in
+++ b/gemrb.6.in
@@ -147,6 +147,11 @@ Game window height (in pixels).
 Color depth of the game window (in bits per pixel).
 
 .TP
+.BR ScaleQuality =(best|linear|nearest)
+Use the specified quality for the texture scaling filter. The default is
+.IR best .
+
+.TP
 .BR CapFPS =(-1|0|n)
 Set FPS handling:
   -1: no limit

--- a/gemrb/GemRB.cfg.noinstall.sample
+++ b/gemrb/GemRB.cfg.noinstall.sample
@@ -54,6 +54,9 @@ Height=480
 # Bits per pixel [Integer:16,32]
 Bpp=32
 
+# Choices: best (default), linear, nearest
+#ScaleQuality = best
+
 # Cap FPS, 0 = request VSync (SDL2 only, default), -1 = no limit, 30+ = cap value
 #CapFPS=0
 

--- a/gemrb/GemRB.cfg.sample.in
+++ b/gemrb/GemRB.cfg.sample.in
@@ -54,6 +54,9 @@ Height=480
 # Bits per pixel [Integer:16,32]
 Bpp=32
 
+# Choices: best (default), linear, nearest
+#ScaleQuality = best
+
 # Cap FPS, 0 = request VSync (SDL2 only, default), -1 = no limit, 30+ = cap value
 #CapFPS=0
 

--- a/gemrb/core/InterfaceConfig.cpp
+++ b/gemrb/core/InterfaceConfig.cpp
@@ -291,6 +291,7 @@ CoreSettings LoadFromDictionary(InterfaceConfig cfg)
 	CONFIG_STRING("AudioDriver", config.AudioDriverName);
 	CONFIG_STRING("VideoDriver", config.VideoDriverName);
 	CONFIG_STRING("Encoding", config.Encoding);
+	CONFIG_STRING("ScaleQuality", config.ScaleQuality);
 
 	auto value = cfg.Get("ModPath", "");
 	if (value.length()) {

--- a/gemrb/core/InterfaceConfig.h
+++ b/gemrb/core/InterfaceConfig.h
@@ -116,6 +116,7 @@ struct CoreSettings {
 	uint32_t ActionRepeatDelay = 250;
 	int TouchInput = -1;
 	std::string SystemEncoding = "UTF-8";
+	std::string ScaleQuality = "best";
 
 	variables_t vars;
 };

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -125,7 +125,7 @@ int SDL20VideoDriver::Init()
 int SDL20VideoDriver::CreateSDLDisplay(const char* title, bool vsync)
 {
 	Log(MESSAGE, "SDL 2 Driver", "Creating display");
-	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "best");
+	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, core->config.ScaleQuality.c_str());
 
 #if USE_OPENGL_BACKEND
 #if USE_OPENGL_API


### PR DESCRIPTION
## Description

Add an option to specify the SDL_HINT_RENDER_SCALE_QUALITY in GemRB.cfg. The value 'best' is the default.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
