### PR TITLE
AREImporter fix for IWD2

### DIFF
--- a/gemrb/plugins/AREImporter/AREImporter.cpp
+++ b/gemrb/plugins/AREImporter/AREImporter.cpp
@@ -602,7 +602,8 @@ void AREImporter::GetInfoPoint(DataStream* str, int idx, Map* map) const
 	if (16 == map->version) {
 		str->ReadPoint(pos); // OverridePoint in NI
 		if (pos.IsZero()) {
-			str->ReadPoint(pos); // AlternatePoint in NI
+			str->ReadScalar(pos.x); // AlternatePoint in NI
+			str->ReadScalar(pos.y);
 		} else {
 			str->Seek(8, GEM_CURRENT_POS);
 		}


### PR DESCRIPTION
## Description
See #2137. 

So ARE1000 has _alternate_ trigger points set (2x 4B) but we did `ReadPoint` that reads 2x 2B. Thus the Y value got lost and trigger points didn't work.

IESDP should maybe be updated, too, since it's both incomplete and doesn't match NI naming.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
