### PR TITLE
Fix against severe FPS drops by scrollbar 

### DIFF
--- a/gemrb/core/GUI/View.cpp
+++ b/gemrb/core/GUI/View.cpp
@@ -173,7 +173,7 @@ Regions View::DirtySuperViewRegions() const
 	// if we are opaque we cover everything and dont care about the superview
 	// if we arent but we need to redraw then we simply report our entire area
 
-	if (IsOpaque()) {
+	if (IsOpaque() || frame.size.IsInvalid()) {
 		return {};
 	}
 


### PR DESCRIPTION
## Description
I noticed that opening some text sections, like a mildly filled journal or dialogs, drops FPS by up to 75%. 

That is because 382ed935c7c4d54a882b21abd9431744db767511 checks whether invisibility is set to get a background redraw of something after turning invisible. Problem: scrollbars may be invisible by design, so that neighbouring content view is marked dirty and thus it draws fonts over and over again, even if nothing actually requires redrawing.

I made `ScrollBar` exempt from counting for this invisibility check, not sure if the name suits well but I still can't come up with any better one.


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
