### PR TITLE
optimize some of our math

### DIFF
--- a/gemrb/core/Bitmap.h
+++ b/gemrb/core/Bitmap.h
@@ -97,12 +97,12 @@ public:
 	}
 	
 	BitProxy operator[](int i) noexcept {
-		div_t res = div(i, 8);
+		div_t res = std::div(i, 8);
 		return BitProxy(data[res.quot], res.rem);
 	}
 	
 	bool operator[](int i) const noexcept {
-		div_t res = div(i, 8);
+		div_t res = std::div(i, 8);
 		return data[res.quot] & (1 << res.rem);
 	}
 	

--- a/gemrb/core/Core.cpp
+++ b/gemrb/core/Core.cpp
@@ -145,8 +145,8 @@ unsigned int SquaredPersonalDistance(const Scriptable *a, const Scriptable *b)
 	return (unsigned int) ret;
 }
 
-unsigned int PersonalLineDistance(const Point &v, const Point &w, const Scriptable *s, double *proj) {
-	double t;
+unsigned int PersonalLineDistance(const Point& v, const Point& w, const Scriptable* s, float_t* proj) {
+	float_t t;
 	Point p;
 
 	int len = SquaredDistance(w, v);
@@ -156,7 +156,7 @@ unsigned int PersonalLineDistance(const Point &v, const Point &w, const Scriptab
 		p = v;
 	} else {
 		// find the projection of Pos onto the line
-		t = ((s->Pos.x - v.x) * (w.x - v.x) + (s->Pos.y - v.y) * (w.y - v.y)) / (double) len;
+		t = ((s->Pos.x - v.x) * (w.x - v.x) + (s->Pos.y - v.y) * (w.y - v.y)) / (float_t) len;
 		if (t < 0.0) {
 			// projection beyond the v end of the line
 			p = v;
@@ -205,11 +205,11 @@ unsigned int PersonalLineDistance(const Point &v, const Point &w, const Scriptab
 // Potential optimisation through precomputing:
 // rounding the angle into 5° intervals [0-90] gives these values per foot:
 // 16 16 16 16 15 15 15 14 14 14 13 13 13 12 12 12 12 12 12
-double Feet2Pixels(int feet, double angle)
+float_t Feet2Pixels(int feet, float_t angle)
 {
-	double sin2 = pow(sin(angle) / 12, 2);
-	double cos2 = pow(cos(angle) / 16, 2);
-	double r = sqrt(1 / (cos2 + sin2));
+	float_t sin2 = std::pow(std::sin(angle) / 12, 2);
+	float_t cos2 = std::pow(std::cos(angle) / 16, 2);
+	float_t r = std::sqrt(1 / (cos2 + sin2));
 	return r * feet;
 }
 
@@ -227,19 +227,19 @@ bool WithinAudibleRange(const Actor *actor, const Point &dest)
 
 bool WithinRange(const Scriptable *actor, const Point &dest, int distance)
 {
-	double angle = AngleFromPoints(actor->Pos, dest);
+	float_t angle = AngleFromPoints(actor->Pos, dest);
 	return Distance(dest, actor) <= Feet2Pixels(distance, angle);
 }
 
 bool WithinPersonalRange(const Scriptable *actor, const Point &dest, int distance)
 {
-	double angle = AngleFromPoints(actor->Pos, dest);
+	float_t angle = AngleFromPoints(actor->Pos, dest);
 	return PersonalDistance(dest, actor) <= Feet2Pixels(distance, angle);
 }
 
 bool WithinPersonalRange(const Scriptable* scr1, const Scriptable* scr2, int distance)
 {
-	double angle = AngleFromPoints(scr1->Pos, scr2->Pos);
+	float_t angle = AngleFromPoints(scr1->Pos, scr2->Pos);
 	return PersonalDistance(scr2, scr1) <= Feet2Pixels(distance, angle);
 }
 

--- a/gemrb/core/Core.cpp
+++ b/gemrb/core/Core.cpp
@@ -71,7 +71,7 @@ unsigned int PersonalDistance(const Point &p, const Scriptable *b)
 {
 	long x = p.x - b->Pos.x;
 	long y = p.y - b->Pos.y;
-	int ret = (int) std::hypot(x, y);
+	auto ret = std::hypot(x, y);
 	if (b->Type==ST_ACTOR) {
 		ret -= static_cast<const Actor*>(b)->CircleSize2Radius() * DistanceFactor;
 	}
@@ -119,7 +119,7 @@ unsigned int PersonalDistance(const Scriptable *a, const Scriptable *b)
 {
 	long x = a->Pos.x - b->Pos.x;
 	long y = a->Pos.y - b->Pos.y;
-	int ret = (int) std::hypot(x, y);
+	auto ret = std::hypot(x, y);
 	if (a->Type==ST_ACTOR) {
 		ret -= static_cast<const Actor*>(a)->CircleSize2Radius() * DistanceFactor;
 	}

--- a/gemrb/core/GUI/EventMgr.cpp
+++ b/gemrb/core/GUI/EventMgr.cpp
@@ -412,10 +412,10 @@ Event EventMgr::CreateTouchEvent(const TouchEvent::Finger fingers[], int numFing
 		for (int i = 0; i < numFingers; ++i) {
 			e.touch.x += fingers[i].x;
 			e.touch.y += fingers[i].y;
-			if (abs(fingers[i].deltaX) > abs(e.touch.deltaX)) {
+			if (std::abs(fingers[i].deltaX) > std::abs(e.touch.deltaX)) {
 				e.touch.deltaX = fingers[i].deltaX;
 			}
-			if (abs(fingers[i].deltaY) > abs(e.touch.deltaY)) {
+			if (std::abs(fingers[i].deltaY) > std::abs(e.touch.deltaY)) {
 				e.touch.deltaY = fingers[i].deltaY;
 			}
 			e.touch.fingers[i] = fingers[i];

--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -148,7 +148,7 @@ Point GameControl::GetFormationOffset(size_t formation, uint8_t pos) const
 	return Formations::GetFormation(formation)[pos];
 }
 
-Point GameControl::GetFormationPoint(const Point& origin, size_t pos, double angle, const std::vector<Point>& exclude) const
+Point GameControl::GetFormationPoint(const Point& origin, size_t pos, float_t angle, const std::vector<Point>& exclude) const
 {
 	Point vec;
 	
@@ -184,7 +184,7 @@ Point GameControl::GetFormationPoint(const Point& origin, size_t pos, double ang
 	Point dest = vec + origin;
 	int step = 0;
 	constexpr int maxStep = 4;
-	double stepAngle = 0.0;
+	float_t stepAngle = 0.0;
 	const Point& start = vec;
 	
 	auto NextDest = [&]() {
@@ -244,7 +244,7 @@ Point GameControl::GetFormationPoint(const Point& origin, size_t pos, double ang
 }
 
 GameControl::FormationPoints GameControl::GetFormationPoints(const Point& origin, const std::vector<Actor*>& actors,
-															 double angle) const
+															 float_t angle) const
 {
 	FormationPoints formation;
 	for (size_t i = 0; i < actors.size(); ++i) {
@@ -253,7 +253,7 @@ GameControl::FormationPoints GameControl::GetFormationPoints(const Point& origin
 	return formation;
 }
 
-void GameControl::DrawFormation(const std::vector<Actor*>& actors, const Point& formationPoint, double angle) const
+void GameControl::DrawFormation(const std::vector<Actor*>& actors, const Point& formationPoint, float_t angle) const
 {
 	std::vector<Point> formationPoints = GetFormationPoints(formationPoint, actors, angle);
 	for (size_t i = 0; i < actors.size(); ++i) {
@@ -612,7 +612,7 @@ void GameControl::DrawSelf(const Region& screen, const Region& /*clip*/)
 	const Point& gameMousePos = GameMousePos();
 	// draw reticles
 	if (isFormationRotation) {
-		double angle = AngleFromPoints(gameMousePos, gameClickPoint);
+		float_t angle = AngleFromPoints(gameMousePos, gameClickPoint);
 		DrawFormation(game->selected, gameClickPoint, angle);
 	} else {
 		for (const auto& selectee : game->selected) {
@@ -2301,7 +2301,7 @@ void GameControl::CommandSelectedMovement(const Point& p, bool formation, bool a
 	if (party.empty())
 		return;
 
-	double angle = isFormationRotation ? AngleFromPoints(GameMousePos(), p) : formationBaseAngle;
+	float_t angle = isFormationRotation ? AngleFromPoints(GameMousePos(), p) : formationBaseAngle;
 	bool doWorldMap = ShouldTriggerWorldMap(party[0]);
 	
 	std::vector<Point> formationPoints = GetFormationPoints(p, party, angle);

--- a/gemrb/core/GUI/GameControl.h
+++ b/gemrb/core/GUI/GameControl.h
@@ -67,7 +67,7 @@ private:
 	Point screenMousePos;
 	Point vpOrigin;
 	bool updateVPTimer = true;
-	double formationBaseAngle = 0.0;
+	float_t formationBaseAngle = 0.0;
 
 	// currently selected targeting type, such as talk, attack, cast, ...
 	// private to enforce proper cursor changes
@@ -111,10 +111,10 @@ private:
 	Region SelectionRect() const;
 	/** Draws an arrow on the edge of the screen based on the point (points at offscreen actors) */
 	void DrawArrowMarker(const Point& p, const Color& color) const;
-	void DrawFormation(const std::vector<Actor*>& actors, const Point& formationPoint, double angle) const;
+	void DrawFormation(const std::vector<Actor*>& actors, const Point& formationPoint, float_t angle) const;
 	
-	Point GetFormationPoint(const Point& origin, size_t pos, double angle, const FormationPoints& exclude = FormationPoints()) const;
-	FormationPoints GetFormationPoints(const Point& origin, const std::vector<Actor*>& actors, double angle) const;
+	Point GetFormationPoint(const Point& origin, size_t pos, float_t angle, const FormationPoints& exclude = FormationPoints()) const;
+	FormationPoints GetFormationPoints(const Point& origin, const std::vector<Actor*>& actors, float_t angle) const;
 	
 	void Scroll(const Point& amt);
 

--- a/gemrb/core/GUI/TextSystem/Font.cpp
+++ b/gemrb/core/GUI/TextSystem/Font.cpp
@@ -88,7 +88,7 @@ bool Font::GlyphAtlasPage::AddGlyph(ieWord chr, const Glyph& g)
 		return false;
 	}
 	
-	int glyphH = g.size.h + abs(g.pos.y);
+	int glyphH = g.size.h + std::abs(g.pos.y);
 	if (glyphH > SheetRegion.h) {
 		// must grow to accommodate this glyph
 		if (Sheet) {

--- a/gemrb/core/GameScript/Actions.cpp
+++ b/gemrb/core/GameScript/Actions.cpp
@@ -6821,7 +6821,7 @@ void GameScript::UseItem(Scriptable* Sender, Action* parameters)
 	}
 	gamedata->FreeItem(itm, itemres, false);
 
-	double angle = AngleFromPoints(Sender->Pos, tar->Pos);
+	float_t angle = AngleFromPoints(Sender->Pos, tar->Pos);
 	unsigned int dist = GetItemDistance(itemres, header, angle);
 	if (PersonalDistance(Sender, tar) > dist) {
 		MoveNearerTo(Sender, tar, dist);
@@ -6871,7 +6871,7 @@ void GameScript::UseItemPoint(Scriptable* Sender, Action* parameters)
 		return;
 	}
 
-	double angle = AngleFromPoints(Sender->Pos, parameters->pointParameter);
+	float_t angle = AngleFromPoints(Sender->Pos, parameters->pointParameter);
 	unsigned int dist = GetItemDistance(itemres, header, angle);
 	if (PersonalDistance(parameters->pointParameter, Sender) > dist) {
 		MoveNearerTo(Sender, parameters->pointParameter, dist, 0);

--- a/gemrb/core/GameScript/GSUtils.cpp
+++ b/gemrb/core/GameScript/GSUtils.cpp
@@ -1534,7 +1534,7 @@ void AttackCore(Scriptable *Sender, Scriptable *target, int flags)
 		}
 	}
 
-	double angle = AngleFromPoints(attacker->Pos, target->Pos);
+	float_t angle = AngleFromPoints(attacker->Pos, target->Pos);
 	if (attacker->GetCurrentArea() != target->GetCurrentArea() ||
 		!WithinPersonalRange(attacker, target, weaponRange) ||
 		!attacker->GetCurrentArea()->IsVisibleLOS(attacker->Pos, target->Pos) ||
@@ -2450,7 +2450,7 @@ unsigned int GetSpellDistance(const ResRef& spellRes, Scriptable* Sender, const 
 	}
 
 	if (!target.IsZero()) {
-		double angle = AngleFromPoints(Sender->Pos, target);
+		float_t angle = AngleFromPoints(Sender->Pos, target);
 		return Feet2Pixels(dist, angle);
 	}
 
@@ -2460,7 +2460,7 @@ unsigned int GetSpellDistance(const ResRef& spellRes, Scriptable* Sender, const 
 
 /* returns an item's casting distance, it depends on the used header, and targeting mode too
  the used header is explicitly given */
-unsigned int GetItemDistance(const ResRef& itemres, int header, double angle)
+unsigned int GetItemDistance(const ResRef& itemres, int header, float_t angle)
 {
 	const Item* itm = gamedata->GetItem(itemres);
 	if (!itm) {
@@ -3065,7 +3065,7 @@ void RunAwayFromCore(Scriptable* Sender, const Action* parameters, int flags)
 	}
 
 	// estimate max distance with time and actor speed
-	double speed = actor->GetSpeed();
+	float_t speed = actor->GetSpeed();
 	int maxDistance = parameters->int0Parameter;
 	if (speed) {
 		maxDistance = static_cast<int>(maxDistance * gamedata->GetStepTime() / speed);

--- a/gemrb/core/GameScript/GSUtils.h
+++ b/gemrb/core/GameScript/GSUtils.h
@@ -137,7 +137,7 @@ GEM_EXPORT bool VariableExists(const Scriptable *Sender, const StringParam& VarN
 Action* GenerateActionCore(const char *src, const char *str, unsigned short actionID);
 Trigger *GenerateTriggerCore(const char *src, const char *str, int trIndex, int negate);
 GEM_EXPORT unsigned int GetSpellDistance(const ResRef& spellRes, Scriptable* Sender, const Point& target = Point());
-unsigned int GetItemDistance(const ResRef& itemres, int header, double angle);
+unsigned int GetItemDistance(const ResRef& itemres, int header, float_t angle);
 void SetupWishCore(Scriptable *Sender, TableMgr::index_t column, int picks);
 void AmbientActivateCore(const Scriptable *Sender, const Action *parameters, bool flag);
 void SpellCore(Scriptable *Sender, Action *parameters, int flags);

--- a/gemrb/core/GameScript/Triggers.cpp
+++ b/gemrb/core/GameScript/Triggers.cpp
@@ -1564,16 +1564,16 @@ int GameScript::InLine(Scriptable *Sender, const Trigger *parameters)
 		return 0;
 	}
 
-	double fdm1 = SquaredDistance(Sender, scr1);
-	double fdm2 = SquaredDistance(Sender, scr2);
-	double fd12 = SquaredDistance(scr1, scr2);
-	double dm1 = sqrt(fdm1);
-	double dm2 = sqrt(fdm2);
+	float_t fdm1 = SquaredDistance(Sender, scr1);
+	float_t fdm2 = SquaredDistance(Sender, scr2);
+	float_t fd12 = SquaredDistance(scr1, scr2);
+	float_t dm1 = std::sqrt(fdm1);
+	float_t dm2 = std::sqrt(fdm2);
 
 	if (fdm1>fdm2 || fd12>fdm2) {
 		return 0;
 	}
-	double angle = acos(( fdm2 + fdm1 - fd12 ) / (2*dm1*dm2));
+	float_t angle = acos(( fdm2 + fdm1 - fd12 ) / (2*dm1*dm2));
 	if (angle*180.0*M_PI<30.0) return 1;
 	return 0;
 }

--- a/gemrb/core/GameScript/Triggers.cpp
+++ b/gemrb/core/GameScript/Triggers.cpp
@@ -1574,7 +1574,7 @@ int GameScript::InLine(Scriptable *Sender, const Trigger *parameters)
 		return 0;
 	}
 	float_t angle = std::acos((fdm2 + fdm1 - fd12) / (2 * dm1 * dm2));
-	if (angle*180.0*M_PI<30.0) return 1;
+	if (angle * (180.0 / M_PI) < 30.0) return 1;
 	return 0;
 }
 

--- a/gemrb/core/GameScript/Triggers.cpp
+++ b/gemrb/core/GameScript/Triggers.cpp
@@ -1573,7 +1573,7 @@ int GameScript::InLine(Scriptable *Sender, const Trigger *parameters)
 	if (fdm1>fdm2 || fd12>fdm2) {
 		return 0;
 	}
-	float_t angle = acos(( fdm2 + fdm1 - fd12 ) / (2*dm1*dm2));
+	float_t angle = std::acos((fdm2 + fdm1 - fd12) / (2 * dm1 * dm2));
 	if (angle*180.0*M_PI<30.0) return 1;
 	return 0;
 }

--- a/gemrb/core/Geometry.cpp
+++ b/gemrb/core/Geometry.cpp
@@ -29,39 +29,39 @@ namespace GemRB {
 // with a maximum error of 0.1620 degrees
 // rcor's rational approximation that can be arbitrarily
 // improved if we ever want greater precision
-static float pseudoAtan2(float y, float x)
+static float_t pseudoAtan2(float_t y, float_t x)
 {
 	static const uint32_t signMask = 0x80000000;
-	static const float b = 0.596227F;
+	static const float_t b = 0.596227F;
 
 	// Extract the sign bits
 	uint32_t xS = signMask & (uint32_t&) x;
 	uint32_t yS = signMask & (uint32_t&) y;
 
 	// Determine the quadrant offset
-	float q = (float) ((~xS & yS) >> 29 | xS >> 30);
+	float_t q = float_t((~xS & yS) >> 29 | xS >> 30);
 
 	// Calculate the arctangent in the first quadrant
-	float bxy = std::fabs(b * x * y);
-	float num = bxy + y * y;
-	float atan1q = num / (x * x + bxy + num);
+	float_t bxy = std::fabs(b * x * y);
+	float_t num = bxy + y * y;
+	float_t atan1q = num / (x * x + bxy + num);
 
 	// Translate it to the proper quadrant
 	uint32_t uatan2q = (xS ^ yS) | (uint32_t&) atan1q;
-	return (q + (float&) uatan2q) * M_PI_2;
+	return (q + (float_t&) uatan2q) * M_PI_2;
 }
 
-double AngleFromPoints(float y, float x)
+float_t AngleFromPoints(float_t y, float_t x)
 {
 	return pseudoAtan2(y, x);
 }
 
-double AngleFromPoints(const Point& p1, const Point& p2, bool exact)
+float_t AngleFromPoints(const Point& p1, const Point& p2, bool exact)
 {
-	double xdiff = p1.x - p2.x;
-	double ydiff = p1.y - p2.y;
+	float_t xdiff = p1.x - p2.x;
+	float_t ydiff = p1.y - p2.y;
 
-	double angle;
+	float_t angle;
 	if (exact) {
 		angle = std::atan2(ydiff, xdiff);
 	} else {
@@ -70,7 +70,7 @@ double AngleFromPoints(const Point& p1, const Point& p2, bool exact)
 	return angle;
 }
 
-Point RotatePoint(const Point& p, double angle)
+Point RotatePoint(const Point& p, float_t angle)
 {
 	int newx = static_cast<int>(p.x * std::cos(angle) - p.y * std::sin(angle));
 	int newy = static_cast<int>(p.x * std::sin(angle) + p.y * std::cos(angle));

--- a/gemrb/core/Geometry.h
+++ b/gemrb/core/Geometry.h
@@ -29,9 +29,9 @@
 
 namespace GemRB {
 
-GEM_EXPORT double AngleFromPoints(const Point& p1, const Point& p2, bool exact = false);
-GEM_EXPORT double AngleFromPoints(float y, float x);
-GEM_EXPORT Point RotatePoint(const Point& p, double angle);
+GEM_EXPORT float_t AngleFromPoints(const Point& p1, const Point& p2, bool exact = false);
+GEM_EXPORT float_t AngleFromPoints(float_t y, float_t x);
+GEM_EXPORT Point RotatePoint(const Point& p, float_t angle);
 GEM_EXPORT unsigned int Distance(const Point &pos, const Point &pos2);
 GEM_EXPORT unsigned int SquaredDistance(const Point &pos, const Point &pos2);
 

--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -2533,10 +2533,10 @@ PathMapFlags Map::GetBlockedInLine(const Point &s, const Point &d, bool stopOnIm
 	PathMapFlags ret = PathMapFlags::IMPASSABLE;
 	Point p = s;
 	const SearchmapPoint sms = ConvertCoordToTile(s);
-	double factor = caller && caller->GetSpeed() ? double(gamedata->GetStepTime()) / double(caller->GetSpeed()) : 1;
+	float_t factor = caller && caller->GetSpeed() ? float_t(gamedata->GetStepTime()) / float_t(caller->GetSpeed()) : 1;
 	while (p != d) {
-		double dx = d.x - p.x;
-		double dy = d.y - p.y;
+		float_t dx = d.x - p.x;
+		float_t dy = d.y - p.y;
 		NormalizeDeltas(dx, dy, factor);
 		p.x += dx;
 		p.y += dy;

--- a/gemrb/core/Map.h
+++ b/gemrb/core/Map.h
@@ -430,7 +430,7 @@ private:
 public:
 	Map(TileMap *tm, TileProps tileProps, Holder<Sprite2D> sm);
 	~Map(void) override;
-	static void NormalizeDeltas(double &dx, double &dy, double factor = 1);
+	static void NormalizeDeltas(float_t &dx, float_t &dy, float_t factor = 1);
 	static Point ConvertCoordToTile(const Point&);
 	static Point ConvertCoordFromTile(const Point&);
 

--- a/gemrb/core/Orientation.h
+++ b/gemrb/core/Orientation.h
@@ -116,11 +116,11 @@ inline orient_t GetOrient(const Point& from, const Point& to)
 	if (!deltaX) return deltaY >= 0 ? S : N;
 
 	// reverse Y to match our game coordinate system
-	float angle = AngleFromPoints(-deltaY, deltaX);
+	float_t angle = AngleFromPoints(-deltaY, deltaX);
 
 	// calculate which segment the angle falls into and which orientation that represents
-	constexpr float M_PI_8 = M_PI / 8;
-	float segment = std::fmod(angle + M_PI_8 / 2 + 2 * M_PI, 2.0F * M_PI);
+	constexpr float_t M_PI_8 = M_PI / 8;
+	float_t segment = std::fmod(angle + M_PI_8 / 2 + 2 * M_PI, 2.0F * M_PI);
 	return PrevOrientation(E, int(segment / M_PI_8));
 }
 

--- a/gemrb/core/Palette.cpp
+++ b/gemrb/core/Palette.cpp
@@ -31,7 +31,7 @@ Palette::Palette(const Color &color, const Color &back) noexcept
 {
 	col[0] = Color(0, 0xff, 0, 0);
 	for (int i = 1; i < 256; i++) {
-		float p = i / 255.0f;
+		float_t p = i / 255.0f;
 		col[i].r = std::min<int>(back.r * (1 - p) + color.r * p, 255);
 		col[i].g = std::min<int>(back.g * (1 - p) + color.g * p, 255);
 		col[i].b = std::min<int>(back.b * (1 - p) + color.b * p, 255);

--- a/gemrb/core/Particles.cpp
+++ b/gemrb/core/Particles.cpp
@@ -183,7 +183,7 @@ void Particles::Draw(Point p)
 		int length; //used only for raindrops
 		if (state>=MAX_SPARK_PHASE) {
 			constexpr int maxDropLength = 6;
-			length = maxDropLength - abs(state - MAX_SPARK_PHASE - maxDropLength);
+			length = maxDropLength - std::abs(state - MAX_SPARK_PHASE - maxDropLength);
 			state = 0;
 		} else {
 			state=MAX_SPARK_PHASE-state-1;

--- a/gemrb/core/PathFinder.cpp
+++ b/gemrb/core/PathFinder.cpp
@@ -54,20 +54,20 @@ constexpr std::array<char, DEGREES_OF_FREEDOM> dxAdjacent{{1, 0, -1, 0}};
 constexpr std::array<char, DEGREES_OF_FREEDOM> dyAdjacent{{0, 1, 0, -1}};
 
 // Cosines
-constexpr std::array<double, RAND_DEGREES_OF_FREEDOM> dxRand{{0.000, -0.383, -0.707, -0.924, -1.000, -0.924, -0.707, -0.383, 0.000, 0.383, 0.707, 0.924, 1.000, 0.924, 0.707, 0.383}};
+constexpr std::array<float_t, RAND_DEGREES_OF_FREEDOM> dxRand{{0.000, -0.383, -0.707, -0.924, -1.000, -0.924, -0.707, -0.383, 0.000, 0.383, 0.707, 0.924, 1.000, 0.924, 0.707, 0.383}};
 // Sines
-constexpr std::array<double, RAND_DEGREES_OF_FREEDOM> dyRand{{1.000, 0.924, 0.707, 0.383, 0.000, -0.383, -0.707, -0.924, -1.000, -0.924, -0.707, -0.383, 0.000, 0.383, 0.707, 0.924}};
+constexpr std::array<float_t, RAND_DEGREES_OF_FREEDOM> dyRand{{1.000, 0.924, 0.707, 0.383, 0.000, -0.383, -0.707, -0.924, -1.000, -0.924, -0.707, -0.383, 0.000, 0.383, 0.707, 0.924}};
 
 // Find the best path of limited length that brings us the farthest from d
 PathListNode *Map::RunAway(const Point &s, const Point &d, unsigned int size, int maxPathLength, bool backAway, const Actor *caller) const
 {
 	if (!caller || !caller->GetSpeed()) return nullptr;
 	Point p = s;
-	double dx = s.x - d.x;
-	double dy = s.y - d.y;
+	float_t dx = s.x - d.x;
+	float_t dy = s.y - d.y;
 	char xSign = 1, ySign = 1;
 	size_t tries = 0;
-	NormalizeDeltas(dx, dy, double(gamedata->GetStepTime()) / caller->GetSpeed());
+	NormalizeDeltas(dx, dy, float_t(gamedata->GetStepTime()) / caller->GetSpeed());
 	if (std::abs(dx) <= 0.333 && std::abs(dy) <= 0.333) return nullptr;
 	while (SquaredDistance(p, s) < unsigned(maxPathLength * maxPathLength * SEARCHMAP_SQUARE_DIAGONAL * SEARCHMAP_SQUARE_DIAGONAL)) {
 		Point rad(std::lround(p.x + 3 * xSign * dx), std::lround(p.y + 3 * ySign * dy));
@@ -94,10 +94,10 @@ PathListNode *Map::RandomWalk(const Point &s, int size, int radius, const Actor 
 	if (!caller || !caller->GetSpeed()) return nullptr;
 	NavmapPoint p = s;
 	size_t i = RAND<size_t>(0, RAND_DEGREES_OF_FREEDOM - 1);
-	double dx = 3 * dxRand[i];
-	double dy = 3 * dyRand[i];
+	float_t dx = 3 * dxRand[i];
+	float_t dy = 3 * dyRand[i];
 
-	NormalizeDeltas(dx, dy, double(gamedata->GetStepTime()) / caller->GetSpeed());
+	NormalizeDeltas(dx, dy, float_t(gamedata->GetStepTime()) / caller->GetSpeed());
 	size_t tries = 0;
 	while (SquaredDistance(p, s) < unsigned(radius * radius * SEARCHMAP_SQUARE_DIAGONAL * SEARCHMAP_SQUARE_DIAGONAL)) {
 		if (!(GetBlockedInRadius(p + Point(dx, dy), size) & PathMapFlags::PASSABLE)) {
@@ -110,7 +110,7 @@ PathListNode *Map::RandomWalk(const Point &s, int size, int radius, const Actor 
 			i = RAND<size_t>(0, RAND_DEGREES_OF_FREEDOM - 1);
 			dx = 3 * dxRand[i];
 			dy = 3 * dyRand[i];
-			NormalizeDeltas(dx, dy, double(gamedata->GetStepTime()) / caller->GetSpeed());
+			NormalizeDeltas(dx, dy, float_t(gamedata->GetStepTime()) / caller->GetSpeed());
 			p = s;
 		} else {
 			p.x += dx;
@@ -149,7 +149,7 @@ PathListNode *Map::GetLine(const Point &start, int Steps, orient_t Orientation, 
 {
 	Point dest = start;
 
-	double xoff, yoff, mult;
+	float_t xoff, yoff, mult;
 	if (Orientation <= 4) {
 		xoff = -Orientation / 4.0;
 	} else if (Orientation <= 12) {
@@ -376,7 +376,7 @@ PathListNode *Map::FindPath(const Point &s, const Point &d, unsigned int size, u
 			if (childBlocked) continue;
 
 			// Weighted heuristic. Finds sub-optimal paths but should be quite a bit faster
-			const float HEURISTIC_WEIGHT = 1.5;
+			const float_t HEURISTIC_WEIGHT = 1.5;
 			SearchmapPoint smptCurrent2 = Map::ConvertCoordToTile(nmptCurrent);
 			NavmapPoint nmptParent = parents[smptCurrent2.y * mapSize.w + smptCurrent2.x];
 			unsigned short oldDist = distFromStart[smptChild.y * mapSize.w + smptChild.x];
@@ -405,9 +405,9 @@ PathListNode *Map::FindPath(const Point &s, const Point &d, unsigned int size, u
 				int dxCross = smptDest.x - smptSource.x;
 				int dyCross = smptDest.y - smptSource.y;
 				int crossProduct = std::abs(xDist * dyCross - yDist * dxCross) >> 3;
-				double distance = std::hypot(xDist, yDist);
-				double heuristic = HEURISTIC_WEIGHT * (distance + crossProduct);
-				double estDist = distFromStart[smptChild.y * mapSize.w + smptChild.x] + heuristic;
+				float_t distance = std::hypot(xDist, yDist);
+				float_t heuristic = HEURISTIC_WEIGHT * (distance + crossProduct);
+				float_t estDist = distFromStart[smptChild.y * mapSize.w + smptChild.x] + heuristic;
 				PQNode newNode(nmptChild, estDist);
 				open.emplace(newNode);
 			}
@@ -454,22 +454,22 @@ PathListNode *Map::FindPath(const Point &s, const Point &d, unsigned int size, u
 	return nullptr;
 }
 
-void Map::NormalizeDeltas(double &dx, double &dy, double factor)
+void Map::NormalizeDeltas(float_t &dx, float_t &dy, float_t factor)
 {
-	constexpr double STEP_RADIUS = 2.0;
+	constexpr float_t STEP_RADIUS = 2.0;
 
-	double ySign = std::copysign(1.0, dy);
-	double xSign = std::copysign(1.0, dx);
+	float_t ySign = std::copysign(1.0, dy);
+	float_t xSign = std::copysign(1.0, dx);
 	dx = std::fabs(dx);
 	dy = std::fabs(dy);
-	double dxOrig = dx;
-	double dyOrig = dy;
+	float_t dxOrig = dx;
+	float_t dyOrig = dy;
 	if (dx == 0.0) {
 		dy = STEP_RADIUS;
 	} else if (dy == 0.0) {
 		dx = STEP_RADIUS;
 	} else {
-		double q = STEP_RADIUS / std::hypot(dx, dy);
+		float_t q = STEP_RADIUS / std::hypot(dx, dy);
 		dx = dx * q;
 		dy = dy * q * 0.75f;
 	}

--- a/gemrb/core/PathFinder.h
+++ b/gemrb/core/PathFinder.h
@@ -86,11 +86,11 @@ enum {
 // to sort nodes by their (heuristic) distance from the destination
 class PQNode {
 public:
-	PQNode(Point p, double l) : point(p), dist(l) {};
+	PQNode(Point p, float_t l) : point(p), dist(l) {};
 	PQNode() : point(Point(0, 0)), dist(0) {};
 
 	Point point;
-	double dist;
+	float_t dist;
 
 	friend bool operator < (const PQNode &lhs, const PQNode &rhs) { return lhs.dist < rhs.dist;}
 	friend bool operator > (const PQNode &lhs, const PQNode &rhs){ return rhs < lhs; }

--- a/gemrb/core/Projectile.cpp
+++ b/gemrb/core/Projectile.cpp
@@ -871,7 +871,7 @@ void Projectile::SetTarget(ieDword tar, bool fake)
 		const Point& B = target->Pos;
 		float_t angle = AngleFromPoints(B, A);
 		float_t adjustedRange = Feet2Pixels(Range, angle);
-		Point C(A.x + adjustedRange * cos(angle), A.y + adjustedRange * sin(angle));
+		Point C(A.x + adjustedRange * std::cos(angle), A.y + adjustedRange * std::sin(angle));
 		SetTarget(C);
 	} else {
 		//replan the path in case the target moved

--- a/gemrb/core/Projectile.cpp
+++ b/gemrb/core/Projectile.cpp
@@ -869,8 +869,8 @@ void Projectile::SetTarget(ieDword tar, bool fake)
 	if (ExtFlags&PEF_CONTINUE) {
 		const Point& A = Origin;
 		const Point& B = target->Pos;
-		double angle = AngleFromPoints(B, A);
-		double adjustedRange = Feet2Pixels(Range, angle);
+		float_t angle = AngleFromPoints(B, A);
+		float_t adjustedRange = Feet2Pixels(Range, angle);
 		Point C(A.x + adjustedRange * cos(angle), A.y + adjustedRange * sin(angle));
 		SetTarget(C);
 	} else {
@@ -1046,7 +1046,7 @@ void Projectile::LineTarget(Path::const_iterator beg, Path::const_iterator end) 
 			if (!target->ValidTarget(targetFlags)) {
 				continue;
 			}
-			double t = 0.0;
+			float_t t = 0.0;
 			if (PersonalLineDistance(s, d, target, &t) > 1) {
 				continue;
 			}
@@ -1134,15 +1134,15 @@ void Projectile::SecondaryTarget()
 			if (Caster == targetID) {
 				continue;
 			}
-			double xdiff = actor->Pos.x - Pos.x;
-			double ydiff = Pos.y - actor->Pos.y;
+			float_t xdiff = actor->Pos.x - Pos.x;
+			float_t ydiff = Pos.y - actor->Pos.y;
 			int deg;
 
 			// a dragon will definitely be easier to hit than a mouse
 			// but nothing checks the personal space of possible targets in the original either #384
 			if (ydiff) {
 				// ensure [0,360] range: transform [-180,180] from atan2, but also take orientation correction factor into account
-				deg = (int) (std::atan2(ydiff, xdiff) * 180/M_PI);
+				deg = int(std::atan2(ydiff, xdiff) * 180 / M_PI);
 				deg = ((deg % 360) + 360 + degOffset) % 360;
 			} else if (xdiff < 0) {
 				deg = 180;
@@ -1485,7 +1485,7 @@ void Projectile::SpawnChild(size_t idx, bool firstExplosion, const Point& offset
 		add = (Orientation * 45 - max) / 2;
 	}
 	max = RAND(1, max) + add;
-	double degree = max * M_PI / 180;
+	float_t degree = max * M_PI / 180;
 	newdest.x = (int) -(rad * std::sin(degree));
 	newdest.y = (int) (rad * std::cos(degree));
 	newdest += Destination;
@@ -1750,29 +1750,29 @@ void Projectile::DrawLine(const Region& vp, orient_t face, BlitFlags flag)
 // adjust position for arcing paths
 void Projectile::BendPosition(Point& pos) const
 {
-	double total_distance = Distance(Origin, Destination);
-	double travelled_distance = Distance(Origin, Pos);
+	float_t total_distance = Distance(Origin, Destination);
+	float_t travelled_distance = Distance(Origin, Pos);
 
 	// distance travelled along the line, from 0.0 to 1.0
-	double travelled = travelled_distance / total_distance;
+	float_t travelled = travelled_distance / total_distance;
 	if (travelled > 1.0) {
 		Log(WARNING, "Projectile", "Travelled over full distance ({} = {} / {})! Origin: {}, Destination: {}, Pos: {}", travelled, travelled_distance, total_distance, Origin, Destination, Pos);
 		travelled = 1.0;
 	}
 
 	// input to sin(): 0 to pi gives us an arc
-	double arc_angle = travelled * M_PI;
+	float_t arc_angle = travelled * M_PI;
 
 	// calculate the distance between the arc and the current pos
 	// (this could use travelled and a larger constant multiplier,
 	// to make the arc size fixed rather than relative to the total
 	// distance to travel)
-	double length_of_normal = travelled_distance * std::sin(arc_angle) * 0.3 * ((bend / 2) + 1);
+	float_t length_of_normal = travelled_distance * std::sin(arc_angle) * 0.3 * ((bend / 2) + 1);
 	if (bend % 2) length_of_normal = -length_of_normal;
 
 	// adjust the to-be-rendered point by that distance
-	double x_vector = (Destination.x - Origin.x) / total_distance;
-	double y_vector = (Destination.y - Origin.y) / total_distance;
+	float_t x_vector = (Destination.x - Origin.x) / total_distance;
+	float_t y_vector = (Destination.y - Origin.y) / total_distance;
 	pos.x += y_vector * length_of_normal;
 	pos.y -= x_vector * length_of_normal;
 }
@@ -2062,7 +2062,7 @@ static Size GetEllipseSize(int circleSize)
 	ellipse.w = 2 * std::max(1, (circleSize - 1) * 8);
 	ellipse.h = static_cast<int>(ellipse.w * 0.6F); // NOTE: not quite 12/16!
 
-	float multiplier = EventMgr::TouchInputEnabled ? 1.4F : 1.1F;
+	float_t multiplier = EventMgr::TouchInputEnabled ? 1.4F : 1.1F;
 	ellipse.w *= multiplier;
 	ellipse.h *= multiplier;
 	return ellipse;

--- a/gemrb/core/RNG.h
+++ b/gemrb/core/RNG.h
@@ -72,7 +72,7 @@ class GEM_EXPORT RNG {
 		return signum * randomNum;
 	}
 	
-	bool randPct(double pct) noexcept {
+	bool randPct(float_t pct) noexcept {
 		std::bernoulli_distribution distribution(pct);
 		return distribution(engine);
 	}

--- a/gemrb/core/Region.cpp
+++ b/gemrb/core/Region.cpp
@@ -197,7 +197,7 @@ Point Region::Intercept(const Point& p) const noexcept
 	if (p.x == mid.x) return Point(p.x, (p.y < min.y) ? min.y : max.y); // vert line
 	if (p.y == mid.y) return Point((p.x < min.x) ? min.x : max.x, p.y); // horiz line
 
-	float m = float(mid.y - p.y) / float(mid.x - p.x);
+	float_t m = float_t(mid.y - p.y) / float_t(mid.x - p.x);
 
 	if (p.x <= mid.x) { // check "left" side
 		int newY = m * (min.x - p.x) + p.y;

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -545,7 +545,7 @@ void Actor::SetCircleSize()
 		return;
 
 	const GameControl *gc = core->GetGameControl();
-	float oscillationFactor = 1.0f;
+	float_t oscillationFactor = 1.0f;
 	Color color;
 	int normalIdx;
 	if (UnselectableTimer) {
@@ -563,7 +563,7 @@ void Actor::SetCircleSize()
 			 * Approximation: pulsating at about 2Hz over a notable radius growth.
 			 * Maybe check this relation for dragons and rats, too.
 			 */
-			oscillationFactor = 1.1F + float(std::sin(double(remainingTalkSoundTime) * (4 * M_PI) / 1000)) * 0.1F;
+			oscillationFactor = 1.1F + std::sin(double(remainingTalkSoundTime) * (4 * M_PI) / 1000) * 0.1F;
 		}
 	} else {
 		switch (Modified[IE_EA]) {

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -4405,11 +4405,11 @@ void Actor::DisplayCombatFeedback(unsigned int damage, int resisted, int damaget
 			HCStrings strref;
 			if (resisted < 0) {
 				//Takes <AMOUNT> <TYPE> damage from <DAMAGER> (<RESISTED> damage bonus)
-				SetTokenAsString("RESISTED", abs(resisted));
+				SetTokenAsString("RESISTED", std::abs(resisted));
 				strref = HCStrings::DamageDetail3;
 			} else if (resisted > 0) {
 				//Takes <AMOUNT> <TYPE> damage from <DAMAGER> (<RESISTED> damage resisted)
-				SetTokenAsString("RESISTED", abs(resisted));
+				SetTokenAsString("RESISTED", std::abs(resisted));
 				strref = HCStrings::DamageDetail2;
 			} else {
 				//Takes <AMOUNT> <TYPE> damage from <DAMAGER>
@@ -4917,7 +4917,7 @@ int Actor::GetWildMod(int level)
 	static int modRange = int(wmLevelMods.size());
 	WMLevelMod = wmLevelMods[core->Roll(1, modRange, -1)][level - 1];
 
-	SetTokenAsString("LEVELDIF", abs(WMLevelMod));
+	SetTokenAsString("LEVELDIF", std::abs(WMLevelMod));
 	if (core->HasFeedback(FT_STATES)) {
 		if (WMLevelMod > 0) {
 			displaymsg->DisplayConstantStringName(HCStrings::CasterLvlInc, GUIColors::WHITE, this);
@@ -5202,7 +5202,7 @@ void Actor::SendDiedTrigger() const
 		} else if (OfType(this, neighbour)) {
 			neighbour->SetBase(IE_MORALE, neighbour->GetBase(IE_MORALE) - 1);
 		// are we an enemy of neighbour, regardless if we're good or evil?
-		} else if (abs(ea - pea) > 30) {
+		} else if (std::abs(ea - pea) > 30) {
 			neighbour->NewBase(IE_MORALE, 2, MOD_ADDITIVE);
 		}
 	}
@@ -7134,7 +7134,7 @@ void Actor::PerformAttack(ieDword gameTime)
 		} else {
 			hitMiss = core->GetString(DisplayMessage::GetStringReference(HCStrings::Miss));
 		}
-		String rollLog = fmt::format(u"{} {} {} {} = {} : {}", leftRight, roll, (rollMod >= 0) ? u"+" : u"-", abs(rollMod), roll + rollMod, hitMiss);
+		String rollLog = fmt::format(u"{} {} {} {} = {} : {}", leftRight, roll, (rollMod >= 0) ? u"+" : u"-", std::abs(rollMod), roll + rollMod, hitMiss);
 		displaymsg->DisplayStringName(std::move(rollLog), GUIColors::WHITE, this);
 	}
 
@@ -7333,7 +7333,7 @@ void Actor::ModifyDamage(Scriptable *hitter, int &damage, int &resisted, int dam
 			} else {
 				int resistance = (signed)GetSafeStat(it->second.resist_stat);
 				// avoid buggy data
-				if ((unsigned)abs(resistance) > maximum_values[it->second.resist_stat]) {
+				if ((unsigned)std::abs(resistance) > maximum_values[it->second.resist_stat]) {
 					resistance = 0;
 					Log(DEBUG, "ModifyDamage", "Ignoring bad damage resistance value ({}).", resistance);
 				}
@@ -10313,8 +10313,8 @@ int Actor::LuckyRoll(int dice, int size, int add, ieDword flags, const Actor* op
 
 	if (dice > 100) {
 		int bonus;
-		if (abs(luck) > size) {
-			bonus = luck/abs(luck) * size;
+		if (std::abs(luck) > size) {
+			bonus = luck / std::abs(luck) * size;
 		} else {
 			bonus = luck;
 		}

--- a/gemrb/core/Scriptable/CombatInfo.cpp
+++ b/gemrb/core/Scriptable/CombatInfo.cpp
@@ -54,7 +54,7 @@ static void SetBonusInternal(int& current, int bonus, int mod)
 					newBonus = tmp;
 				} // else leave it be at the current value
 			} else {
-				if (abs(tmp) > abs(current)) {
+				if (std::abs(tmp) > std::abs(current)) {
 					newBonus = tmp;
 				} // else leave it be at the current value
 			}

--- a/gemrb/core/Scriptable/Scriptable.cpp
+++ b/gemrb/core/Scriptable/Scriptable.cpp
@@ -1650,7 +1650,7 @@ void Selectable::DrawCircle(const Point& p) const
 	if (sprite) {
 		VideoDriver->BlitSprite(sprite, Pos - p);
 	} else {
-		float baseSize = CircleSize2Radius() * sizeFactor;
+		auto baseSize = CircleSize2Radius() * sizeFactor;
 		const Size s(baseSize * 8, baseSize * 6);
 		const Region r(Pos - p - s.Center(), s);
 		VideoDriver->DrawEllipse(r, *col);
@@ -1695,7 +1695,7 @@ void Selectable::Select(int Value)
 	}
 }
 
-void Selectable::SetCircle(int circlesize, float factor, const Color &color, Holder<Sprite2D> normal_circle, Holder<Sprite2D> selected_circle)
+void Selectable::SetCircle(int circlesize, float_t factor, const Color &color, Holder<Sprite2D> normal_circle, Holder<Sprite2D> selected_circle)
 {
 	circleSize = circlesize;
 	sizeFactor = factor;
@@ -2078,9 +2078,9 @@ void Movable::DoStep(unsigned int walkScale, ieDword time) {
 
 	if (time > timeStartStep) {
 		Point nmptStep = step->point;
-		double dx = nmptStep.x - Pos.x;
-		double dy = nmptStep.y - Pos.y;
-		Map::NormalizeDeltas(dx, dy, double(gamedata->GetStepTime()) / double(walkScale));
+		float_t dx = nmptStep.x - Pos.x;
+		float_t dy = nmptStep.y - Pos.y;
+		Map::NormalizeDeltas(dx, dy, float_t(gamedata->GetStepTime()) / float_t(walkScale));
 		if (dx == 0 && dy == 0) {
 			// probably shouldn't happen, but it does when running bg2's cut28a set of cutscenes
 			ClearPath(true);
@@ -2094,8 +2094,8 @@ void Movable::DoStep(unsigned int walkScale, ieDword time) {
 		// and not be blocked by actors who are on the sides
 		int collisionLookaheadRadius = ((circleSize < 3 ? 3 : circleSize) - 1) * 3;
 		for (int r = collisionLookaheadRadius; r > 0 && !actorInTheWay; r--) {
-			double xCollision = Pos.x + dx * r;
-			double yCollision = Pos.y + dy * r * 0.75;
+			auto xCollision = Pos.x + dx * r;
+			auto yCollision = Pos.y + dy * r * 0.75;
 			Point nmptCollision(xCollision, yCollision);
 			actorInTheWay = area->GetActor(nmptCollision, GA_NO_DEAD|GA_NO_UNSCHEDULED|GA_NO_SELF, this);
 		}

--- a/gemrb/core/Scriptable/Scriptable.h
+++ b/gemrb/core/Scriptable/Scriptable.h
@@ -436,7 +436,7 @@ public:
 	Color overColor = ColorBlack;
 	Holder<Sprite2D> circleBitmap[2] = {};
 	int circleSize = 0;
-	float sizeFactor = 1.0f;
+	float_t sizeFactor = 1.0f;
 public:
 	void SetBBox(const Region &newBBox);
 	void DrawCircle(const Point& p) const;
@@ -444,7 +444,7 @@ public:
 	void SetOver(bool over);
 	bool IsSelected() const;
 	void Select(int Value);
-	void SetCircle(int size, float, const Color &color, Holder<Sprite2D> normal_circle, Holder<Sprite2D> selected_circle);
+	void SetCircle(int size, float_t, const Color &color, Holder<Sprite2D> normal_circle, Holder<Sprite2D> selected_circle);
 	int CircleSize2Radius() const;
 };
 

--- a/gemrb/includes/globals.h
+++ b/gemrb/includes/globals.h
@@ -158,8 +158,8 @@ GEM_EXPORT unsigned int SquaredDistance(const Scriptable *a, const Scriptable *b
 GEM_EXPORT unsigned int PersonalDistance(const Scriptable *a, const Scriptable *b);
 GEM_EXPORT unsigned int SquaredPersonalDistance(const Scriptable *a, const Scriptable *b);
 GEM_EXPORT unsigned int SquaredMapDistance(const Scriptable *a, const Scriptable *b);
-GEM_EXPORT unsigned int PersonalLineDistance(const Point &v, const Point &w, const Scriptable *s, double *proj);
-GEM_EXPORT double Feet2Pixels(int feet, double angle);
+GEM_EXPORT unsigned int PersonalLineDistance(const Point& v, const Point& w, const Scriptable* s, float_t* proj);
+GEM_EXPORT float_t Feet2Pixels(int feet, float_t angle);
 GEM_EXPORT bool WithinAudibleRange(const Actor *actor, const Point &dest);
 GEM_EXPORT bool WithinRange(const Scriptable *actor, const Point &dest, int distance);
 GEM_EXPORT bool WithinPersonalRange(const Scriptable *actor, const Point &dest, int distance);

--- a/gemrb/plugins/BIKPlayer/BIKPlayer.cpp
+++ b/gemrb/plugins/BIKPlayer/BIKPlayer.cpp
@@ -508,7 +508,7 @@ void BIKPlayer::DecodeBlock(short *out)
 
 		for (unsigned int i = 0; i < s_num_bands; i++) {
 			int value = s_gb.get_bits(8);
-			quant[i] = (float) pow(10.0, std::min(value, 95) * 0.066399999) * s_root;
+			quant[i] = (float)std::pow(10.0, std::min(value, 95) * 0.066399999) * s_root;
 		}
 
 		// find band (k)

--- a/gemrb/plugins/BIKPlayer/rdft.cpp
+++ b/gemrb/plugins/BIKPlayer/rdft.cpp
@@ -66,7 +66,7 @@ av_cold int ff_rdft_init(RDFTContext *s, int nbits, enum RDFTransformType trans)
     s->tcos = ff_cos_tabs[nbits];
     s->tsin = ff_sin_tabs[nbits]+(trans == RDFT || trans == IRIDFT)*(n>>2);
     for (int i = 0; i < (n>>2); i++) {
-        s->tsin[i] = (float) sin(i*theta);
+        s->tsin[i] = (float)std::sin(i*theta);
     }
     return 0;
 }

--- a/gemrb/plugins/SDLVideo/SDLSurfaceDrawing.h
+++ b/gemrb/plugins/SDLVideo/SDLSurfaceDrawing.h
@@ -275,7 +275,7 @@ void DrawLineSurface(SDL_Surface* surface, const Point& start, const Point& end,
 	bool yLonger = false;
 	int shortLen = p2.y - p1.y;
 	int longLen = p2.x - p1.x;
-	if (abs( shortLen ) > abs( longLen )) {
+	if (std::abs(shortLen) > std::abs(longLen)) {
 		std::swap(shortLen, longLen);
 		yLonger = true;
 	}


### PR DESCRIPTION
## Description
we should be using `float_t` for math operations since we don't care about scientific precision. This allows the compiler to select the native floating point type for the architecture.

additionally, we should always use `std` for invoking math functions to use an appropriate overload that can be reduced to a compiler builtin suitable for the native arch. non `std` math functions are the `C` functions with only one signature and probably cant always get inlined.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
