### PR TITLE
Palettes, shadows and blending

### DIFF
--- a/gemrb/CMakeLists.txt
+++ b/gemrb/CMakeLists.txt
@@ -176,7 +176,9 @@ ENDIF(VITA)
 # Tests
 IF (BUILD_TESTING)
   ADD_EXECUTABLE(Test_gemrb_core
+    tests/core/Test_MurmurHash.cpp
     tests/core/Test_Orient.cpp
+    tests/core/Test_Palette.cpp
     tests/core/Streams/Test_DataStream.cpp
     tests/core/Strings/Test_CString.cpp
     tests/core/Strings/Test_String.cpp

--- a/gemrb/core/CMakeLists.txt
+++ b/gemrb/core/CMakeLists.txt
@@ -36,6 +36,7 @@ FILE(GLOB gemrb_core_LIB_SRCS
 	Map.cpp
 	MapReverb.cpp
 	MoviePlayer.cpp
+	MurmurHash.cpp
 	Palette.cpp
 	PalettedImageMgr.cpp
 	Particles.cpp

--- a/gemrb/core/CharAnimations.cpp
+++ b/gemrb/core/CharAnimations.cpp
@@ -2801,6 +2801,8 @@ void CharAnimations::PulseRGBModifiers()
 
 static inline void applyMod(const Color& src, Color& dest, const RGBModifier& mod) noexcept
 {
+	dest.a = src.a;
+
 	if (mod.speed == -1) {
 		if (mod.type == RGBModifier::TINT) {
 			dest.r = ((unsigned int)src.r * mod.rgb.r)>>8;

--- a/gemrb/core/CharAnimations.cpp
+++ b/gemrb/core/CharAnimations.cpp
@@ -543,7 +543,7 @@ void CharAnimations::SetupColors(PaletteType type)
 		*/
 		for (int i = 0; i < colorcount; i++) {
 			const auto& pal32 = core->GetPalette32(static_cast<uint8_t>(Colors[i]));
-			PartPalettes[PAL_MAIN]->CopyColorRange(&pal32[0], &pal32[32], static_cast<uint8_t>(dest));
+			PartPalettes[PAL_MAIN]->CopyColors(dest, &pal32[0], &pal32[32]);
 			dest +=size;
 		}
 
@@ -2885,66 +2885,73 @@ Palette SetupRGBModification(const Holder<Palette>& src, const RGBModifier* mods
 	unsigned int type) noexcept
 {
 	Palette pal;
+	Palette::Colors buffer;
 
 	const RGBModifier* tmods = mods+(8*type);
 	int i;
 
-	for (i = 0; i < 4; ++i)
-		pal.col[i] = src->col[i];
+	std::copy(src->cbegin(), src->cbegin() + 4, buffer.begin());
+	auto srcData = src->ColorData();
 
 	for (i = 0; i < 12; ++i)
-		applyMod(src->col[0x04+i], pal.col[0x04+i], tmods[0]);
+		applyMod(srcData[0x04+i], buffer[0x04+i], tmods[0]);
 	for (i = 0; i < 12; ++i)
-		applyMod(src->col[0x10+i], pal.col[0x10+i], tmods[1]);
+		applyMod(srcData[0x10+i], buffer[0x10+i], tmods[1]);
 	for (i = 0; i < 12; ++i)
-		applyMod(src->col[0x1c+i], pal.col[0x1c+i], tmods[2]);
+		applyMod(srcData[0x1c+i], buffer[0x1c+i], tmods[2]);
 	for (i = 0; i < 12; ++i)
-		applyMod(src->col[0x28+i], pal.col[0x28+i], tmods[3]);
+		applyMod(srcData[0x28+i], buffer[0x28+i], tmods[3]);
 	for (i = 0; i < 12; ++i)
-		applyMod(src->col[0x34+i], pal.col[0x34+i], tmods[4]);
+		applyMod(srcData[0x34+i], buffer[0x34+i], tmods[4]);
 	for (i = 0; i < 12; ++i)
-		applyMod(src->col[0x40+i], pal.col[0x40+i], tmods[5]);
+		applyMod(srcData[0x40+i], buffer[0x40+i], tmods[5]);
 	for (i = 0; i < 12; ++i)
-		applyMod(src->col[0x4c+i], pal.col[0x4c+i], tmods[6]);
+		applyMod(srcData[0x4c+i], buffer[0x4c+i], tmods[6]);
 	for (i = 0; i < 8; ++i)
-		applyMod(src->col[0x58+i], pal.col[0x58+i], tmods[1]);
+		applyMod(srcData[0x58+i], buffer[0x58+i], tmods[1]);
 	for (i = 0; i < 8; ++i)
-		applyMod(src->col[0x60+i], pal.col[0x60+i], tmods[2]);
+		applyMod(srcData[0x60+i], buffer[0x60+i], tmods[2]);
 	for (i = 0; i < 8; ++i)
-		applyMod(src->col[0x68+i], pal.col[0x68+i], tmods[1]);
+		applyMod(srcData[0x68+i], buffer[0x68+i], tmods[1]);
 	for (i = 0; i < 8; ++i)
-		applyMod(src->col[0x70+i], pal.col[0x70+i], tmods[0]);
+		applyMod(srcData[0x70+i], buffer[0x70+i], tmods[0]);
 	for (i = 0; i < 8; ++i)
-		applyMod(src->col[0x78+i], pal.col[0x78+i], tmods[4]);
+		applyMod(srcData[0x78+i], buffer[0x78+i], tmods[4]);
 	for (i = 0; i < 8; ++i)
-		applyMod(src->col[0x80+i], pal.col[0x80+i], tmods[4]);
+		applyMod(srcData[0x80+i], buffer[0x80+i], tmods[4]);
 	for (i = 0; i < 8; ++i)
-		applyMod(src->col[0x88+i], pal.col[0x88+i], tmods[1]);
+		applyMod(srcData[0x88+i], buffer[0x88+i], tmods[1]);
 	for (i = 0; i < 24; ++i)
-		applyMod(src->col[0x90+i], pal.col[0x90+i], tmods[4]);
+		applyMod(srcData[0x90+i], buffer[0x90+i], tmods[4]);
+
+	std::copy(src->cbegin() + 0xA8, src->cbegin() + 0xA8 + 8, buffer.begin() + 0xA8);
 
 	for (i = 0; i < 8; ++i)
-		pal.col[0xA8+i] = src->col[0xA8+i];
-
-	for (i = 0; i < 8; ++i)
-		applyMod(src->col[0xB0+i], pal.col[0xB0+i], tmods[3]);
+		applyMod(srcData[0xB0+i], buffer[0xB0+i], tmods[3]);
 	for (i = 0; i < 72; ++i)
-		applyMod(src->col[0xB8+i], pal.col[0xB8+i], tmods[4]);
-	
+		applyMod(srcData[0xB8+i], buffer[0xB8+i], tmods[4]);
+
+	pal.CopyColors(0, buffer.cbegin(), buffer.cend());
+
 	return pal;
 }
 
 Palette SetupGlobalRGBModification(const Holder<Palette>& src, const RGBModifier& mod) noexcept
 {
 	Palette pal;
+	Palette::Colors buffer;
+
+	auto srcData = src->ColorData();
 	// don't modify the transparency and shadow colour
 	for (int i = 0; i < 2; ++i) {
-		pal.col[i] = src->col[i];
+		buffer[i] = srcData[i];
 	}
 
 	for (int i = 2; i < 256; ++i) {
-		applyMod(src->col[i], pal.col[i], mod);
+		applyMod(srcData[i], buffer[i], mod);
 	}
+
+	pal.CopyColors(0, buffer.cbegin(), buffer.cend());
 
 	return pal;
 }
@@ -2954,6 +2961,7 @@ Palette SetupPaperdollColours(const ieDword* colors, unsigned int type) noexcept
 	unsigned int s = Clamp<ieDword>(8*type, 0, 8*sizeof(ieDword)-1);
 	constexpr uint8_t numCols = 12;
 	Palette pal;
+	Palette::Colors buffer;
 
 	enum PALETTES : uint8_t
 	{
@@ -2963,38 +2971,40 @@ Palette SetupPaperdollColours(const ieDword* colors, unsigned int type) noexcept
 
 	for (uint8_t idx = METAL; idx < END; ++idx) {
 		const auto& pal16 = core->GetPalette16(colors[idx]>>s);
-		pal.CopyColorRange(&pal16[0], &pal16[numCols], 0x04 + (idx * 12));
+		std::copy(&pal16[0], &pal16[numCols], buffer.begin() + 0x04 + (idx * 12));
 	}
 	
 	//minor
-	memcpy(&pal.col[0x58], &pal.col[0x11], 8 * sizeof(Color));
+	memcpy(&buffer[0x58], &buffer[0x11], 8 * sizeof(Color));
 	//major
-	memcpy(&pal.col[0x60], &pal.col[0x1d], 8 * sizeof(Color));
+	memcpy(&buffer[0x60], &buffer[0x1d], 8 * sizeof(Color));
 	//minor
-	memcpy(&pal.col[0x68], &pal.col[0x11], 8 * sizeof(Color));
+	memcpy(&buffer[0x68], &buffer[0x11], 8 * sizeof(Color));
 	//metal
-	memcpy(&pal.col[0x70], &pal.col[0x05], 8 * sizeof(Color));
+	memcpy(&buffer[0x70], &buffer[0x05], 8 * sizeof(Color));
 	//leather
-	memcpy(&pal.col[0x78], &pal.col[0x35], 8 * sizeof(Color));
+	memcpy(&buffer[0x78], &buffer[0x35], 8 * sizeof(Color));
 	//leather
-	memcpy(&pal.col[0x80], &pal.col[0x35], 8 * sizeof(Color));
+	memcpy(&buffer[0x80], &buffer[0x35], 8 * sizeof(Color));
 	//minor
-	memcpy(&pal.col[0x88], &pal.col[0x11], 8 * sizeof(Color));
+	memcpy(&buffer[0x88], &buffer[0x11], 8 * sizeof(Color));
 
 	for (int i = 0x90; i < 0xA8; i += 0x08) {
 		//leather
-		memcpy(&pal.col[i], &pal.col[0x35], 8 * sizeof(Color));
+		memcpy(&buffer[i], &buffer[0x35], 8 * sizeof(Color));
 	}
 
 	//skin
-	memcpy(&pal.col[0xB0], &pal.col[0x29], 8 * sizeof(Color));
+	memcpy(&buffer[0xB0], &buffer[0x29], 8 * sizeof(Color));
 
 	for (int i = 0xB8; i < 0xFF; i += 0x08) {
 		//leather
-		memcpy(&pal.col[i], &pal.col[0x35], 8 * sizeof(Color));
+		memcpy(&buffer[i], &buffer[0x35], 8 * sizeof(Color));
 	}
 
-	pal.col[1] = Color(0, 0, 0, 128); // shadows are always half trans black
+	buffer[1] = Color(0, 0, 0, 255); // shadows, will be half-trans'ed when required
+
+	pal.CopyColors(0, buffer.cbegin(), buffer.cend());
 	return pal;
 }
 

--- a/gemrb/core/GUI/TextSystem/Font.cpp
+++ b/gemrb/core/GUI/TextSystem/Font.cpp
@@ -146,11 +146,16 @@ void Font::GlyphAtlasPage::Draw(ieWord chr, const Region& dest, const PrintColor
 		if (font->background) {
 			invertedSheet = Sheet->copy();
 			auto invertedPalette = MakeHolder<Palette>(*font->palette);
-			for (auto& c : invertedPalette->col) {
+
+			Palette::Colors buffer;
+			for (size_t i = 0; i < buffer.size(); ++i) {
+				auto c = invertedPalette->GetColorAt(i);
 				c.r = 255 - c.r;
 				c.g = 255 - c.g;
 				c.b = 255 - c.b;
+				buffer[i] = c;
 			}
+			invertedPalette->CopyColors(0, buffer.cbegin(), buffer.cend());
 			invertedSheet->SetPalette(invertedPalette);
 		}
 	}

--- a/gemrb/core/GameData.cpp
+++ b/gemrb/core/GameData.cpp
@@ -151,9 +151,8 @@ Holder<Palette> GameData::GetPalette(const ResRef& resname)
 		return NULL;
 	}
 
-	Holder<Palette> palette = MakeHolder<Palette>();
-	im->GetPalette(256,palette->col);
-	palette->named=true;
+	Holder<Palette> palette = MakeHolder<Palette>(true);
+	im->GetPalette(256, *palette);
 	PaletteCache[resname] = palette;
 	return palette;
 }

--- a/gemrb/core/ImageMgr.cpp
+++ b/gemrb/core/ImageMgr.cpp
@@ -26,7 +26,7 @@ namespace GemRB {
 
 const TypeID ImageMgr::ID = { "ImageMgr" };
 
-int ImageMgr::GetPalette(int /*colors*/, Color* /*pal*/)
+int ImageMgr::GetPalette(int /*colors*/, Palette& /*pal*/)
 {
 	return -1;
 }

--- a/gemrb/core/ImageMgr.h
+++ b/gemrb/core/ImageMgr.h
@@ -47,11 +47,11 @@ public:
 	 * Returns image palette.
 	 *
 	 * @param[in] colors Number of colors to return.
-	 * @param[out] pal Array to fill with colors.
+	 * @param[out] pal Palette to fill with colors.
 	 *
 	 * This does nothing if there is no palette.
 	 */
-	virtual int GetPalette(int colors, Color* pal);
+	virtual int GetPalette(int colors, Palette& pal);
 	
 	Size GetSize() const { return size; }
 

--- a/gemrb/core/MurmurHash.cpp
+++ b/gemrb/core/MurmurHash.cpp
@@ -1,0 +1,61 @@
+/* GemRB - Infinity Engine Emulator
+* Copyright (C) 2024 The GemRB Project
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+*/
+
+#include "MurmurHash.h"
+
+namespace GemRB {
+
+MurmurHash::MurmurHash(uint32_t v) : value(v) {}
+
+bool MurmurHash::operator==(const MurmurHash& other) const {
+	return value == other.value;
+}
+
+bool MurmurHash::operator!=(const MurmurHash& other) const {
+	return !operator==(other);
+}
+
+bool MurmurHash::operator==(uint32_t other) const {
+	return value == other;
+}
+
+void MurmurHash3_32::Feed(uint32_t value) {
+	value *= 0xCC9E2D51;
+	value = (value << 15) | (value >> 17);
+	value *= 0x1B873593;
+
+	state ^= value;
+	state = (state << 13) | (state >> 19);
+	state = state * 5 + 0xE6546B64;
+	calls++;
+}
+
+MurmurHash MurmurHash3_32::GetHash() const {
+	uint32_t hash = state;
+	hash ^= calls * 4;
+	hash ^= hash >> 16;
+	hash *= 0x85EBCA6B;
+	hash ^= hash >> 13;
+	hash *= 0xC2B2AE35;
+	hash ^= hash >> 16;
+
+	return {hash};
+}
+
+}

--- a/gemrb/core/MurmurHash.h
+++ b/gemrb/core/MurmurHash.h
@@ -1,0 +1,55 @@
+/* GemRB - Infinity Engine Emulator
+* Copyright (C) 2024 The GemRB Project
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+*/
+
+#ifndef H_GEMRB_MURMUR_HASH
+#define H_GEMRB_MURMUR_HASH
+
+#include <cstdint>
+
+#include "exports.h"
+
+namespace GemRB {
+
+struct GEM_EXPORT MurmurHash {
+	uint32_t value = 0;
+
+	MurmurHash() {};
+	MurmurHash(uint32_t value);
+	bool operator==(const MurmurHash& other) const;
+	bool operator!=(const MurmurHash& other) const;
+	bool operator==(uint32_t value) const;
+};
+
+class GEM_EXPORT MurmurHash3_32 {
+	public:
+		MurmurHash3_32() {};
+
+		void Feed(uint32_t value);
+		MurmurHash GetHash() const;
+	private:
+		uint32_t state = 0;
+		uint32_t calls = 0;
+};
+
+using Hasher = MurmurHash3_32;
+using Hash = MurmurHash;
+
+}
+
+#endif

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -8322,22 +8322,20 @@ void Actor::Draw(const Region& vp, Color baseTint, Color tint, BlitFlags flags) 
 		}
 
 		if (!currentStance.shadow.empty()) {
-			const Game* game = core->GetGame();
-			// infravision, independent of light map and global light
-			if (HasBodyHeat() &&
-				game->PartyHasInfravision() &&
-				!game->IsDay() &&
-				(area->AreaType & AT_OUTDOOR) && !(area->AreaFlags & AF_DREAM)) {
-				Color irTint = Color(255, 120, 120, tint.a);
-
-				/* IWD2: infravision is white, not red. */
-				if(core->HasFeature(GFFlags::RULES_3ED)) {
-					irTint = Color(255, 255, 255, tint.a);
-				}
-
-				DrawActorSprite(drawPos, flags, currentStance.shadow, irTint);
-			} else {
 				DrawActorSprite(drawPos, flags, currentStance.shadow, tint);
+		}
+
+		const Game* game = core->GetGame();
+		// infravision, independent of light map and global light
+		if (HasBodyHeat() &&
+			game->PartyHasInfravision() &&
+			!game->IsDay() &&
+			(area->AreaType & AT_OUTDOOR) && !(area->AreaFlags & AF_DREAM)) {
+			tint = Color(255, 120, 120, tint.a);
+
+			/* IWD2: infravision is white, not red. */
+			if(core->HasFeature(GFFlags::RULES_3ED)) {
+				tint = Color(255, 255, 255, tint.a);
 			}
 		}
 

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -429,7 +429,7 @@ void Actor::SetAnimationID(stat_t animID)
 		// Take ownership so the palette won't be deleted
 		if (recover) {
 			paletteResRef = anims->PaletteResRef[PAL_MAIN];
-			if (recover->named) {
+			if (recover->IsNamed()) {
 				recover = gamedata->GetPalette(paletteResRef);
 			}
 		}
@@ -7864,8 +7864,11 @@ void Actor::DrawActorSprite(const Point& p, BlitFlags flags,
 	
 	if (!anims->lockPalette) {
 		flags |= BlitFlags::COLOR_MOD;
+
+		if (tint.a < 255) {
+			flags |= BlitFlags::ALPHA_MOD;
+		}
 	}
-	flags |= BlitFlags::ALPHA_MOD;
 
 	for (const auto& part : animParts) {
 		const Animation* anim = part.first;
@@ -7873,11 +7876,11 @@ void Actor::DrawActorSprite(const Point& p, BlitFlags flags,
 
 		Holder<Sprite2D> currentFrame = anim->CurrentFrame();
 		if (currentFrame) {
-			if (TranslucentShadows && palette) {
-				ieByte tmpa = palette->col[1].a;
-				palette->col[1].a /= 2;
+			if (palette) {
+				auto shadowColor = palette->GetColorAt(1);
+				shadowColor.a = TranslucentShadows ? 128 : 255;
+				palette->SetColor(1, shadowColor);
 				VideoDriver->BlitGameSpriteWithPalette(currentFrame, palette, p, flags, tint);
-				palette->col[1].a = tmpa;
 			} else {
 				VideoDriver->BlitGameSpriteWithPalette(currentFrame, palette, p, flags, tint);
 			}

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -8233,7 +8233,7 @@ void Actor::Draw(const Region& vp, Color baseTint, Color tint, BlitFlags flags) 
 	} else if (State & STATE_BLUR) {
 		//can't move this, because there is permanent blur state where
 		//there is no effect (just state bit)
-		trans = 128;
+		trans = 160;
 	}
 
 	tint.a = 255 - trans;

--- a/gemrb/core/Scriptable/Container.cpp
+++ b/gemrb/core/Scriptable/Container.cpp
@@ -65,10 +65,10 @@ void Container::Draw(bool highlight, const Region& vp, Color tint, BlitFlags fla
 		} else {
 			const Color trans;
 			Holder<Palette> p = icon->GetPalette();
-			Color tmpc = p->col[1];
-			p->CopyColorRange(&trans, &trans + 1, 1);
+			Color tmpc = p->GetColorAt(1);
+			p->SetColor(1, trans);
 			VideoDriver->BlitGameSprite(icon, Pos - vp.origin, flags, tint);
-			p->CopyColorRange(&tmpc, &tmpc + 1, 1);
+			p->SetColor(1, tmpc);
 		}
 	}
 }

--- a/gemrb/core/Sprite2D.h
+++ b/gemrb/core/Sprite2D.h
@@ -117,7 +117,7 @@ public:
 
 	virtual const void* LockSprite() const;
 	virtual void* LockSprite();
-	virtual void UnlockSprite() const {};
+	virtual void UnlockSprite() {};
 
 	const PixelFormat& Format() const noexcept { return format; }
 	Color GetPixel(const Point&) const noexcept;

--- a/gemrb/core/Video/Pixels.cpp
+++ b/gemrb/core/Video/Pixels.cpp
@@ -182,18 +182,20 @@ void PixelFormatIterator::ReadRGBA(uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& 
 		case 2:
 			pixel = *static_cast<uint16_t*>(imp->pixel);
 			break;
-		case 1:
+		case 1: {
 			pixel = *static_cast<uint8_t*>(imp->pixel);
-			r = format.palette->col[pixel].r;
-			g = format.palette->col[pixel].g;
-			b = format.palette->col[pixel].b;
+			auto& c = format.palette->GetColorAt(pixel);
+			r = c.r;
+			g = c.g;
+			b = c.b;
 
 			if (format.HasColorKey && pixel == format.ColorKey) {
 				a = 0;
 			} else {
-				a = format.palette->col[pixel].a;
+				a = c.a;
 			}
 			return;
+		}
 		default:
 			ERROR_UNKNOWN_BPP;
 	}

--- a/gemrb/plugins/AREImporter/AREImporter.cpp
+++ b/gemrb/plugins/AREImporter/AREImporter.cpp
@@ -262,7 +262,7 @@ static TileProps MakeTileProps(const TileMap* tm, const ResRef& wedref, bool day
 		}
 		
 		if (hmit.clip.PointInside(pos)) {
-			b = hmpal->col[*hmit].r; // pick any channel, they are all the same
+			b = hmpal->GetColorAt(*hmit).r; // pick any channel, they are all the same
 			++hmit;
 		}
 		

--- a/gemrb/plugins/BAMImporter/BAMImporter.cpp
+++ b/gemrb/plugins/BAMImporter/BAMImporter.cpp
@@ -120,8 +120,10 @@ bool BAMImporter::Import(DataStream* str)
 
 	str->Seek( PaletteOffset, GEM_STREAM_START );
 	palette = MakeHolder<Palette>();
+	Palette::Colors buffer;
+
 	// no need to switch this
-	for (auto& color : palette->col) {
+	for (auto& color : buffer) {
 		// bgra format
 		str->Read(&color.b, 1);
 		str->Read(&color.g, 1);
@@ -132,6 +134,7 @@ bool BAMImporter::Import(DataStream* str)
 		// BAM v2 (EEs) supports alpha, but for backwards compatibility an alpha of 0 is still 255
 		color.a = a ? a : 255;
 	}
+	palette->CopyColors(0, buffer.cbegin(), buffer.cend());
 
 	return true;
 }

--- a/gemrb/plugins/BMPImporter/BMPImporter.cpp
+++ b/gemrb/plugins/BMPImporter/BMPImporter.cpp
@@ -249,7 +249,7 @@ Holder<Sprite2D> BMPImporter::GetSprite2D()
 		spr->UnlockSprite();
 	} else if (BitCount == 8) {
 		Holder<Palette> pal = MakeHolder<Palette>(PaletteColors, PaletteColors + NumColors);
-		PixelFormat fmt = PixelFormat::Paletted8Bit(pal, pal->col[0] == ColorGreen, 0);
+		PixelFormat fmt = PixelFormat::Paletted8Bit(pal, pal->GetColorAt(0) == ColorGreen, 0);
 		spr = VideoDriver->CreateSprite(Region(0,0, size.w, size.h), nullptr, fmt);
 		const uint8_t* src = static_cast<uint8_t*>(pixels);
 		const uint8_t* end = src + size.Area();
@@ -262,18 +262,21 @@ Holder<Sprite2D> BMPImporter::GetSprite2D()
 	return spr;
 }
 
-int BMPImporter::GetPalette(int colors, Color* pal)
+int BMPImporter::GetPalette(int colors, Palette& pal)
 {
 	if (BitCount > 8) {
 		return ImageMgr::GetPalette(colors, pal);
 	}
 
+	Palette::Colors buffer;
 	for (int i = 0; i < colors; i++) {
-		pal[i].r = PaletteColors[i % NumColors].r;
-		pal[i].g = PaletteColors[i % NumColors].g;
-		pal[i].b = PaletteColors[i % NumColors].b;
-		pal[i].a = 0xff;
+		buffer[i].r = PaletteColors[i % NumColors].r;
+		buffer[i].g = PaletteColors[i % NumColors].g;
+		buffer[i].b = PaletteColors[i % NumColors].b;
+		buffer[i].a = 0xff;
 	}
+
+	pal.CopyColors(0, buffer.cbegin(), buffer.cbegin() + colors);
 	return -1;
 }
 

--- a/gemrb/plugins/BMPImporter/BMPImporter.h
+++ b/gemrb/plugins/BMPImporter/BMPImporter.h
@@ -53,7 +53,7 @@ public:
 	bool Import(DataStream* stream) override;
 	Holder<Sprite2D> GetSprite2D() override;
 	Holder<Sprite2D> GetSprite2D(Region&&) override { return {}; }
-	int GetPalette(int colors, Color* pal) override;
+	int GetPalette(int colors, Palette& pal) override;
 
 private:
 	void Read8To8(const void *rpixels);

--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -3631,7 +3631,7 @@ static PyObject* SetButtonBAM(Button* btn, StringView ResRef, AnimationFactory::
 
 		Holder<Palette> newpal = MakeHolder<Palette>(*Picture->GetPalette());
 		const auto& pal16 = core->GetPalette16(static_cast<uint8_t>(col1));
-		newpal->CopyColorRange(&pal16[0],&pal16[12], 4);
+		newpal->CopyColors(4, &pal16[0],&pal16[12]);
 		Picture->SetPalette( newpal );
 	}
 

--- a/gemrb/plugins/MVEPlayer/MVEPlayer.cpp
+++ b/gemrb/plugins/MVEPlayer/MVEPlayer.cpp
@@ -45,9 +45,9 @@ MVEPlay::MVEPlay() noexcept
 	g_palette = MakeHolder<Palette>();
 
 	// these colors don't change
-	g_palette->col[0] = ColorBlack;
+	g_palette->SetColor(1, ColorBlack);
 	//Set color 255 to be our subtitle color
-	g_palette->col[255] = Color(50,50,50,255);
+	g_palette->SetColor(255, Color(50,50,50,255));
 }
 
 bool MVEPlay::Import(DataStream* str)
@@ -94,12 +94,14 @@ void MVEPlay::showFrame(const unsigned char* buf, unsigned int bufw, unsigned in
 void MVEPlay::setPalette(unsigned char* p, unsigned start, unsigned count) const
 {
 	p = p + (start * 3);
+	Palette::Colors buffer;
 	for (unsigned int i = start; i < start+count; i++) {
-		g_palette->col[i].r = ( *p++ ) << 2;
-		g_palette->col[i].g = ( *p++ ) << 2;
-		g_palette->col[i].b = ( *p++ ) << 2;
-		g_palette->col[i].a = 0xff;
+		buffer[i].r = ( *p++ ) << 2;
+		buffer[i].g = ( *p++ ) << 2;
+		buffer[i].b = ( *p++ ) << 2;
+		buffer[i].a = 0xff;
 	}
+	g_palette->CopyColors(start, buffer.cbegin() + start, buffer.cbegin() + start + count);
 }
 
 int MVEPlay::setAudioStream() const

--- a/gemrb/plugins/PNGImporter/PNGImporter.h
+++ b/gemrb/plugins/PNGImporter/PNGImporter.h
@@ -41,7 +41,7 @@ public:
 	bool Import(DataStream* stream) override;
 	Holder<Sprite2D> GetSprite2D() override;
 	Holder<Sprite2D> GetSprite2D(Region&&) override { return {}; };
-	int GetPalette(int colors, Color* pal) override;
+	int GetPalette(int colors, Palette& pal) override;
 };
 
 }

--- a/gemrb/plugins/PVRZImporter/PVRZImporter.cpp
+++ b/gemrb/plugins/PVRZImporter/PVRZImporter.cpp
@@ -382,7 +382,7 @@ Holder<Sprite2D> PVRZImporter::getSprite2DDXT5(Region&& region) const {
 	return {spr};
 }
 
-int PVRZImporter::GetPalette(int, Color*) {
+int PVRZImporter::GetPalette(int, Palette&) {
 	return -1;
 }
 

--- a/gemrb/plugins/PVRZImporter/PVRZImporter.h
+++ b/gemrb/plugins/PVRZImporter/PVRZImporter.h
@@ -44,7 +44,7 @@ public:
 	bool Import(DataStream* stream) override;
 	Holder<Sprite2D> GetSprite2D() override;
 	Holder<Sprite2D> GetSprite2D(Region&&) override;
-	int GetPalette(int colors, Color* pal) override;
+	int GetPalette(int colors, Palette& pal) override;
 
 private:
 	std::tuple<uint16_t, uint16_t> extractPalette(size_t offset, std::array<uint8_t, 6>& colors) const;

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -441,7 +441,7 @@ void SDL20VideoDriver::BlitSpriteNativeClipped(SDL_Texture* texSprite, const Reg
 			SDL_SetTextureAlphaMod(ScratchBuffer(), alpha);
 		}
 		SDL_SetRenderTarget(renderer, CurrentRenderBuffer());
-		SDL_SetTextureBlendMode(ScratchBuffer(), SDL_BLENDMODE_BLEND);
+		SetTextureBlendMode(ScratchBuffer(), flags);
 		ret = SDL_RenderCopy(renderer, ScratchBuffer(), &drect, &drect);
 	} else {
 		UpdateRenderTarget();
@@ -586,7 +586,16 @@ int SDL20VideoDriver::RenderCopyShaded(SDL_Texture* texture, const SDL_Rect* src
 	} else {
 		SDL_SetTextureColorMod(texture, 0xff, 0xff, 0xff);
 	}
-	
+
+	SetTextureBlendMode(texture, flags);
+
+	SDL_RendererFlip flipflags = (flags & BlitFlags::MIRRORY) ? SDL_FLIP_VERTICAL : SDL_FLIP_NONE;
+	flipflags = static_cast<SDL_RendererFlip>(flipflags | ((flags & BlitFlags::MIRRORX) ? SDL_FLIP_HORIZONTAL : SDL_FLIP_NONE));
+
+	return SDL_RenderCopyEx(renderer, texture, srcrect, dstrect, 0.0, nullptr, flipflags);
+}
+
+void SDL20VideoDriver::SetTextureBlendMode(SDL_Texture *texture, BlitFlags flags) const {
 	if (flags & BlitFlags::ADD) {
 		SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_ADD);
 	} else if (flags & BlitFlags::MOD) {
@@ -606,11 +615,6 @@ int SDL20VideoDriver::RenderCopyShaded(SDL_Texture* texture, const SDL_Rect* src
 	} else {
 		SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_NONE);
 	}
-
-	SDL_RendererFlip flipflags = (flags & BlitFlags::MIRRORY) ? SDL_FLIP_VERTICAL : SDL_FLIP_NONE;
-	flipflags = static_cast<SDL_RendererFlip>(flipflags | ((flags & BlitFlags::MIRRORX) ? SDL_FLIP_HORIZONTAL : SDL_FLIP_NONE));
-
-	return SDL_RenderCopyEx(renderer, texture, srcrect, dstrect, 0.0, nullptr, flipflags);
 }
 
 void SDL20VideoDriver::DrawRawGeometry(

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -393,19 +393,7 @@ int SDL20VideoDriver::UpdateRenderTarget(const Color* color, BlitFlags flags)
 
 void SDL20VideoDriver::BlitSpriteNativeClipped(const SDLTextureSprite2D* spr, const Region& src, const Region& dst, BlitFlags flags, const SDL_Color* tint)
 {
-	BlitFlags version = BlitFlags::NONE;
-#if !USE_OPENGL_BACKEND
-	// we need to isolate flags that require software rendering to use as the "version"
-	version = (BlitFlags::GREY | BlitFlags::SEPIA) & flags;
-#endif
-	// WARNING: software fallback == slow
-	if (spr->Format().Bpp == 1 && (flags & BlitFlags::ALPHA_MOD)) {
-		version |= BlitFlags::ALPHA_MOD;
-		flags &= ~spr->RenderWithFlags(version, reinterpret_cast<const Color*>(tint));
-	} else {
-		flags &= ~spr->RenderWithFlags(version);
-	}
-
+	flags &= ~spr->PrepareForRendering(flags, reinterpret_cast<const Color*>(tint));
 	SDL_Texture* tex = spr->GetTexture(renderer);
 	BlitSpriteNativeClipped(tex, src, dst, flags, tint);
 }

--- a/gemrb/plugins/SDLVideo/SDL20Video.h
+++ b/gemrb/plugins/SDLVideo/SDL20Video.h
@@ -177,7 +177,7 @@ public:
 
 			const Uint8* src = static_cast<const Uint8*>(pixelBuf);
 			for (int xy = 0; xy < bufDest.w * bufDest.h; ++xy) {
-				const Color& c = pal->col[*src++];
+				const Color& c = pal->GetColorAt(*src++);
 				*dst++ = (c.r << pxfmt->Rshift) | (c.g << pxfmt->Gshift) | (c.b << pxfmt->Bshift) | (c.a << pxfmt->Ashift);
 				if (hasalpha == false) {
 					dst = (Uint32*)((Uint8*)dst - 1);

--- a/gemrb/plugins/SDLVideo/SDL20Video.h
+++ b/gemrb/plugins/SDLVideo/SDL20Video.h
@@ -285,6 +285,7 @@ private:
 	void BlitSpriteNativeClipped(SDL_Texture* spr, const Region& src, const Region& dst, BlitFlags flags = BlitFlags::NONE, const SDL_Color* tint = NULL);
 
 	int RenderCopyShaded(SDL_Texture*, const SDL_Rect* srcrect, const SDL_Rect* dstrect, BlitFlags flags, const SDL_Color* = nullptr);
+	void SetTextureBlendMode(SDL_Texture *texture, BlitFlags flags) const;
 
 	int GetTouchFingers(TouchEvent::Finger(&fingers)[FINGER_MAX], SDL_TouchID device) const;
 

--- a/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.cpp
+++ b/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.cpp
@@ -50,8 +50,6 @@ SDLSurfaceSprite2D::SDLSurfaceSprite2D (const Region& rgn, void* px, const Pixel
 	UpdateColorKey();
 	
 	format = PixelFormatForSurface(surface, format.palette);
-	
-	renderedSurface = surface;
 }
 
 SDLSurfaceSprite2D::SDLSurfaceSprite2D (const Region& rgn, const PixelFormat& fmt) noexcept
@@ -61,29 +59,22 @@ SDLSurfaceSprite2D::SDLSurfaceSprite2D (const Region& rgn, const PixelFormat& fm
 SDLSurfaceSprite2D::SDLSurfaceSprite2D(const SDLSurfaceSprite2D &obj) noexcept
 : SDLSurfaceSprite2D(obj.Frame, nullptr, obj.format)
 {
-	SDL_BlitSurface(obj.surface, nullptr, surface, nullptr);
 	renderFlags = obj.renderFlags;
+	appliedBlitFlags = obj.appliedBlitFlags;
+	appliedTint = obj.appliedTint;
+	surfaceInvalidated = obj.surfaceInvalidated;
+	palVersion = obj.palVersion;
+	if (obj.shadedPalette) {
+		shadedPalette = MakeHolder<Palette>(*obj.shadedPalette);
+	}
+	shadedPaletteVersion = obj.shadedPaletteVersion;
+
+	SDL_BlitSurface(obj.surface, nullptr, surface, nullptr);
 }
 
 SDLSurfaceSprite2D::~SDLSurfaceSprite2D() noexcept
 {
-	if (renderedSurface != surface) {
-		SDL_FreeSurface(renderedSurface);
-	}
 	SDL_FreeSurface(surface);
-}
-
-void SDLSurfaceSprite2D::UpdateSurfacePalette() const noexcept
-{
-	assert (format.Depth <= 8);
-	
-	const auto& pal = format.palette;
-	SDLVideoDriver::SetSurfacePalette(surface, reinterpret_cast<const SDL_Color*>(pal->col), 0x01 << format.Depth);
-#if SDL_VERSION_ATLEAST(1,3,0)
-	// must reset the color key or SDL 2 won't render properly
-	SDL_SetColorKey(surface, SDL_bool(format.HasColorKey), GetColorKey());
-#endif
-	palVersion = pal->GetVersion();
 }
 
 Holder<Sprite2D> SDLSurfaceSprite2D::copy() const
@@ -103,27 +94,14 @@ void* SDLSurfaceSprite2D::LockSprite()
 	return surface->pixels;
 }
 
-void SDLSurfaceSprite2D::UnlockSprite() const
+void SDLSurfaceSprite2D::UnlockSprite()
 {
 	SDL_UnlockSurface(surface);
 	Invalidate();
 }
 
-bool SDLSurfaceSprite2D::IsPaletteStale() const noexcept
-{
-	// a 'version' implies tha palette was color modified
-	// however, the only caller her is RenderWithFlags
-	// where we already compare the version with the requested one
-	// the version includes the color modification so for now we dont worry about it
-	
-	const Holder<Palette>& pal = format.palette;
-	assert(pal);
-	return pal->GetVersion() != palVersion;
-}
-
-void SDLSurfaceSprite2D::UpdatePalette() noexcept
-{
-	Invalidate();
+void SDLSurfaceSprite2D::Invalidate() noexcept {
+	surfaceInvalidated = true;
 }
 
 void SDLSurfaceSprite2D::UpdateColorKey() noexcept
@@ -172,7 +150,8 @@ bool SDLSurfaceSprite2D::ConvertFormatTo(const PixelFormat& tofmt) noexcept
 			surface = ns;
 			format = PixelFormatForSurface(ns);
 			if (ns->format->palette) {
-				UpdateSurfacePalette();
+				UpdatePaletteForSurface(*format.palette);
+				palVersion = format.palette->GetVersion();
 			}
 			return true;
 		} else {
@@ -188,97 +167,122 @@ bool SDLSurfaceSprite2D::ConvertFormatTo(const PixelFormat& tofmt) noexcept
 	return false;
 }
 
-void SDLSurfaceSprite2D::Invalidate() const noexcept
-{
-	version = 0;
-	if (renderedSurface != surface) {
-		SDL_FreeSurface(renderedSurface);
-		renderedSurface = surface;
-	}
-	if (format.Depth <= 8) {
-		UpdateSurfacePalette();
+void SDLSurfaceSprite2D::EnsureShadedPalette() const noexcept {
+	if (!shadedPalette) {
+		shadedPalette = MakeHolder<Palette>();
 	}
 }
 
-void* SDLSurfaceSprite2D::NewVersion(version_t newversion) const noexcept
-{
-	if (newversion == 0 || version != newversion) {
-		Invalidate();
-		version = newversion;
+void SDLSurfaceSprite2D::ShadePalette(BlitFlags renderflags, const Color* tint) const noexcept {
+	Palette::Colors buffer;
+
+	for (size_t i = 1; i < 256; ++i) {
+		buffer[i] = format.palette->GetColorAt(i);
+
+		if (renderflags&BlitFlags::COLOR_MOD) {
+			ShaderTint(*tint, buffer[i]);
+		}
+
+		if (renderflags & BlitFlags::ALPHA_MOD) {
+			buffer[i].a = tint->a;
+		}
+
+		if (renderflags&BlitFlags::GREY) {
+			ShaderGreyscale(buffer[i]);
+		} else if (renderflags&BlitFlags::SEPIA) {
+			ShaderSepia(buffer[i]);
+		}
 	}
 
-	if (format.Bpp == 1) {
-		// we just allow overwriting the palette
-		return surface->format->palette;
-	}
-
-	palVersion = 0;
-
-	if (version != newversion) {
-		renderedSurface = SDL_ConvertSurface(surface, surface->format, 0);
-	}
-	return renderedSurface;
+	shadedPalette->CopyColors(1, buffer.cbegin() + 1, buffer.cend());
 }
-	
-BlitFlags SDLSurfaceSprite2D::RenderWithFlags(BlitFlags renderflags, const Color* tint) const noexcept
+
+bool SDLSurfaceSprite2D::NeedToUpdatePalette() const noexcept {
+	return format.palette && palVersion != format.palette->GetVersion();
+}
+
+bool SDLSurfaceSprite2D::NeedToReshade(const Color* tint, BlitFlags flags) const noexcept {
+	return flags != appliedBlitFlags
+		|| surfaceInvalidated
+		|| NeedToUpdatePalette()
+		|| ((flags & BlitFlags::COLOR_MOD) && tint && (appliedTint.Packed() & 0xFFFFFF00) != (tint->Packed() & 0xFFFFFF00))
+		|| ((flags & BlitFlags::ALPHA_MOD) && tint && (appliedTint.Packed() & 0xFF) != (tint->Packed() & 0xFF));
+}
+
+BlitFlags SDLSurfaceSprite2D::PrepareForRendering(BlitFlags renderflags, const Color* tint) const noexcept
 {
-	SDLSurfaceSprite2D::version_t oldVersion = version;
-	SDLSurfaceSprite2D::version_t newVersion = renderflags;
-	auto ret = (BlitFlags::GREY | BlitFlags::SEPIA) & newVersion;
-	
-	if (format.Bpp == 1) {
+	// Non-paletted surfaces can only have their pixels changed: refresh texture
+	if (format.Bpp > 1) {
+		if (surfaceInvalidated) {
+			OnSurfaceUpdate();
+			surfaceInvalidated = false;
+		}
+
+		// All surface operations to be done by SDL
+		return BlitFlags::NONE;
+	}
+
+	auto blitFlags = (BlitFlags::GREY | BlitFlags::SEPIA) & renderflags;
+	if (tint) {
+		blitFlags |= (BlitFlags::COLOR_MOD | BlitFlags::ALPHA_MOD) & renderflags;
+	}
+
+	// Something has changed/is new?
+	if (NeedToReshade(tint, blitFlags)) {
+		// modifiers for shaded version of palette/surface?
+		if (blitFlags) {
+			EnsureShadedPalette();
+			ShadePalette(blitFlags, tint);
+		}
+
+		bool flagsChanged = blitFlags != appliedBlitFlags;
+		surfaceInvalidated = false;
+		appliedBlitFlags = blitFlags;
 		if (tint) {
-			assert(renderflags & (BlitFlags::COLOR_MOD | BlitFlags::ALPHA_MOD));
-			uint64_t tintv = *reinterpret_cast<const uint32_t*>(tint);
-			newVersion |= tintv << 32;
+			appliedTint = *tint;
 		}
-		
-		if (oldVersion != newVersion || IsPaletteStale()) {
-			SDL_Palette* pal = static_cast<SDL_Palette*>(NewVersion(newVersion));
 
-			for (size_t i = 1; i < 256; ++i) {
-				Color& dstc = reinterpret_cast<Color&>(pal->colors[i]);
-
-				if (renderflags&BlitFlags::COLOR_MOD) {
-					assert(tint);
-					ShaderTint(*tint, dstc);
-					ret |= BlitFlags::COLOR_MOD;
-				}
-				
-				if (renderflags & BlitFlags::ALPHA_MOD) {
-					assert(tint);
-					dstc.a = tint->a;
-					ret |= BlitFlags::ALPHA_MOD;
-				}
-
-				if (renderflags&BlitFlags::GREY) {
-					ShaderGreyscale(dstc);
-				} else if (renderflags&BlitFlags::SEPIA) {
-					ShaderSepia(dstc);
-				}
-			}
-		} else {
-			ret |= (BlitFlags::COLOR_MOD | BlitFlags::ALPHA_MOD) & newVersion;
-		}
-	} else if (oldVersion != newVersion) {
-		SDL_Surface* newV = (SDL_Surface*)NewVersion(newVersion);
-		SDL_LockSurface(newV);
-
-		const Region& r = {0, 0, newV->w, newV->h};
-		SDLPixelIterator beg = MakeSDLPixelIterator(newV, r);
-		SDLPixelIterator end = SDLPixelIterator::end(beg);
-		StaticAlphaIterator alpha(0xff);
-
-		if (renderflags & BlitFlags::GREY) {
-			RGBBlendingPipeline<SHADER::GREYSCALE, true> blender;
-			Blit(beg, beg, end, alpha, blender);
-		} else if (renderflags & BlitFlags::SEPIA) {
-			RGBBlendingPipeline<SHADER::SEPIA, true> blender;
-			Blit(beg, beg, end, alpha, blender);
-		}
-		SDL_UnlockSurface(newV);
+		UpdatePalettesState(flagsChanged);
 	}
-	return static_cast<BlitFlags>(ret);
+
+	return appliedBlitFlags;
+}
+
+void SDLSurfaceSprite2D::UpdatePalette() noexcept {
+	PrepareForRendering(appliedBlitFlags, &appliedTint);
+}
+
+void SDLSurfaceSprite2D::UpdatePaletteForSurface(const Palette& pal) const noexcept
+{
+		SDLVideoDriver::SetSurfacePalette(surface, reinterpret_cast<const SDL_Color*>(pal.ColorData()), 0x01 << format.Depth);
+#if SDL_VERSION_ATLEAST(1,3,0)
+		// must reset the color key or SDL 2 won't render properly
+		SDL_SetColorKey(surface, SDL_bool(format.HasColorKey), GetColorKey());
+#endif
+}
+
+void SDLSurfaceSprite2D::UpdatePalettesState(bool flagsChanged) const noexcept {
+	// effects modified?
+	if (appliedBlitFlags && shadedPaletteVersion != shadedPalette->GetVersion()) {
+		UpdatePaletteForSurface(*shadedPalette);
+		shadedPaletteVersion = shadedPalette->GetVersion();
+	// main palette modified or all effects lost?
+	} else if (!appliedBlitFlags && (flagsChanged || NeedToUpdatePalette())) {
+		UpdatePaletteForSurface(*format.palette);
+	}
+	// version has been applied in either case
+	palVersion = format.palette->GetVersion();
+
+	if (!appliedBlitFlags && shadedPalette) {
+		shadedPalette.reset();
+		shadedPaletteVersion = 0;
+	}
+
+	OnSurfaceUpdate();
+}
+
+SDL_Surface* SDLSurfaceSprite2D::GetSurface() const {
+	return surface;
 }
 
 #if SDL_VERSION_ATLEAST(1,3,0)
@@ -324,10 +328,8 @@ SDL_Texture* SDLTextureSprite2D::GetTexture(SDL_Renderer* renderer) const
 	return texture;
 }
 
-void SDLTextureSprite2D::Invalidate() const noexcept
-{
+void SDLTextureSprite2D::OnSurfaceUpdate() const noexcept {
 	staleTexture = true;
-	SDLSurfaceSprite2D::Invalidate();
 }
 #endif
 

--- a/gemrb/plugins/SDLVideo/SDLVideo.cpp
+++ b/gemrb/plugins/SDLVideo/SDLVideo.cpp
@@ -349,9 +349,11 @@ void SDLVideoDriver::BlitSpriteClipped(const Holder<Sprite2D>& spr, Region src, 
 	Color ck = ColorBlack;
 	if (flags & (BlitFlags::ONE_MINUS_DST | BlitFlags::DST | BlitFlags::SRC)) {
 		// FIXME: this is a hack. the video driver just needs to be able to ignore the color key during any blending
-		if (pal && pal->col[0] != ColorBlack) {
-			ck = pal->col[0];
-			pal->CopyColorRange(&ColorBlack, &ColorBlack + 1, 0);
+		if (pal) {
+			ck = pal->GetColorAt(0);
+			if (ck != ColorBlack) {
+				pal->SetColor(0, ColorBlack);
+			}
 		}
 	}
 
@@ -363,7 +365,7 @@ void SDLVideoDriver::BlitSpriteClipped(const Holder<Sprite2D>& spr, Region src, 
 	}
 	
 	if (ck != ColorBlack) {
-		pal->CopyColorRange(&ck, &ck + 1, 0);
+		pal->SetColor(0, ck);
 	}
 }
 

--- a/gemrb/plugins/TTFImporter/TTFFontManager.cpp
+++ b/gemrb/plugins/TTFImporter/TTFFontManager.cpp
@@ -103,10 +103,11 @@ Holder<Font> TTFFontManager::GetFont(unsigned short pxSize, FontStyle /*style*/,
 {
 	Holder<Palette> pal = MakeHolder<Palette>(ColorWhite, ColorBlack);
 	
+	Palette::Colors buffer;
 	// FIXME: we probably dont need to do this
 	// Font already can do blending between fg and bg colors
 	for (int i = 1; i < 256; ++i) {
-		Color& c = pal->col[i];
+		auto c = pal->GetColorAt(i);
 		unsigned int m = (c.r + c.g + c.b) / 3;
 		if (m > 2) {
 			int tmp = m * MUL;
@@ -114,8 +115,11 @@ Holder<Font> TTFFontManager::GetFont(unsigned short pxSize, FontStyle /*style*/,
 		} else {
 			c.a = 0;
 		}
+		buffer[i] = c;
 	}
-	
+
+	pal->CopyColors(1, buffer.cbegin() + 1, buffer.cend());
+
 	FT_Error error = 0;
 	ieWord lineHeight = 0, baseline = 0;
 	/* Make sure that our font face is scalable (global metrics) */

--- a/gemrb/tests/BMPImporter/Test_BMPImporter.cpp
+++ b/gemrb/tests/BMPImporter/Test_BMPImporter.cpp
@@ -46,8 +46,8 @@ public:
 
 // More like a smoke test
 TEST_P(BMPImporter_Test, GetPalette) {
-	std::array<Color, 2> colors;
-	EXPECT_EQ(unit.GetPalette(2, colors.data()), -1);
+	Palette pal;
+	EXPECT_EQ(unit.GetPalette(2, pal), -1);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/gemrb/tests/core/Test_MurmurHash.cpp
+++ b/gemrb/tests/core/Test_MurmurHash.cpp
@@ -1,0 +1,18 @@
+#include <gtest/gtest.h>
+
+#include "../../core/MurmurHash.h"
+
+namespace GemRB {
+
+TEST(MurmurHash_Test, Feed) {
+	auto hasher = MurmurHash3_32();
+	EXPECT_EQ(hasher.GetHash(), 0);
+
+	hasher.Feed(0x34333231);
+	EXPECT_EQ(hasher.GetHash(), 0x721C5DC3);
+
+	hasher.Feed(0x38373635);
+	EXPECT_EQ(hasher.GetHash(), 0x91B313CE);
+}
+
+}

--- a/gemrb/tests/core/Test_Palette.cpp
+++ b/gemrb/tests/core/Test_Palette.cpp
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+
+#include "../../core/Palette.h"
+
+namespace GemRB {
+
+TEST(Palette_Test, Constructor) {
+	Palette unit;
+	EXPECT_FALSE(unit.IsNamed());
+}
+
+TEST(Palette_Test, SetAndGetColor) {
+	Color c {0x12, 0x34, 0x56, 0};
+	Palette unit;
+
+	unit.SetColor(17, c);
+	EXPECT_EQ(c, unit[17]);
+}
+
+TEST(Palette_Test, CopyColors) {
+	Palette::Colors buffer;
+	Palette unit;
+
+	for (size_t i = 0; i < 256; ++i) {
+		Color c {static_cast<uint8_t>(i), 1, 2, 3};
+		buffer[i] = c;
+	}
+
+	unit.CopyColors(1, buffer.cbegin() + 1, buffer.cend());
+
+	EXPECT_EQ(unit[0], Color {});
+	for (size_t i = 1; i < 256; ++i) {
+		Color c {static_cast<uint8_t>(i), 1, 2, 3};
+		EXPECT_EQ(unit[i], c);
+	}
+}
+
+TEST(Palette_Test, SetColor_Version) {
+	Color c{1, 0, 0, 255};
+	Palette unit;
+
+	auto v1 = unit.GetVersion();
+	unit.SetColor(0, c);
+	auto v2a = unit.GetVersion();
+	EXPECT_NE(v1, v2a);
+
+	unit.SetColor(0, c);
+	auto v2b = unit.GetVersion();
+	EXPECT_EQ(v2a, v2b);
+
+	c.a = 123;
+	unit.SetColor(1, c);
+	auto v3 = unit.GetVersion();
+	EXPECT_NE(v2a, v3);
+
+	unit.SetColor(0, c);
+	auto v4 = unit.GetVersion();
+	EXPECT_NE(v3, v4);
+}
+
+TEST(Palette_Test, CopyColors_Version) {
+	Palette::Colors buffer;
+	Palette unit;
+
+	for (size_t i = 0; i < 256; ++i) {
+		Color c {static_cast<uint8_t>(i), 1, 2, 3};
+		buffer[i] = c;
+	}
+
+	unit.CopyColors(1, buffer.cbegin() + 1, buffer.cend());
+	auto v1 = unit.GetVersion();
+
+	for (size_t i = 1; i < 256; ++i) {
+		Color c {static_cast<uint8_t>(i), 2, 3, 4};
+		buffer[i] = c;
+	}
+
+	unit.CopyColors(1, buffer.cbegin() + 1, buffer.cend());
+	auto v2 = unit.GetVersion();
+
+	EXPECT_NE(v1, v2);
+}
+
+}


### PR DESCRIPTION
## Description
This fixes #2150, #2146 (and fallout) and also restores, again, infravision.

What does it do:
* Changes to `Palette` won't go unnoticed anymore which makes it easier to check if it needs to be updated to the surface.
* `SDLSurfaceSprite2D` has some easier to understand update-requirements for both palettes and surface.
* I've eliminated one manual blitting path, because I don't see where SDL2 is unable to do the same, so only one surface left to have.
* There is now an original palette + a tinted one when required, leaving the original untouched for rendering.
* Non-accelerated stencilling preserves the desired blend mode, so all code-paths look the same.

Tested all the known edge cases that now are easy to handle under less heuristics and state:
* PST: crystal room + Ignus spells
* IWD: Cloack of oscillating colors
* BG: Thalantyr's store room
* IWD2: infravision

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
