### PR TITLE
BG1: fix radiobutton preselections in GUICG with associated cleanups

### DIFF
--- a/gemrb/GUIScripts/bg1/GUICG1.py
+++ b/gemrb/GUIScripts/bg1/GUICG1.py
@@ -42,17 +42,21 @@ def OnLoad():
 	TextAreaControl = GenderWindow.GetControl(5)
 	TextAreaControl.SetText(17236)
 
-	MaleButton = GenderWindow.GetControl(2)
-	MaleButton.SetFlags(IE_GUI_BUTTON_RADIOBUTTON,OP_OR)
+	GemRB.SetVar("Gender", 0)
 
-	FemaleButton = GenderWindow.GetControl(3)
-	FemaleButton.SetFlags(IE_GUI_BUTTON_RADIOBUTTON,OP_OR)
-	
-	GemRB.SetVar("Gender",0)
-	MaleButton.SetVarAssoc("Gender",1)
-	FemaleButton.SetVarAssoc("Gender",2)
-	MaleButton.OnPress (ClickedMale)
-	FemaleButton.OnPress (ClickedFemale)
+	def SetGenderButton(controlID, var, onPress):
+		Button = GenderWindow.GetControl(controlID)
+		Button.SetVarAssoc("Gender", var)
+		Button.SetFlags(IE_GUI_BUTTON_RADIOBUTTON, OP_OR)
+		Button.SetState(IE_GUI_BUTTON_ENABLED) # reset from SELECTED after SetVarAssoc
+		Button.OnPress(onPress)
+
+	SetGenderButton(2, 1, ClickedMale)
+	SetGenderButton(3, 2, ClickedFemale)
+
+	# restore after SetVarAssoc
+	GemRB.SetVar("Gender", 0)
+
 	DoneButton.OnPress (NextPress)
 	BackButton.OnPress (lambda: CharGenCommon.back(GenderWindow))
 	DoneButton.SetState(IE_GUI_BUTTON_DISABLED)

--- a/gemrb/GUIScripts/bg1/GUICG10.py
+++ b/gemrb/GUIScripts/bg1/GUICG10.py
@@ -35,40 +35,34 @@ def OnLoad():
 	ClassWindow = GemRB.LoadWindow(10, "GUICG")
 
 	ClassCount = CommonTables.Classes.GetRowCount()+1
-	RaceName = CommonTables.Races.GetRowName(GemRB.GetVar("Race")-1 )
+	RaceName = CommonTables.Races.GetRowName(GemRB.GetVar("Race")-1)
 
-	j=0
-	for i in range(1,ClassCount):
-		ClassName = CommonTables.Classes.GetRowName (i-1)
-		if CommonTables.Classes.GetValue (ClassName, "MULTI") == 0:
-			continue
-		if j>11:
-			Button = ClassWindow.GetControl(j+7)
-		else:
-			Button = ClassWindow.GetControl(j+2)
-		Button.SetState(IE_GUI_BUTTON_DISABLED)
-		Button.SetFlags(IE_GUI_BUTTON_RADIOBUTTON,OP_OR)
-		j = j + 1
+	GemRB.SetVar("Class", 0)
 
-	j=0
-	for i in range(1,ClassCount):
-		ClassName = CommonTables.Classes.GetRowName (i-1)
+	for i in range(1, ClassCount):
+		ClassName = CommonTables.Classes.GetRowName(i-1)
 		Allowed = CommonTables.Classes.GetValue(ClassName, RaceName)
-		if CommonTables.Classes.GetValue (ClassName, "MULTI") == 0:
-			continue
-		if j>11:
-			Button = ClassWindow.GetControl(j+7)
-		else:
-			Button = ClassWindow.GetControl(j+2)
 
-		t = CommonTables.Classes.GetValue (ClassName, "NAME_REF")
-		Button.SetText(t )
-		j=j+1
-		if Allowed ==0:
+		# Don't setup buttons for non-multiclasses.
+		if CommonTables.Classes.GetValue(ClassName, "MULTI") == 0:
 			continue
-		Button.SetState(IE_GUI_BUTTON_ENABLED)
-		Button.OnPress (ClassPress)
+
+		# Only enable the button if this class is allowed by this race.
+		# Test for != 0 because of possible value 2 for gnomes.
+		if Allowed != 0:
+			btnState = IE_GUI_BUTTON_ENABLED
+		else:
+			btnState = IE_GUI_BUTTON_DISABLED
+
+		Button = ClassWindow.GetControl(i-7)
 		Button.SetVarAssoc("Class", i) #multiclass, actually
