### PR TITLE
GAMImporter: fixes PST variable special case when saving

### DIFF
--- a/gemrb/plugins/GAMImporter/GAMImporter.cpp
+++ b/gemrb/plugins/GAMImporter/GAMImporter.cpp
@@ -730,18 +730,13 @@ int GAMImporter::PutVariables(DataStream *stream, const Game *game) const
 	for (const auto& entry : game->locals) {
 		//global variables are locals for game, that's why the local/global confusion
 
-		/* PST hates to have some variables lowercased. */
-		if (core->HasFeature(GFFlags::NO_NEW_VARIABLES)) {
-			/* This is one anomaly that must have a space injected (PST crashes otherwise). */
-			if (entry.first == "dictionary_githzerai_hjacknir") {
-				tmpname = "DICTIONARY_GITHZERAI_ HJACKNIR";
-			} else {
-				tmpname = MakeVariable(entry.first);
-			}
-		} else {
-			tmpname = MakeVariable(entry.first);
+		tmpname = MakeVariable(entry.first);
+		/* This is one anomaly that must have a space injected (PST crashes otherwise). */
+		if (tmpname == "dictionary_githzerai_hjacknir") {
+			tmpname = "DICTIONARY_GITHZERAI_ HJACKNIR";
 		}
 
+		/* PST hates to have some variables lowercased. */
 		stream->WriteVariableUC(tmpname);
 		stream->WriteFilling(8);
 		stream->WriteDword(entry.second);


### PR DESCRIPTION
## Description
As reported by https://github.com/gemrb/gemrb/issues/1404#issuecomment-1966478997 PST original crashes again when loading one of our save games. Not sure when it broke but `MakeVariable` removes that critical whitespace from this variable, and the old fix did not do much help anymore.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
