### PR TITLE
BG1: add missing shadows for modal windows in character creation

### DIFF
--- a/gemrb/GUIScripts/GUICG13.py
+++ b/gemrb/GUIScripts/GUICG13.py
@@ -40,9 +40,10 @@ SkinColor = 0
 MinorColor = 0
 MajorColor = 0
 PDollButton = 0
+ModalShadow = MODAL_SHADOW_NONE
 
 def OnLoad():
-	global ColorWindow, DoneButton, PDollButton, ColorTable
+	global ColorWindow, DoneButton, PDollButton, ColorTable, ModalShadow
 	global HairButton, SkinButton, MajorButton, MinorButton
 	global HairColor, SkinColor, MinorColor, MajorColor
 	
@@ -98,7 +99,12 @@ def OnLoad():
 	DoneButton.OnPress (NextPress)
 	BackButton.OnPress (BackPress)
 	BGCommon.RefreshPDoll (PDollButton, MinorColor, MajorColor, SkinColor, HairColor)
-	ColorWindow.ShowModal (MODAL_SHADOW_GRAY)
+
+	if GameCheck.IsBG1 ():
+		ModalShadow = MODAL_SHADOW_GRAY
+
+	ColorWindow.ShowModal (ModalShadow)
+
 	return
 
 def DonePress():
@@ -107,7 +113,7 @@ def DonePress():
 	if ColorPicker:
 		ColorPicker.Close ()
 
-	ColorWindow.ShowModal (MODAL_SHADOW_GRAY)
+	ColorWindow.ShowModal (ModalShadow)
 
 	PickedColor = ColorTable.GetValue(ColorIndex, GemRB.GetVar("Selected"))
 	if ColorIndex == 0:
@@ -159,7 +165,7 @@ def GetColor():
 		Button.OnPress (DonePress)
 
 	ColorPicker.GetControl(0).MakeEscape ()
-	ColorPicker.ShowModal (MODAL_SHADOW_GRAY)
+	ColorPicker.ShowModal (ModalShadow)
 	return
 
 def HairPress():

--- a/gemrb/GUIScripts/GUICG13.py
+++ b/gemrb/GUIScripts/GUICG13.py
@@ -165,7 +165,6 @@ def GetColor():
 def HairPress():
 	global ColorIndex, PickedColor
 
-	ColorWindow.SetVisible(True)
 	ColorIndex = 0
 	PickedColor = HairColor
 	GetColor()
@@ -174,7 +173,6 @@ def HairPress():
 def SkinPress():
 	global ColorIndex, PickedColor
 
-	ColorWindow.SetVisible(True)
 	ColorIndex = 1
 	PickedColor = SkinColor
 	GetColor()
@@ -183,7 +181,6 @@ def SkinPress():
 def MajorPress():
 	global ColorIndex, PickedColor
 
-	ColorWindow.SetVisible(True)
 	ColorIndex = 2
 	PickedColor = MinorColor
 	GetColor()
@@ -192,7 +189,6 @@ def MajorPress():
 def MinorPress():
 	global ColorIndex, PickedColor
 
-	ColorWindow.SetVisible(True)
 	ColorIndex = 3
 	PickedColor = MajorColor
 	GetColor()

--- a/gemrb/GUIScripts/GUICG13.py
+++ b/gemrb/GUIScripts/GUICG13.py
@@ -109,24 +109,24 @@ def DonePress():
 
 	ColorWindow.ShowModal (MODAL_SHADOW_GRAY)
 
-	PickedColor=ColorTable.GetValue(ColorIndex, GemRB.GetVar("Selected"))
+	PickedColor = ColorTable.GetValue(ColorIndex, GemRB.GetVar("Selected"))
 	if ColorIndex == 0:
-		HairColor=PickedColor
+		HairColor = PickedColor
 		HairButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, HairColor)
 		BGCommon.RefreshPDoll (PDollButton, MinorColor, MajorColor, SkinColor, HairColor)
 		return
 	if ColorIndex == 1:
-		SkinColor=PickedColor
+		SkinColor = PickedColor
 		SkinButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, SkinColor)
 		BGCommon.RefreshPDoll (PDollButton, MinorColor, MajorColor, SkinColor, HairColor)
 		return
 	if ColorIndex == 2:
-		MinorColor=PickedColor
+		MinorColor = PickedColor
 		MajorButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, MinorColor)
 		BGCommon.RefreshPDoll (PDollButton, MinorColor, MajorColor, SkinColor, HairColor)
 		return
 