+		Button.SetFlags(IE_GUI_BUTTON_RADIOBUTTON, OP_OR)
+		Button.SetState(btnState) # reset from SELECTED after SetVarAssoc
+		Button.SetText(CommonTables.Classes.GetValue(ClassName, "NAME_REF"))
+		Button.OnPress(ClassPress)
+
+	# restore after SetVarAssoc
+	GemRB.SetVar("Class", 0)
 
 	BackButton = ClassWindow.GetControl(14)
 	BackButton.SetText(15416)

--- a/gemrb/GUIScripts/bg1/GUICG15.py
+++ b/gemrb/GUIScripts/bg1/GUICG15.py
@@ -36,39 +36,46 @@ LISTSIZE = 6
 def DisplayRaces():
 	global TopIndex
 
-	TopIndex=GemRB.GetVar("TopIndex")
+	GemRB.SetVar("HatedRace", 0)
+
+	TopIndex = GemRB.GetVar("TopIndex")
+
 	for i in range(LISTSIZE):
-		Button = RaceWindow.GetControl(i+2)
-		Val = RacialEnemyTable.GetValue(i+TopIndex,0)
-		if Val==0:
-			Button.SetText("")
-			Button.SetState(IE_GUI_BUTTON_DISABLED)
+		Val = RacialEnemyTable.GetValue(i+TopIndex, 0)
+		btnFlags = IE_GUI_BUTTON_RADIOBUTTON
+
+		# Only enable the button if it is visible.
+		if Val > 0:
+			btnState = IE_GUI_BUTTON_ENABLED
 		else:
-			Button.SetText(Val)
-			Button.SetState(IE_GUI_BUTTON_ENABLED)
-			Button.OnPress (RacePress)
-			Button.SetVarAssoc("HatedRace",RacialEnemyTable.GetValue(i+TopIndex,1) )
+			btnFlags |= IE_GUI_BUTTON_NO_TEXT
+			btnState = IE_GUI_BUTTON_DISABLED
+
+		Button = RaceWindow.GetControl(i+2)
+		Button.SetVarAssoc("HatedRace", RacialEnemyTable.GetValue(i+TopIndex, 1))
+		Button.SetFlags(btnFlags, OP_OR)
+		Button.SetSprites("GUIHRC", i, 0, 1, 2, 3)
+		Button.SetState(btnState) # reset from SELECTED after SetVarAssoc
+		Button.SetText(Val)
+		Button.OnPress(RacePress)
+
+	# restore after SetVarAssoc
+	GemRB.SetVar("HatedRace", 0)
+
 	return
 
 def OnLoad():
 	global RaceWindow, TextAreaControl, DoneButton
 	global RacialEnemyTable, RaceCount, TopIndex
-	
-	GemRB.SetVar ("HatedRace",0)
-	
+
 	ClassName = GUICommon.GetClassRowName (GemRB.GetVar ("Class")-1, "index")
 	TableName = CommonTables.ClassSkills.GetValue(ClassName, "HATERACE")
 	
 	RaceWindow = GemRB.LoadWindow(15, "GUICG")
 	RacialEnemyTable = GemRB.LoadTable(TableName)
 	RaceCount = RacialEnemyTable.GetRowCount()-LISTSIZE
-	if RaceCount<0:
-		RaceCount=0
-
-	for i in range(LISTSIZE):
-		Button = RaceWindow.GetControl(i+2)
-		Button.SetFlags(IE_GUI_BUTTON_RADIOBUTTON,OP_OR)
-		Button.SetSprites("GUIHRC",i,0,1,2,3)
+	if RaceCount < 0:
+		RaceCount = 0
 
 	BackButton = RaceWindow.GetControl(10)
 	BackButton.SetText(15416)

--- a/gemrb/GUIScripts/bg1/GUICG22.py
+++ b/gemrb/GUIScripts/bg1/GUICG22.py
@@ -46,44 +46,59 @@ def OnLoad():
 	#there is only a specialist mage window for bg1
 	KitWindow = GemRB.LoadWindow(12, "GUICG")
 
