### PR TITLE
CMakeLists: removes `SDL_RESOLUTION_INDEPENDANCE`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,6 @@ OPTION(DISABLE_WERROR "Do not treat warnings as errors" OFF)
 OPTION(USE_TRACY "Build with Tracy support" OFF)
 
 OPTION(USE_SDL_CONTROLLER_API "Enable SDL controller APIs. (disable if you plan on handling controller input in an external program like gptokeyb)" ON)
-OPTION(SDL_RESOLUTION_INDEPENDANCE "Scale the window to the size of the screen with pixel scaling." OFF)
 
 #VCPKG dll deployment is circumvented because it doesn't currently work for gemrb
 IF(WIN32 AND _VCPKG_INSTALLED_DIR)

--- a/cmake/cmake_config.h.in
+++ b/cmake/cmake_config.h.in
@@ -22,5 +22,4 @@
 #cmakedefine SUPPORTS_MEMSTREAM ${SUPPORTS_MEMSTREAM}
 #cmakedefine BAKE_ICON 1
 #cmakedefine USE_SDL_CONTROLLER_API 1
-#cmakedefine SDL_RESOLUTION_INDEPENDANCE 1
 #endif

--- a/gemrb.6.in
+++ b/gemrb.6.in
@@ -40,6 +40,11 @@ settings in the engine configuration file below. A full install is recommended.
 Disable audio completely, regardless of supported audio plugins.
 
 .TP
+.BI \-f
+Start in full screen. Try this if the game window suffers from bad aspect ratio. Otherwise
+just switch to your preference in the game's video options.
+
+.TP
 .BI \-c " FILE"
 Use the specified configuration file
 .IR FILE " instead"

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -408,6 +408,10 @@ Interface::Interface(CoreSettings&& cfg)
 			throw CIE("Cannot initialize shaders.");
 		}
 		VideoDriver->SetGamma(brightness, contrast);
+
+		if (config.FullScreen) {
+			VideoDriver->SetFullscreenMode(true);
+		}
 	}
 
 	// We use this for the game's state exclusively

--- a/gemrb/core/InterfaceConfig.cpp
+++ b/gemrb/core/InterfaceConfig.cpp
@@ -167,6 +167,7 @@ CoreSettings LoadFromDictionary(InterfaceConfig cfg)
 	CONFIG_INT("DoubleClickDelay", config.DoubleClickDelay);
 	CONFIG_INT("DrawFPS", config.DrawFPS);
 	CONFIG_INT("CapFPS", config.CapFPS);
+	CONFIG_INT("FullScreen", config.FullScreen);
 	CONFIG_INT("EnableCheatKeys", config.CheatFlag);
 	CONFIG_INT("GCDebug", config.DebugFlags);
 	CONFIG_INT("GUIEnhancements", config.GUIEnhancements);
@@ -342,6 +343,8 @@ CoreSettings LoadFromArgs(int argc, char *argv[])
 		} else if (stricmp(argv[i], "-q") == 0) {
 			// quiet mode
 			settings.Set("AudioDriver", "none");
+		} else if (stricmp(argv[i], "-f") == 0) {
+			settings.Set("FullScreen", "1");
 		} else if (stricmp(argv[i], "--color") == 0) {
 			if (i < argc - 1) settings.Set("LogColor", argv[++i]);
 		} else {

--- a/gemrb/core/InterfaceConfig.h
+++ b/gemrb/core/InterfaceConfig.h
@@ -94,6 +94,7 @@ struct CoreSettings {
 	int Bpp = 32;
 	bool DrawFPS = false;
 	int CapFPS = 0;
+	bool FullScreen = false;
 	bool SpriteFoW = false;
 	uint32_t debugMode = 0;
 	bool Logging = true;

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -148,25 +148,7 @@ int SDL20VideoDriver::CreateSDLDisplay(const char* title, bool vsync)
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
 #endif
 
-
-#ifdef SDL_RESOLUTION_INDEPENDANCE
-	SDL_DisplayMode current;
-
-	int should_be_zero = SDL_GetCurrentDisplayMode(0, &current);
-
-	if (should_be_zero != 0) {
-		Log(ERROR, "SDL 2 Driver", "couldnt get resolution: {}", SDL_GetError());
-		return GEM_ERROR;
-	}
-
-	Log(DEBUG, "SDL 2 Driver", "Game Resolution: {}x{}, Screen Resolution: {}x{}",
-		screenSize.w, screenSize.h, current.w, current.h);
-	window = SDL_CreateWindow(title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, current.w, current.h, winFlags);
-#else
-
 	window = SDL_CreateWindow(title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, screenSize.w, screenSize.h, winFlags);
-#endif
-
 	if (window == NULL) {
 		Log(ERROR, "SDL 2 Driver", "couldnt create window: {}", SDL_GetError());
 		return GEM_ERROR;


### PR DESCRIPTION
## Description
It appears that the original intent of this macro was never validated, and I've noticed that choosing _Full screen_ at the in-game options makes no difference to this code path. Can be tested by starting GemRB from TTY on a Wayland computer with something like a full HD screen.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
