### PR TITLE
Fixes around save game directories

### DIFF
--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -2976,7 +2976,7 @@ void Interface::DelTree(const path_t& path, bool onlysave) const
 		const path_t& name = dir.GetName();
 		if (!onlysave || SavedExtension(name) ) {
 			path_t dtmp = dir.GetFullPath();
-			unlink(dtmp.c_str());
+			UnlinkFile(dtmp);
 		}
 	} while (++dir);
 }
@@ -3573,7 +3573,7 @@ int Interface::SwapoutArea(Map *map) const
 {
 	auto RemoveFromCache = [&](const ResRef& resref, SClass_ID classID) {
 		path_t filename = PathJoinExt(config.CachePath, resref, TypeExt(classID));
-		unlink(filename.c_str());
+		UnlinkFile(filename);
 	};
 
 	//refuse to save ambush areas, for example

--- a/gemrb/core/SaveGameIterator.cpp
+++ b/gemrb/core/SaveGameIterator.cpp
@@ -718,7 +718,7 @@ void SaveGameIterator::DeleteSaveGame(const Holder<SaveGame>& game) const
 	}
 
 	core->DelTree(game->GetPath(), false); //remove all files from folder
-	rmdir(game->GetPath().c_str());
+	RemoveDirectory(game->GetPath());
 }
 
 }

--- a/gemrb/core/System/VFS.h
+++ b/gemrb/core/System/VFS.h
@@ -150,6 +150,9 @@ void* readonly_mmap(void *fd);
 void munmap(void *start, size_t);
 #endif
 
+GEM_EXPORT bool RemoveDirectory(const path_t& path);
+GEM_EXPORT bool UnlinkFile(const path_t& path);
+
 class GEM_EXPORT DirectoryIterator {
 public:
 	enum Flags {

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -4417,7 +4417,7 @@ static PyObject* GemRB_SaveGame(PyObject * /*self*/, PyObject * args)
 	if (slot == -1) {
 		CObject<SaveGame> save(obj);
 
-		return PyLong_FromLong(sgip->CreateSaveGame(save, PyString_AsStringView(folder)));
+		return PyLong_FromLong(sgip->CreateSaveGame(save, PyString_AsStringObj(folder)));
 	} else {
 		return PyLong_FromLong(sgip->CreateSaveGame(slot, core->config.MultipleQuickSaves));
 	}


### PR DESCRIPTION
## Description
Some issues fixed I encountered earlier today:

1. Crash when saving with non-ASCII characters since code path used open setting `SystemEncoding` when everything else is expected UTF-8 regarding paths for now, so invalid bytes.
1. Underlying VFS fixes on Windows after that was fixed.
1. Cannot delete directories on Windows with non-ASCII chars from FS.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
