### PR TITLE
Cleanup and fix colorwindow and -picker

### DIFF
--- a/gemrb/GUIScripts/GUICG13.py
+++ b/gemrb/GUIScripts/GUICG13.py
@@ -46,7 +46,7 @@ def OnLoad():
 	global HairButton, SkinButton, MajorButton, MinorButton
 	global HairColor, SkinColor, MajorColor, MinorColor
 
-	ColorWindow=GemRB.LoadWindow(13, "GUICG")
+	ColorWindow = GemRB.LoadWindow(13, "GUICG")
 	ColorWindow.SetFlags (WF_ALPHA_CHANNEL, OP_OR)
 	if GameCheck.IsBG2 ():
 		CharGenCommon.PositionCharGenWin (ColorWindow, -6)

--- a/gemrb/GUIScripts/GUICG13.py
+++ b/gemrb/GUIScripts/GUICG13.py
@@ -30,7 +30,6 @@ ColorWindow = 0
 ColorPicker = 0
 DoneButton = 0
 ColorIndex = 0
-PickedColor = 0
 HairButton = 0
 SkinButton = 0
 MajorButton = 0
@@ -45,8 +44,8 @@ ModalShadow = MODAL_SHADOW_NONE
 def OnLoad():
 	global ColorWindow, DoneButton, PDollButton, ColorTable, ModalShadow
 	global HairButton, SkinButton, MajorButton, MinorButton
-	global HairColor, SkinColor, MinorColor, MajorColor
-	
+	global HairColor, SkinColor, MajorColor, MinorColor
+
 	ColorWindow=GemRB.LoadWindow(13, "GUICG")
 	ColorWindow.SetFlags (WF_ALPHA_CHANNEL, OP_OR)
 	if GameCheck.IsBG2 ():
@@ -62,8 +61,8 @@ def OnLoad():
 		PortraitIndex = 0
 	HairColor = PortraitTable.GetValue (PortraitIndex, 1)
 	SkinColor = PortraitTable.GetValue (PortraitIndex, 2)
-	MinorColor = PortraitTable.GetValue (PortraitIndex, 3)
-	MajorColor = PortraitTable.GetValue (PortraitIndex, 4)
+	MajorColor = PortraitTable.GetValue (PortraitIndex, 3)
+	MinorColor = PortraitTable.GetValue (PortraitIndex, 4)
 
 	PDollButton = ColorWindow.GetControl(1)
 	PDollButton.SetState (IE_GUI_BUTTON_LOCKED)
@@ -79,15 +78,15 @@ def OnLoad():
 	SkinButton.OnPress (SkinPress)
 	SkinButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, SkinColor)
 
-	MajorButton = ColorWindow.GetControl(5)
+	MajorButton = ColorWindow.GetControl(4)
 	MajorButton.SetFlags(IE_GUI_BUTTON_PICTURE,OP_OR)
 	MajorButton.OnPress (MajorPress)
-	MajorButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, MinorColor)
+	MajorButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, MajorColor)
 
-	MinorButton = ColorWindow.GetControl(4)
+	MinorButton = ColorWindow.GetControl(5)
 	MinorButton.SetFlags(IE_GUI_BUTTON_PICTURE,OP_OR)
 	MinorButton.OnPress (MinorPress)
-	MinorButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, MajorColor)
+	MinorButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, MinorColor)
 
 	BackButton = ColorWindow.GetControl(13)
 	BackButton.SetText(15416)
@@ -108,32 +107,32 @@ def OnLoad():
 	return
 
 def DonePress():
-	global HairColor, SkinColor, MinorColor, MajorColor
+	global HairColor, SkinColor, MajorColor, MinorColor
 
 	if ColorPicker:
 		ColorPicker.Close ()
 
 	ColorWindow.ShowModal (ModalShadow)
 
-	PickedColor = ColorTable.GetValue(ColorIndex, GemRB.GetVar("Selected"))
+	pickedColor = ColorTable.GetValue(ColorIndex, GemRB.GetVar("Selected"))
 	if ColorIndex == 0:
-		HairColor = PickedColor
+		HairColor = pickedColor
 		HairButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, HairColor)
 		BGCommon.RefreshPDoll (PDollButton, MinorColor, MajorColor, SkinColor, HairColor)
 		return
 	if ColorIndex == 1:
-		SkinColor = PickedColor
+		SkinColor = pickedColor
 		SkinButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, SkinColor)
 		BGCommon.RefreshPDoll (PDollButton, MinorColor, MajorColor, SkinColor, HairColor)
 		return
 	if ColorIndex == 2:
-		MinorColor = PickedColor
-		MajorButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, MinorColor)
+		MajorColor = pickedColor
+		MajorButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, MajorColor)
 		BGCommon.RefreshPDoll (PDollButton, MinorColor, MajorColor, SkinColor, HairColor)
 		return
 
-	MajorColor = PickedColor
-	MinorButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, MajorColor)
+	MinorColor = pickedColor
+	MinorButton.SetBAM ("COLGRAD", GameCheck.IsBG2(), 0, MinorColor)
 	BGCommon.RefreshPDoll (PDollButton, MinorColor, MajorColor, SkinColor, HairColor)
 	return
 