-	for i in range(8):
-		Button = KitWindow.GetControl(i+2)
-		Button.SetState(IE_GUI_BUTTON_DISABLED)
-		Button.SetFlags(IE_GUI_BUTTON_RADIOBUTTON, OP_OR)
+	GemRB.SetVar("Class Kit", -1)
+
+	def GetKit(rowIdx):
+		if not KitTable:
+			if ClassName == "MAGE":
+				return GemRB.GetVar("MAGESCHOOL")
+			return 0
+		else:
+			kit = KitTable.GetValue(rowIdx, 0)
+			if kit and ClassName == "MAGE":
+				kit -= 21
+			return kit
+
+	def GetKitName(rowIdx, kit):
+		if not KitTable:
+			if ClassName == "MAGE":
+				return SchoolList.GetValue(rowIdx, 0)
+			return CommonTables.Classes.GetValue(ClassName, "NAME_REF")
+		else:
+			if ClassName == "MAGE":
+				return SchoolList.GetValue(kit, 0)
+			elif kit:
+				return CommonTables.KitList.GetValue(kit, 1)
+			return CommonTables.Classes.GetValue(ClassName, "NAME_REF")
 
 	if not KitTable:
 		RowCount = 1
 	else:
 		RowCount = KitTable.GetRowCount()
 
-	for i in range(RowCount):
-		Button = KitWindow.GetControl(i+2)
-		if not KitTable:
-			if ClassName == "MAGE":
-				Kit=GemRB.GetVar("MAGESCHOOL")
-				KitName = SchoolList.GetValue(i, 0)
-			else:
-				Kit = 0
-				KitName = CommonTables.Classes.GetValue(ClassName, "NAME_REF")
+	for i in range(8):
+		btnFlags = IE_GUI_BUTTON_RADIOBUTTON
 
+		# Only process the button if it holds a Kit.
+		if i < RowCount:
+			Kit = GetKit(i)
+			KitName = GetKitName(i, Kit)
+			btnState = IE_GUI_BUTTON_ENABLED
 		else:
-			Kit = KitTable.GetValue(i,0)
-			if ClassName == "MAGE":
-				if Kit:
-					Kit = Kit - 21
-				KitName = SchoolList.GetValue(Kit, 0)
-			else:
-				if Kit:
-					KitName = CommonTables.KitList.GetValue(Kit, 1)
-				else:
-					KitName = CommonTables.Classes.GetValue (ClassName, "NAME_REF")
+			Kit = -1
+			KitName = ""
+			btnFlags |= IE_GUI_BUTTON_NO_TEXT
+			btnState = IE_GUI_BUTTON_DISABLED
 
-		Button.SetState(IE_GUI_BUTTON_ENABLED)
+		Button = KitWindow.GetControl(i+2)
+		Button.SetVarAssoc("Class Kit", Kit)
+		Button.SetFlags(btnFlags, OP_OR)
+		Button.SetState(btnState) # reset from SELECTED after SetVarAssoc
 		Button.SetText(KitName)
-		Button.SetVarAssoc("Class Kit",Kit)
-		if i==0:
-			GemRB.SetVar("Class Kit",Kit)
-		Button.OnPress (KitPress)
+		Button.OnPress(KitPress)
+
+	# restore after SetVarAssoc
+	GemRB.SetVar("Class Kit", -1)
 
 	BackButton = KitWindow.GetControl(12)
 	BackButton.SetText(15416)

--- a/gemrb/GUIScripts/bg1/GUICG3.py
+++ b/gemrb/GUIScripts/bg1/GUICG3.py
@@ -33,8 +33,6 @@ def OnLoad():
 	global AlignmentWindow, TextAreaControl, DoneButton
 
 	MyChar = GemRB.GetVar ("Slot")
-
-	GemRB.SetVar("Alignment",-1)
 	
 	KitName = GUICommon.GetClassRowName (MyChar)
 
@@ -44,18 +42,25 @@ def OnLoad():
 
 	# This section enables or disables different alignment selections
 	# based on Class, and depends on the ALIGNMNT.2DA table
-	#
-	# For now, we just enable all buttons
+
+	GemRB.SetVar("Alignment", -1)
+
 	for i in range(9):