-	MajorColor=PickedColor
+	MajorColor = PickedColor
 	MinorButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, MajorColor)
 	BGCommon.RefreshPDoll (PDollButton, MinorColor, MajorColor, SkinColor, HairColor)
 	return
@@ -134,7 +134,7 @@ def DonePress():
 def GetColor():
 	global ColorPicker
 
-	ColorPicker=GemRB.LoadWindow(14)
+	ColorPicker = GemRB.LoadWindow(14)
 	GemRB.SetVar("Selected",-1)
 	btnFlags = IE_GUI_BUTTON_PICTURE
 	btnState = IE_GUI_BUTTON_LOCKED

--- a/gemrb/GUIScripts/GUICG13.py
+++ b/gemrb/GUIScripts/GUICG13.py
@@ -98,7 +98,7 @@ def OnLoad():
 	DoneButton.OnPress (NextPress)
 	BackButton.OnPress (BackPress)
 	BGCommon.RefreshPDoll (PDollButton, MinorColor, MajorColor, SkinColor, HairColor)
-	ColorWindow.ShowModal (MODAL_SHADOW_NONE)
+	ColorWindow.ShowModal (MODAL_SHADOW_GRAY)
 	return
 
 def DonePress():
@@ -107,7 +107,7 @@ def DonePress():
 	if ColorPicker:
 		ColorPicker.Close ()
 
-	ColorWindow.ShowModal (MODAL_SHADOW_NONE)
+	ColorWindow.ShowModal (MODAL_SHADOW_GRAY)
 
 	PickedColor=ColorTable.GetValue(ColorIndex, GemRB.GetVar("Selected"))
 	if ColorIndex==0:
@@ -159,13 +159,13 @@ def GetColor():
 		Button.OnPress (DonePress)
 
 	ColorPicker.GetControl(0).MakeEscape ()
-	ColorPicker.ShowModal (MODAL_SHADOW_NONE)
+	ColorPicker.ShowModal (MODAL_SHADOW_GRAY)
 	return
 
 def HairPress():
 	global ColorIndex, PickedColor
 
-	ColorWindow.SetVisible(False)
+	ColorWindow.SetVisible(True)
 	ColorIndex = 0
 	PickedColor = HairColor
 	GetColor()
@@ -174,7 +174,7 @@ def HairPress():
 def SkinPress():
 	global ColorIndex, PickedColor
 
-	ColorWindow.SetVisible(False)
+	ColorWindow.SetVisible(True)
 	ColorIndex = 1
 	PickedColor = SkinColor
 	GetColor()
@@ -183,7 +183,7 @@ def SkinPress():
 def MajorPress():
 	global ColorIndex, PickedColor
 
-	ColorWindow.SetVisible(False)
+	ColorWindow.SetVisible(True)
 	ColorIndex = 2
 	PickedColor = MinorColor
 	GetColor()
@@ -192,7 +192,7 @@ def MajorPress():
 def MinorPress():
 	global ColorIndex, PickedColor
 
-	ColorWindow.SetVisible(False)
+	ColorWindow.SetVisible(True)
 	ColorIndex = 3
 	PickedColor = MajorColor
 	GetColor()

--- a/gemrb/GUIScripts/GUICG13.py
+++ b/gemrb/GUIScripts/GUICG13.py
@@ -110,17 +110,17 @@ def DonePress():
 	ColorWindow.ShowModal (MODAL_SHADOW_GRAY)
 
 	PickedColor=ColorTable.GetValue(ColorIndex, GemRB.GetVar("Selected"))
-	if ColorIndex==0:
+	if ColorIndex == 0:
 		HairColor=PickedColor
 		HairButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, HairColor)
 		BGCommon.RefreshPDoll (PDollButton, MinorColor, MajorColor, SkinColor, HairColor)
 		return
-	if ColorIndex==1:
+	if ColorIndex == 1:
 		SkinColor=PickedColor
 		SkinButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, SkinColor)
 		BGCommon.RefreshPDoll (PDollButton, MinorColor, MajorColor, SkinColor, HairColor)
 		return
-	if ColorIndex==2:
+	if ColorIndex == 2:
 		MinorColor=PickedColor
 		MajorButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, MinorColor)
 		BGCommon.RefreshPDoll (PDollButton, MinorColor, MajorColor, SkinColor, HairColor)