@@ -160,45 +159,38 @@ def GetColor():
 			break
 		Button = ColorPicker.GetControl(i)
 		Button.SetBAM("COLGRAD", 2, 0, MyColor)
-		if PickedColor == MyColor:
-			GemRB.SetVar("Selected",i)
 		Button.SetState(IE_GUI_BUTTON_ENABLED)
 		Button.SetVarAssoc("Selected",i)
 		Button.OnPress (DonePress)
 
-	ColorPicker.GetControl(0).MakeEscape ()
 	ColorPicker.ShowModal (ModalShadow)
 	return
 
 def HairPress():
-	global ColorIndex, PickedColor
+	global ColorIndex
 
 	ColorIndex = 0
-	PickedColor = HairColor
 	GetColor()
 	return
 
 def SkinPress():
-	global ColorIndex, PickedColor
+	global ColorIndex
 
 	ColorIndex = 1
-	PickedColor = SkinColor
 	GetColor()
 	return
 
 def MajorPress():
-	global ColorIndex, PickedColor
+	global ColorIndex
 
 	ColorIndex = 2
-	PickedColor = MinorColor
 	GetColor()
 	return
 
 def MinorPress():
-	global ColorIndex, PickedColor
+	global ColorIndex
 
 	ColorIndex = 3
-	PickedColor = MajorColor
 	GetColor()
 	return
 

--- a/gemrb/GUIScripts/GUIREC.py
+++ b/gemrb/GUIScripts/GUIREC.py
@@ -1042,34 +1042,30 @@ def UpdatePaperDoll ():
 	return
 
 def SetHairColor ():
-	global ColorIndex, PickedColor
+	global ColorIndex
 
 	ColorIndex = 0
-	PickedColor = HairColor
 	OpenColorPicker ()
 	return
 
 def SetSkinColor ():
-	global ColorIndex, PickedColor
+	global ColorIndex
 
 	ColorIndex = 1
-	PickedColor = SkinColor
 	OpenColorPicker ()
 	return
 
 def SetMinorColor ():
-	global ColorIndex, PickedColor
+	global ColorIndex
 
 	ColorIndex = 2
-	PickedColor = MinorColor
 	OpenColorPicker ()
 	return
 
 def SetMajorColor ():
-	global ColorIndex, PickedColor
+	global ColorIndex
 
 	ColorIndex = 3
-	PickedColor = MajorColor
 	OpenColorPicker ()
 	return
 
@@ -1089,8 +1085,6 @@ def OpenColorPicker ():
 			break
 		Button = Window.GetControl (i+1)
 		Button.SetBAM("COLGRAD", 2, 0, MyColor)
-		if PickedColor == MyColor:
-			GemRB.SetVar ("Selected",i)
 		Button.SetState (IE_GUI_BUTTON_ENABLED)
 		Button.SetVarAssoc("Selected",i)
 		Button.OnPress (DonePress)
@@ -1100,24 +1094,23 @@ def OpenColorPicker ():
 
 def DonePress():
 	global HairColor, SkinColor, MajorColor, MinorColor
-	global PickedColor
 
 	GemRB.GetView("SUB_WIN", 1).Close()
-	PickedColor=ColorTable.GetValue (ColorIndex, GemRB.GetVar ("Selected"))
-	if ColorIndex==0:
-		HairColor=PickedColor
+	pickedColor = ColorTable.GetValue (ColorIndex, GemRB.GetVar ("Selected"))
+	if ColorIndex == 0:
+		HairColor = pickedColor
 		UpdatePaperDoll ()
 		return
-	if ColorIndex==1:
-		SkinColor=PickedColor
+	if ColorIndex == 1:
+		SkinColor = pickedColor
 		UpdatePaperDoll ()
 		return
-	if ColorIndex==2:
-		MinorColor=PickedColor
+	if ColorIndex == 2:
+		MinorColor = pickedColor
 		UpdatePaperDoll ()
 		return
 
-	MajorColor=PickedColor
+	MajorColor = pickedColor
 	UpdatePaperDoll ()
 	return
 

--- a/gemrb/GUIScripts/InventoryCommon.py
+++ b/gemrb/GUIScripts/InventoryCommon.py
@@ -766,53 +766,49 @@ def ColorDonePress():
 		ColorPicker.Close ()
 
 	ColorTable = GemRB.LoadTable ("clowncol")
-	PickedColor=ColorTable.GetValue (ColorIndex, GemRB.GetVar ("Selected"))
-	if ColorIndex==0:
-		GUICommon.SetColorStat (pc, IE_HAIR_COLOR, PickedColor)
-	elif ColorIndex==1:
-		GUICommon.SetColorStat (pc, IE_SKIN_COLOR, PickedColor)
-	elif ColorIndex==2:
-		GUICommon.SetColorStat (pc, IE_MAJOR_COLOR, PickedColor)
+	pickedColor = ColorTable.GetValue (ColorIndex, GemRB.GetVar ("Selected"))
+	if ColorIndex == 0:
+		GUICommon.SetColorStat (pc, IE_HAIR_COLOR, pickedColor)
+	elif ColorIndex == 1:
+		GUICommon.SetColorStat (pc, IE_SKIN_COLOR, pickedColor)
+	elif ColorIndex == 2:
+		GUICommon.SetColorStat (pc, IE_MAJOR_COLOR, pickedColor)
 	else:
