### PR TITLE
BG1: fix wrong battle music in subareas without songlist

### DIFF
--- a/gemrb/core/Game.h
+++ b/gemrb/core/Game.h
@@ -360,8 +360,6 @@ public:
 	bool MasterArea(const ResRef &area) const;
 	/** Dynamically adding an area to master areas*/
 	void SetMasterArea(const ResRef &area);
-	/** Guess the master area of the given area*/
-	//Map* GetMasterArea(const char *area);
 	/** place persistent actors in the fresly loaded area*/
 	void PlacePersistents(Map *map, const ResRef &resRef);
 	/** Returns slot of the map, if it was already loaded,


### PR DESCRIPTION
## Description
Fallback to the songlist from masterarea in order to play the correct battle music.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