-		Button = AlignmentWindow.GetControl(i+2)
-		Button.SetFlags (IE_GUI_BUTTON_RADIOBUTTON, OP_OR)
-		Button.SetText (CommonTables.Aligns.GetValue (i,0))
-		if AlignmentOk.GetValue (KitName, CommonTables.Aligns.GetValue (i, 4)) != 0:
-			Button.SetState(IE_GUI_BUTTON_ENABLED)
+		# Only enable the button if this alignment is allowed by this class.
+		if AlignmentOk.GetValue(KitName, CommonTables.Aligns.GetValue(i, 4)):
+			btnState = IE_GUI_BUTTON_ENABLED
 		else:
-			Button.SetState(IE_GUI_BUTTON_DISABLED)
-		Button.OnPress (AlignmentPress)
+			btnState = IE_GUI_BUTTON_DISABLED
+
+		Button = AlignmentWindow.GetControl(i+2)
 		Button.SetVarAssoc("Alignment", i)
+		Button.SetFlags(IE_GUI_BUTTON_RADIOBUTTON, OP_OR)
+		Button.SetState(btnState) # reset from SELECTED after SetVarAssoc
+		Button.SetText(CommonTables.Aligns.GetValue(i, 0))
+		Button.OnPress(AlignmentPress)
+
+	# restore after SetVarAssoc
+	GemRB.SetVar("Alignment", -1)
 
 	BackButton = AlignmentWindow.GetControl(13)
 	BackButton.SetText(15416)

--- a/gemrb/GUIScripts/bg1/GUICG8.py
+++ b/gemrb/GUIScripts/bg1/GUICG8.py
@@ -32,22 +32,23 @@ DoneButton = 0
 def OnLoad():
 	global RaceWindow, TextAreaControl, DoneButton
 	global RaceTable
-	
-	GemRB.SetVar("Race",0) 
 
 	RaceWindow = GemRB.LoadWindow(8, "GUICG")
 
 	RaceCount = CommonTables.Races.GetRowCount()
 
-	for i in range(2,RaceCount+2):
-		Button = RaceWindow.GetControl(i)
-		Button.SetFlags(IE_GUI_BUTTON_RADIOBUTTON,OP_OR)
+	GemRB.SetVar("Race", 0)
+
 	for i in range(2, RaceCount+2):
 		Button = RaceWindow.GetControl(i)
-		Button.SetText(CommonTables.Races.GetValue(i-2,0) )
-		Button.SetState(IE_GUI_BUTTON_ENABLED)
-		Button.OnPress (RacePress)
-		Button.SetVarAssoc("Race",i-1)
+		Button.SetVarAssoc("Race", i-1)
+		Button.SetFlags(IE_GUI_BUTTON_RADIOBUTTON, OP_OR)
+		Button.SetState(IE_GUI_BUTTON_ENABLED) # reset from SELECTED after SetVarAssoc
+		Button.SetText(CommonTables.Races.GetValue(i-2, 0))
+		Button.OnPress(RacePress)
+
+	# restore after SetVarAssoc
+	GemRB.SetVar("Race", 0)
 
 	BackButton = RaceWindow.GetControl(10)
 	BackButton.SetText(15416)


### PR DESCRIPTION
## Description

The radiobuttons in the GUICG windows suffer from the known radiobutton preselection issue, i.e. the last created button of a buttongroup is preselected, which is not the behaviour in the original and also leaves the controls in a wrong state, e.g. the Done-button isn't enabled despite a preselected radiobutton.

Steps to fix this issue:
- call SetState(enabled/disabled) after SetVarAssoc in order to reset the selected state
- call SetVar(DictVar) after radiobuttons are created in order to restore the value of DictVar which was overriden by SetVarAssoc

While applying the above steps, the surrounding code contexts need cleanups and simplifications:
- wrap male/female button into a function in GUICG1
- wrap Kit and KitName into functions in GUICG22 in order to improve readability of the for-loop
- group button settings (SetVarAssoc, SetFlags, SetState, ...) together and use the same sequence of settings for more clarity and consistency
- merge multiple for-loops over the same buttons into one for-loop
- simplify index and associated ControlID calculations
- add more comments to improve reasoning

Example screenshot of issue in gender window:
![gender](https://github.com/gemrb/gemrb/assets/155195419/2f4272e4-d658-4cdc-a413-65779646e585)

Example screenshot of issue in race window:
![race](https://github.com/gemrb/gemrb/assets/155195419/f20c80cb-ed79-45a1-ba3f-344f09c536f9)

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