-		GUICommon.SetColorStat (pc, IE_MINOR_COLOR, PickedColor)
+		GUICommon.SetColorStat (pc, IE_MINOR_COLOR, pickedColor)
 	UpdateInventoryWindow ()
 	return
 
 def HairPress():
-	global ColorIndex, PickedColor
+	global ColorIndex
 
 	pc = GemRB.GameGetSelectedPCSingle ()
 	ColorIndex = 0
-	PickedColor = GemRB.GetPlayerStat (pc, IE_HAIR_COLOR, 1) & 0xFF
 	GetColor()
 	return
 
 def SkinPress():
-	global ColorIndex, PickedColor
+	global ColorIndex
 
 	pc = GemRB.GameGetSelectedPCSingle ()
 	ColorIndex = 1
-	PickedColor = GemRB.GetPlayerStat (pc, IE_SKIN_COLOR, 1) & 0xFF
 	GetColor()
 	return
 
 def MajorPress():
 	"""Selects the major color."""
-	global ColorIndex, PickedColor
+	global ColorIndex
 
 	pc = GemRB.GameGetSelectedPCSingle ()
 	ColorIndex = 2
-	PickedColor = GemRB.GetPlayerStat (pc, IE_MAJOR_COLOR, 1) & 0xFF
 	GetColor()
 	return
 
 def MinorPress():
 	"""Selects the minor color."""
-	global ColorIndex, PickedColor
+	global ColorIndex
 
 	pc = GemRB.GameGetSelectedPCSingle ()
 	ColorIndex = 3
-	PickedColor = GemRB.GetPlayerStat (pc, IE_MINOR_COLOR, 1) & 0xFF
 	GetColor()
 	return
 
@@ -829,9 +825,10 @@ def GetColor():
 	if GameCheck.IsIWD2 () or GameCheck.IsGemRBDemo ():
 		Button = ColorPicker.GetControl (35)
 		Button.OnPress (CancelColor)
-		Button.SetText (103)
 		if GameCheck.IsIWD2 ():
 			Button.SetText (13727)
+		else:
+			Button.SetText (103)
 
 	for i in range (34):
 		Button = ColorPicker.GetControl (i)
@@ -839,14 +836,9 @@ def GetColor():
 		if MyColor == "*":
 			Button.SetState (IE_GUI_BUTTON_LOCKED)
 			continue
-		if PickedColor == MyColor:
-			GemRB.SetVar ("Selected",i)
-			Button.SetState (IE_GUI_BUTTON_LOCKED)
-			Button.MakeEscape()
-		else:
-			Button.SetBAM ("COLGRAD", 2, 0, MyColor)
-			Button.SetFlags (IE_GUI_BUTTON_PICTURE|IE_GUI_BUTTON_RADIOBUTTON, OP_OR)
-			Button.SetState (IE_GUI_BUTTON_ENABLED)
+		Button.SetBAM ("COLGRAD", 2, 0, MyColor)
+		Button.SetFlags (IE_GUI_BUTTON_PICTURE|IE_GUI_BUTTON_RADIOBUTTON, OP_OR)
+		Button.SetState (IE_GUI_BUTTON_ENABLED)
 		Button.SetVarAssoc ("Selected",i)
 		Button.OnPress (ColorDonePress)
 	ColorPicker.Focus()


### PR DESCRIPTION
## Description

GUICG13:
- demote unneeded global PickedColor to local variable
- sequence MajorColor and MinorColor consistently across the sourcecode in order to prevent confusion for the reader
- fix swapped lookup in PortraitTable for initial MajorColor and MinorColor
- fix swapped assignment of ControlID for MajorButton and MinorButton
- fix swapped assignment of Gradient for initial MajorButton and MinorButton
- fix swapped assignment of ColorIndex for MajorColor and MinorColor in DonePress
- fix swapped assignment of Gradient for MajorColor and MinorColor in DonePress
- remove unneeded update of Selected-variable on matching color in GetColor; SetVarAssoc overrides it anyway afterwards
- remove MakeEscape for the first button in GetColor, otherwise pressing ESC always sets the color to the first button's color

GUIREC:
- demote unneeded global PickedColor to local variable
- remove unneeded update of Selected-variable on matching color in OpenColorPicker; SetVarAssoc overrides it anyway afterwards
- add a few whitespaces in DonePress (python-lint)

InventoryCommon:
- demote unneeded global PickedColor to local variable
- add a few whitespaces in ColorDonePress (python-lint)
- put demo buttontext behind the proper else branch in GetColor
- remove useless if/else branch in GetColor

The changes to `ColorWindow.GetControl` in GUICG13 are correct for BG1. If the other games have different ControlIDs (GUICG.CHU), then I need to add GameChecks.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
