### PR TITLE
Refine some music handling

### DIFF
--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -1566,6 +1566,12 @@ void Game::UpdateScripts()
 		CombatCounter--;
 		doChangeSong = !CombatCounter;
 		doChangeSongHard = false;
+	} else if (!core->GetMusicMgr()->IsPlaying()) {
+		// perhaps a StartMusic action stopped the area music?
+		// (we should probably find a less silly way to handle this,
+		// because nothing can ever stop area music now..)
+		doChangeSong = true;
+		doChangeSongHard = false;
 	} else {
 		// nothing to change
 		doChangeSong = false;
@@ -1587,13 +1593,6 @@ void Game::UpdateScripts()
 		for(unsigned int i=0;i<idx;i++) {
 			DelMap(i, false);
 		}
-	}
-
-	// perhaps a StartMusic action stopped the area music?
-	// (we should probably find a less silly way to handle this,
-	// because nothing can ever stop area music now..)
-	if (!core->GetMusicMgr()->IsPlaying()) {
-		ChangeSong(false,false);
 	}
 
 	//this is used only for the death delay so far

--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -1570,8 +1570,18 @@ void Game::UpdateScripts()
 		// perhaps a StartMusic action stopped the area music?
 		// (we should probably find a less silly way to handle this,
 		// because nothing can ever stop area music now..)
-		doChangeSong = true;
+
+		// Call ChangeSong only once per round in order to prevent spam
+		// calls every tick in areas without music.
+		static int ticks = 0;
+		ticks++;
+
+		doChangeSong = ticks >= core->Time.round_size;
 		doChangeSongHard = false;
+
+		if (doChangeSong) {
+			ticks = 0;
+		}
 	} else {
 		// nothing to change
 		doChangeSong = false;

--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -2158,10 +2158,9 @@ void Game::ChangeSong(bool always, bool force) const
 		BattleSong++;
 	} else {
 		//will select SONG_DAY or SONG_NIGHT
-		Trigger* parameters = new Trigger;
-		parameters->int0Parameter = 0; // TIMEOFDAY_DAY, while dusk, dawn and night we treat as night
-		Song = int(GameScript::TimeOfDay(nullptr, parameters) != 1);
-		delete parameters;
+		Trigger parameters;
+		parameters.int0Parameter = 0; // TIMEOFDAY_DAY, while dusk, dawn and night we treat as night
+		Song = int(GameScript::TimeOfDay(nullptr, &parameters) != 1);
 		BattleSong = 0;
 	}
 	//area may override the song played (stick in battlemusic)

--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -1552,18 +1552,27 @@ void Game::UpdateScripts()
 		Maps[idx]->UpdateScripts();
 	}
 
+	// determine if we should start some music
+	bool doChangeSong;
+	bool doChangeSongHard;
+
 	if (PartyAttack) {
 		//ChangeSong will set the battlesong only if CombatCounter is nonzero
-		CombatCounter=150;
-		ChangeSong(false, true);
+		CombatCounter = 150;
+		doChangeSong = true;
+		doChangeSongHard = true;
+	} else if (CombatCounter) {
+		//Change song if combatcounter goes down to 0
+		CombatCounter--;
+		doChangeSong = !CombatCounter;
+		doChangeSongHard = false;
 	} else {
-		if (CombatCounter) {
-			CombatCounter--;
-			//Change song if combatcounter went down to 0
-			if (!CombatCounter) {
-				ChangeSong(false, false);
-			}
-		}
+		// nothing to change
+		doChangeSong = false;
+		doChangeSongHard = false;
+	}
+	if (doChangeSong) {
+		ChangeSong(false, doChangeSongHard);
 	}
 
 	if (StateOverrideTime)

--- a/gemrb/core/GameScript/GSUtils.cpp
+++ b/gemrb/core/GameScript/GSUtils.cpp
@@ -1349,7 +1349,7 @@ void MoveBetweenAreasCore(Actor* actor, const ResRef &area, const Point &positio
 	Map* map1 = actor->GetCurrentArea();
 	Map* map2;
 	Game* game = core->GetGame();
-	bool newSong = false;
+
 	if (!area.IsEmpty() && (!map1 || area != map1->GetScriptRef())) { //do we need to switch area?
 		//we have to change the pathfinder
 		//to the target area if adjust==true
@@ -1358,7 +1358,6 @@ void MoveBetweenAreasCore(Actor* actor, const ResRef &area, const Point &positio
 			map1->RemoveActor( actor );
 		}
 		map2->AddActor( actor, true );
-		newSong = true;
 
 		// update the worldmap if needed
 		if (actor->InParty) {
@@ -1379,9 +1378,6 @@ void MoveBetweenAreasCore(Actor* actor, const ResRef &area, const Point &positio
 	if (actor->InParty) {
 		GameControl *gc=core->GetGameControl();
 		gc->SetScreenFlags(ScreenFlags::CenterOnActor, BitOp::OR);
-		if (newSong) {
-			game->ChangeSong(false, true);
-		}
 	}
 }
 

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -2397,12 +2397,12 @@ void Map::PlayAreaSong(int SongType, bool restart, bool hard) const
 	// Some subareas don't have their own songlist. It is currently unclear
 	// how the different games handle this situation and which music GemRB
 	// should play, if any. Further research is needed.
-	// At least for the battle music in BG1, e.g. AR2607 (intro candlekeep
-	// ambush south), there is a strong assumption to play the music from
-	// the masterarea's songlist.
+	// At least for BG1 there is a strong assumption to play the music from
+	// the masterarea's songlist, e.g. AR2607 (intro candlekeep ambush south),
+	// or AR2302 (friendly arm inn 2nd floor).
 	// This assumption is definitely wrong for IWD, see #1476! Therefore we
 	// use a preliminary flag test to restrict it to BG1 for now.
-	if (IsStar(*poi) && !MasterArea && SongType == SONG_BATTLE && core->HasFeature(GFFlags::BREAKABLE_WEAPONS)) {
+	if (IsStar(*poi) && !MasterArea && core->HasFeature(GFFlags::BREAKABLE_WEAPONS)) {
 		static constexpr int bc1Idx = 19; // fallback to first BG1 battle music
 
 		const Map* lastMasterArea = game->GetMap(game->LastMasterArea, false);

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -2402,7 +2402,9 @@ void Map::PlayAreaSong(int SongType, bool restart, bool hard) const
 	// or AR2302 (friendly arm inn 2nd floor).
 	// This assumption is definitely wrong for IWD, see #1476! Therefore we
 	// use a preliminary flag test to restrict it to BG1 for now.
-	if (IsStar(*poi) && !MasterArea && core->HasFeature(GFFlags::BREAKABLE_WEAPONS)) {
+	// Test for non-zero pl in order to keep subareas quiet which disable
+	// music explicitely with pl=0.
+	if (IsStar(*poi) && pl && !MasterArea && core->HasFeature(GFFlags::BREAKABLE_WEAPONS)) {
 		static constexpr int bc1Idx = 19; // fallback to first BG1 battle music
 
 		const Map* lastMasterArea = game->GetMap(game->LastMasterArea, false);


### PR DESCRIPTION
## Description
The initial goal was to solve #2008. On the way to the solution I discovered some circumstances that could be improved:

- unnecessary heap allocation in `ChangeSong`
- `ChangeSong` is spammed if the area has no music set
- `MoveBetweenAreasCore` executes an ineffective `ChangeSong`
- fallback music in `PlayAreaSong` almost hid another not understood behaviour of the engine from me (topic for another issue/PR), so remove the fallback
- further opportunities for improved subarea music handling in BG1
- and finally #2008 itself

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
