### PR TITLE
Actor: clearing scripts when cloning

### DIFF
--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -4125,6 +4125,11 @@ static void ChunkActor(Actor* actor)
 		copy->SetBase(IE_DONOTJUMP, DNJ_UNHINDERED);
 		copy->MoveTo(actor->Pos + OrientedOffset(RandomOrientation(), RAND(5, 40)));
 		copy->SetBase(IE_DONOTJUMP, 0); // revert, so we get occlusion
+
+		for (uint8_t i = 0; i < MAX_SCRIPTS; ++i) {
+			copy->SetScript(ResRef{}, i, false);
+		}
+
 		// make it expire
 		copy->SetInternalFlag(IF_REALLYDIED, BitOp::OR);
 		Effect* fx = EffectQueue::CreateEffect(fx_remove_creature_ref, 0, 0, FX_DURATION_DELAY_PERMANENT);


### PR DESCRIPTION
## Description
See #2179.

That's maybe just half of the fix since surviving chunks continue to be visible, by just spinning around locally and preventing saving when nearby. But it makes the game more playable again in this situation.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