--- a/gemrb/GUIScripts/LUSpellSelection.py
+++ b/gemrb/GUIScripts/LUSpellSelection.py
@@ -246,7 +246,7 @@ def OpenSpellsWindow (actor, table, level, diff, kit=0, gen=0, recommend=True, b
 		if recommend:
 			SpellsWindow.Focus()
 		else:
-			SpellsWindow.ShowModal (MODAL_SHADOW_NONE)
+			SpellsWindow.ShowModal (MODAL_SHADOW_GRAY)
 	else:
 		SpellsWindow.ShowModal (MODAL_SHADOW_GRAY)
 

--- a/gemrb/GUIScripts/bg1/GUICG1.py
+++ b/gemrb/GUIScripts/bg1/GUICG1.py
@@ -56,7 +56,7 @@ def OnLoad():
 	DoneButton.OnPress (NextPress)
 	BackButton.OnPress (lambda: CharGenCommon.back(GenderWindow))
 	DoneButton.SetState(IE_GUI_BUTTON_DISABLED)
-	GenderWindow.ShowModal(MODAL_SHADOW_NONE)
+	GenderWindow.ShowModal(MODAL_SHADOW_GRAY)
 	return
 
 def ClickedMale():

--- a/gemrb/GUIScripts/bg1/GUICG10.py
+++ b/gemrb/GUIScripts/bg1/GUICG10.py
@@ -81,7 +81,7 @@ def OnLoad():
 	DoneButton.OnPress (lambda: NextPress(ClassWindow))
 	BackButton.OnPress (lambda: CharGenCommon.back(ClassWindow))
 	DoneButton.SetState(IE_GUI_BUTTON_DISABLED)
-	ClassWindow.ShowModal(MODAL_SHADOW_NONE)
+	ClassWindow.ShowModal(MODAL_SHADOW_GRAY)
 	return
 
 def ClassPress():

--- a/gemrb/GUIScripts/bg1/GUICG12.py
+++ b/gemrb/GUIScripts/bg1/GUICG12.py
@@ -93,7 +93,7 @@ def OnLoad():
 				break
 			flag = True
 
-	AppearanceWindow.ShowModal(MODAL_SHADOW_NONE)
+	AppearanceWindow.ShowModal(MODAL_SHADOW_GRAY)
 	return
 
 def RightPress():
@@ -134,7 +134,7 @@ def CustomAbort():
 
 	if CustomWindow:
 		CustomWindow.Close ()
-	AppearanceWindow.ShowModal (MODAL_SHADOW_NONE) # narrower than CustomWindow, so borders will remain
+	AppearanceWindow.ShowModal (MODAL_SHADOW_GRAY) # narrower than CustomWindow, so borders will remain
 	return
 
 def LargeCustomPortrait():

--- a/gemrb/GUIScripts/bg1/GUICG15.py
+++ b/gemrb/GUIScripts/bg1/GUICG15.py
@@ -87,7 +87,7 @@ def OnLoad():
 
 	DoneButton.OnPress (NextPress)
 	BackButton.OnPress (lambda: CharGenCommon.back(RaceWindow))
-	RaceWindow.ShowModal(MODAL_SHADOW_NONE)
+	RaceWindow.ShowModal(MODAL_SHADOW_GRAY)
 	DisplayRaces()
 	return
 

--- a/gemrb/GUIScripts/bg1/GUICG19.py
+++ b/gemrb/GUIScripts/bg1/GUICG19.py
@@ -61,7 +61,7 @@ def OnLoad():
 	VoiceList.OnSelect (ChangeVoice)
 	DoneButton.OnPress (NextPress)
 	BackButton.OnPress (lambda: CharGenCommon.back(CharSoundWindow))
-	CharSoundWindow.ShowModal(MODAL_SHADOW_NONE)
+	CharSoundWindow.ShowModal(MODAL_SHADOW_GRAY)
 	return
 
 def PlayPress():

--- a/gemrb/GUIScripts/bg1/GUICG2.py
+++ b/gemrb/GUIScripts/bg1/GUICG2.py
@@ -108,7 +108,7 @@ def OnLoad():
 	SpecialistButton.OnPress (SpecialistPress)
 	DoneButton.OnPress (NextPress)
 	BackButton.OnPress (lambda: CharGenCommon.back(ClassWindow))
-	ClassWindow.ShowModal(MODAL_SHADOW_NONE)
+	ClassWindow.ShowModal(MODAL_SHADOW_GRAY)
 	return
 
 def MultiClassPress():

--- a/gemrb/GUIScripts/bg1/GUICG22.py
+++ b/gemrb/GUIScripts/bg1/GUICG22.py
@@ -97,7 +97,7 @@ def OnLoad():
 	DoneButton.OnPress (NextPress)
 	BackButton.OnPress (lambda: CharGenCommon.back(KitWindow))
 	#KitPress()
-	KitWindow.ShowModal(MODAL_SHADOW_NONE)
+	KitWindow.ShowModal(MODAL_SHADOW_GRAY)
 	return
 
 def KitPress():

--- a/gemrb/GUIScripts/bg1/GUICG3.py
+++ b/gemrb/GUIScripts/bg1/GUICG3.py
@@ -70,7 +70,7 @@ def OnLoad():
 	DoneButton.OnPress (NextPress)
 	BackButton.OnPress (lambda: CharGenCommon.back(AlignmentWindow))
 	DoneButton.SetState(IE_GUI_BUTTON_DISABLED)
-	AlignmentWindow.ShowModal(MODAL_SHADOW_NONE)
+	AlignmentWindow.ShowModal(MODAL_SHADOW_GRAY)
 	return
 
 def AlignmentPress():

--- a/gemrb/GUIScripts/bg1/GUICG4.py
+++ b/gemrb/GUIScripts/bg1/GUICG4.py
@@ -171,7 +171,7 @@ def OnLoad():
 	RerollButton.OnPress (RollPress)
 	DoneButton.OnPress (NextPress)
 	BackButton.OnPress (lambda: CharGenCommon.back(AbilityWindow))
-	AbilityWindow.ShowModal(MODAL_SHADOW_NONE)
+	AbilityWindow.ShowModal(MODAL_SHADOW_GRAY)
 	return
 
 def RightPress():

--- a/gemrb/GUIScripts/bg1/GUICG5.py
+++ b/gemrb/GUIScripts/bg1/GUICG5.py
@@ -48,7 +48,7 @@ def OnLoad():
 	DoneButton.OnPress (NextPress)
 	BackButton.OnPress (lambda: CharGenCommon.back(NameWindow))
 	NameField.OnChange (EditChange)
-	NameWindow.ShowModal(MODAL_SHADOW_NONE)
+	NameWindow.ShowModal(MODAL_SHADOW_GRAY)
 	NameField.Focus()
 	return
 

--- a/gemrb/GUIScripts/bg1/GUICG6.py
+++ b/gemrb/GUIScripts/bg1/GUICG6.py
@@ -60,7 +60,7 @@ def OnLoad():
 	DoneButton.SetState(IE_GUI_BUTTON_DISABLED)
 
 	RedrawSkills()
-	SkillWindow.ShowModal(MODAL_SHADOW_NONE)
+	SkillWindow.ShowModal(MODAL_SHADOW_GRAY)
 	return
 
 def NextPress():

--- a/gemrb/GUIScripts/bg1/GUICG8.py
+++ b/gemrb/GUIScripts/bg1/GUICG8.py
@@ -61,7 +61,7 @@ def OnLoad():
 
 	DoneButton.OnPress (NextPress)
 	BackButton.OnPress (lambda: CharGenCommon.back(RaceWindow))
-	RaceWindow.ShowModal(MODAL_SHADOW_NONE)
+	RaceWindow.ShowModal(MODAL_SHADOW_GRAY)
 	return
 
 def RacePress():

--- a/gemrb/GUIScripts/bg1/GUICG9.py
+++ b/gemrb/GUIScripts/bg1/GUICG9.py
@@ -57,7 +57,7 @@ def OnLoad():
 	DoneButton.OnPress (NextPress)
 	DoneButton.SetState(IE_GUI_BUTTON_DISABLED)
 
-	SkillWindow.ShowModal(MODAL_SHADOW_NONE)
+	SkillWindow.ShowModal(MODAL_SHADOW_GRAY)
 	return
 
 def NextPress():

--- a/gemrb/GUIScripts/bg1/ImportFile.py
+++ b/gemrb/GUIScripts/bg1/ImportFile.py
@@ -48,7 +48,7 @@ def OnLoad():
 	DoneButton.OnPress (DonePress)
 	CancelButton.OnPress (CancelPress)
 	TextAreaControl.OnSelect (SelectPress)
-	ImportWindow.ShowModal(MODAL_SHADOW_NONE)
+	ImportWindow.ShowModal(MODAL_SHADOW_GRAY)
 	return
 
 def SelectPress():


### PR DESCRIPTION
## Description

Need to call ShowModal with MODAL_SHADOW_GRAY instead of MODAL_SHADOW_NONE.

![cc](https://github.com/gemrb/gemrb/assets/155195419/d1a39360-2bd7-4663-81e9-6b92ca570797)

It is correct for BG1, but this changes `gemrb/GUIScripts/GUICG13.py` and `gemrb/GUIScripts/LUSpellSelection.py` too. If this is troublesome for the other games then I would need to add game checks.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
