### PR TITLE
WEDImporter: getting rid of float math

### DIFF
--- a/gemrb/plugins/WEDImporter/WEDImporter.cpp
+++ b/gemrb/plugins/WEDImporter/WEDImporter.cpp
@@ -376,7 +376,19 @@ std::vector<WallPolygonGroup> WEDImporter::GetWallGroups() const
 		str->ReadWord(idx);
 	}
 
-	size_t groupSize = ceilf(overlays[0].size.w / 10.0f) * ceilf(overlays[0].size.h / 7.5f);
+	auto ceilInt = [](int32_t v, int32_t div) {
+		if (v % div == 0) {
+			return v / div;
+		}
+
+		return (v + (div - (v % div))) / div;
+	};
+
+	// was error-prone w.r.t. IEEE754 optimization: ceilf(overlays[0].size.w / 10.0f) * ceilf(overlays[0].size.h / 7.5f)
+	auto w = overlays[0].size.w;
+	auto h = overlays[0].size.h * 2;
+	size_t groupSize = ceilInt(w, 10) * ceilInt(h, 15);
+
 	std::vector<WallPolygonGroup> polygonGroups;
 	polygonGroups.reserve(groupSize);
 


### PR DESCRIPTION
## Description
Similar to #1790, #2104, Clang on Raspberry Pi will warn that `-frounding-math` is not supported on this platform, and the same crash will happen again.

So instead of this annoying flag handling, let's get rid of this `ceilf` here.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
