### PR TITLE
Three sound improvements

### DIFF
--- a/gemrb/core/Audio.cpp
+++ b/gemrb/core/Audio.cpp
@@ -24,6 +24,9 @@ namespace GemRB {
 
 const TypeID Audio::ID = { "Audio" };
 
+// walking/armor sounds are too loud relative to other noises
+static const EnumArray<SFXChannel, float> channelVolumeMultipliers { 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 0.3f, 0.3f, 0.1f };
+
 void Audio::UpdateChannel(const std::string& name, int idx, int volume, float reverb)
 {
 	channels[idx] = Channel(name);
@@ -50,7 +53,7 @@ int Audio::GetVolume(SFXChannel channel) const
 	if (channel >= SFXChannel::count) {
 		return 100;
 	}
-	return channels[channel].getVolume();
+	return channels[channel].getVolume() * channelVolumeMultipliers[channel];
 }
 
 float Audio::GetReverb(SFXChannel channel) const

--- a/gemrb/core/Audio.cpp
+++ b/gemrb/core/Audio.cpp
@@ -24,11 +24,42 @@ namespace GemRB {
 
 const TypeID Audio::ID = { "Audio" };
 
-// walking/armor sounds are too loud relative to other noises
-static const EnumArray<SFXChannel, float> channelVolumeMultipliers { 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 0.3f, 0.3f, 0.1f };
+static std::unordered_map<std::string, SFXChannel> channelEnumMap = {
+	{"NARRATIO", SFXChannel::Narrator},
+	{"AREA_AMB", SFXChannel::MainAmbient},
+	{"ACTIONS",  SFXChannel::Actions},
+	{"SWINGS",   SFXChannel::Swings},
+	{"CASTING",  SFXChannel::Casting},
+	{"GUI",      SFXChannel::GUI},
+	{"DIALOG",   SFXChannel::Dialog},
+	{"CHARACT0", SFXChannel::Char0},
+	{"CHARACT1", SFXChannel::Char1},
+	{"CHARACT2", SFXChannel::Char2},
+	{"CHARACT3", SFXChannel::Char3},
+	{"CHARACT4", SFXChannel::Char4},
+	{"CHARACT5", SFXChannel::Char5},
+	{"CHARACT6", SFXChannel::Char6},
+	{"CHARACT7", SFXChannel::Char7},
+	{"CHARACT8", SFXChannel::Char8},
+	{"CHARACT9", SFXChannel::Char9},
+	{"MONSTER",  SFXChannel::Monster},
+	{"HITS",     SFXChannel::Hits},
+	{"MISSILE",  SFXChannel::Missile},
+	{"AMBIENTL", SFXChannel::AmbientLoop},
+	{"AMBIENTN", SFXChannel::AmbientOther},
+	{"WALKINGC", SFXChannel::WalkChar},
+	{"WALKINGM", SFXChannel::WalkMonster},
+	{"ARMOR",    SFXChannel::Armor}
+};
 
-void Audio::UpdateChannel(const std::string& name, int idx, int volume, float reverb)
+void Audio::UpdateChannel(const std::string& name, int volume, float reverb)
 {
+	auto it = channelEnumMap.find(name);
+	if (it == channelEnumMap.cend()) {
+		return;
+	}
+
+	auto idx = it->second;
 	channels[idx] = Channel(name);
 
 	volume = Clamp(volume, 0, 100);
@@ -53,7 +84,7 @@ int Audio::GetVolume(SFXChannel channel) const
 	if (channel >= SFXChannel::count) {
 		return 100;
 	}
-	return channels[channel].getVolume() * channelVolumeMultipliers[channel];
+	return channels[channel].getVolume();
 }
 
 float Audio::GetReverb(SFXChannel channel) const

--- a/gemrb/core/Audio.h
+++ b/gemrb/core/Audio.h
@@ -88,6 +88,7 @@ public:
 };
 
 static const EnumArray<SFXChannel, float> channelHeights { 0.0F, 0.0F, 100.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F };
+
 class GEM_EXPORT Channel {
 public:
 	Channel() = default;
@@ -155,10 +156,12 @@ public:
 	int GetVolume(SFXChannel channel) const;
 	float GetReverb(SFXChannel channel) const;
 	float GetHeight(SFXChannel channel) const;
+	void SetScreenSize(Size size) { screenSize = size; }
 
 protected:
 	AmbientMgr* ambim = nullptr;
 	EnumArray<SFXChannel, Channel> channels;
+	Size screenSize;
 };
 
 }

--- a/gemrb/core/Audio.h
+++ b/gemrb/core/Audio.h
@@ -151,7 +151,7 @@ public:
 				int channels, short* memory, int size, int samplerate) = 0;
 	virtual void UpdateMapAmbient(const MapReverbProperties&) {};
 
-	void UpdateChannel(const std::string& name, int idx, int volume, float reverb);
+	void UpdateChannel(const std::string& name, int volume, float reverb);
 	SFXChannel GetChannel(const std::string& name) const;
 	int GetVolume(SFXChannel channel) const;
 	float GetReverb(SFXChannel channel) const;

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -914,7 +914,7 @@ bool Interface::ReadSoundChannelsTable() const
 		if (irev != TableMgr::npos) {
 			reverb = atof(tm->QueryField(i, irev).c_str());
 		}
-		AudioDriver->UpdateChannel(rowname, i, volume, reverb);
+		AudioDriver->UpdateChannel(rowname, volume, reverb);
 	}
 	return true;
 }

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -1081,6 +1081,8 @@ void Interface::InitAudio()
 	if (!ret) {
 		Log(WARNING, "Core", "Failed to read channel table.");
 	}
+
+	AudioDriver->SetScreenSize(Size(config.Width, config.Height));
 }
 
 void Interface::LoadPlugins() const

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -4508,7 +4508,7 @@ void Actor::PlayWalkSound()
 
 	tick_t len = 0;
 	SFXChannel channel = InParty ? SFXChannel::WalkChar : SFXChannel::WalkMonster;
-	core->GetAudioDrv()->Play(Sound, channel, Pos, 0, &len);
+	core->GetAudioDrv()->Play(Sound, channel, Pos, GEM_SND_SPATIAL, &len);
 	Timers.nextWalkSound = ieDword(thisTime + len);
 }
 

--- a/gemrb/core/SoundMgr.h
+++ b/gemrb/core/SoundMgr.h
@@ -44,6 +44,7 @@ public:
 	 * @returns Number of samples read.
 	 */
 	virtual int read_samples( short* memory, int cnt ) = 0 ;
+	virtual int ReadSamplesIntoChannels(char *channel1, char *channel2, int numSamples) = 0;
 	int get_channels() const
 	{
 		return channels;

--- a/gemrb/plugins/ACMReader/ACMReader.h
+++ b/gemrb/plugins/ACMReader/ACMReader.h
@@ -70,6 +70,7 @@ public:
 
 	bool Import(DataStream* stream) override;
 	int read_samples(short* buffer, int count) override;
+	int ReadSamplesIntoChannels(char *channel1, char *channel2, int numSamples) override;
 };
 
 }

--- a/gemrb/plugins/OGGReader/OGGReader.cpp
+++ b/gemrb/plugins/OGGReader/OGGReader.cpp
@@ -124,6 +124,11 @@ int OGGReader::read_samples(short* buffer, int count)
 	return samples_got;
 }
 
+int OGGReader::ReadSamplesIntoChannels(char* /*channel1*/, char* /*channel2*/, int /*numSamples*/) {
+	assert(false);
+	return 0;
+}
+
 #include "plugindef.h"
 
 GEMRB_PLUGIN(0x18C310C3, "OGG File Importer")

--- a/gemrb/plugins/OGGReader/OGGReader.h
+++ b/gemrb/plugins/OGGReader/OGGReader.h
@@ -53,6 +53,7 @@ public:
 	}
 	bool Import(DataStream* stream) override;
 	int read_samples(short* buffer, int count) override;
+	int ReadSamplesIntoChannels(char *channel1, char *channel2, int numSamples) override;
 };
 
 }

--- a/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
+++ b/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
@@ -515,6 +515,15 @@ Holder<SoundHandle> OpenALAudioDriver::Play(StringView ResRef, SFXChannel channe
 	// AL_SOURCE_RELATIVE = source pos & co to be interpreted as if listener was at (0, 0, 0)
 	alSourcei(Source, AL_SOURCE_RELATIVE, !(flags & GEM_SND_SPATIAL));
 	alSourcefv(Source, AL_POSITION, SourcePos);
+
+	if (flags & GEM_SND_SPATIAL) {
+		auto keepDistance = std::max(screenSize.w, screenSize.h);
+		auto offsetDistance = keepDistance * 4;
+		alSourcei(Source, AL_REFERENCE_DISTANCE, keepDistance);
+		alSourcei(Source, AL_MAX_DISTANCE, offsetDistance);
+		alSourcei(Source, AL_ROLLOFF_FACTOR, 25);
+	}
+
 	checkALError("Unable to set audio parameters", WARNING);
 
 #ifdef HAVE_OPENAL_EFX_H

--- a/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
+++ b/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
@@ -77,12 +77,7 @@ static void showALCError(const char* msg, LogLevel level, ALCdevice *device) {
 void OpenALSoundHandle::SetPos(const Point& p) {
 	if (!parent) return;
 
-	ALfloat SourcePos[] = {
-		float(p.x), float(p.y), 0.0f
-	};
-
-	alSourcefv(parent->Source, AL_POSITION, SourcePos);
-	checkALError("Unable to set source position", WARNING);
+	parent->SetPos(p);
 }
 
 bool OpenALSoundHandle::Playing() {
@@ -101,11 +96,19 @@ void OpenALSoundHandle::Stop() {
 void OpenALSoundHandle::StopLooping() {
 	if (!parent) return;
 
-	alSourcei(parent->Source, AL_LOOPING, 0);
-	checkALError("Unable to stop audio loop", WARNING);
+	parent->StopLooping();
 }
 
-void AudioStream::ClearProcessedBuffers() const
+void AudioStream::ClearProcessedBuffers() const {
+	if (sources.first) {
+		ClearProcessedBuffers(sources.first);
+	}
+	if (sources.second) {
+		ClearProcessedBuffers(sources.second);
+	}
+}
+
+void AudioStream::ClearProcessedBuffers(ALuint Source) const
 {
 	ALint processed = 0;
 	alGetSourcei( Source, AL_BUFFERS_PROCESSED, &processed );
@@ -137,13 +140,33 @@ void AudioStream::ClearProcessedBuffers() const
 
 }
 
-void AudioStream::ClearIfStopped()
-{
+void AudioStream::ClearIfStopped() {
 	if (free || locked) return;
 
+	bool sourceDeleted = ClearIfStopped(sources.first);
+	if (sources.second) {
+		ClearIfStopped(sources.second);
+	}
+
+	if (sourceDeleted) {
+		free = true;
+		locked = false;
+		delete_buffers = false;
+		ambient = false;
+		sources = {0, 0};
+		buffers = {0, 0};
+		if (handle) {
+			handle->Invalidate();
+			handle.reset();
+		}
+	}
+}
+
+bool AudioStream::ClearIfStopped(ALuint Source)
+{
 	if (!Source || !alIsSource(Source)) {
 		checkALError("No AL Context", WARNING);
-		return;
+		return false;
 	}
 
 	ALint state;
@@ -154,24 +177,72 @@ void AudioStream::ClearIfStopped()
 		ClearProcessedBuffers();
 		alDeleteSources( 1, &Source );
 		checkALError("Failed to delete source", WARNING);
-		Source = 0;
-		Buffer = 0;
-		free = true;
-		if (handle) { handle->Invalidate(); handle.reset(); }
-		ambient = false;
-		locked = false;
-		delete_buffers = false;
+
+		return true;
+	}
+
+	return false;
+}
+
+void AudioStream::Stop() const {
+	Stop(sources.first);
+	if (sources.second) {
+		Stop(sources.second);
 	}
 }
 
 void AudioStream::ForceClear()
 {
-	if (!Source || !alIsSource(Source)) return;
-
-	alSourceStop(Source);
-	checkALError("Failed to stop source", WARNING);
+	Stop();
 	ClearProcessedBuffers();
 	ClearIfStopped();
+}
+
+void AudioStream::Stop(ALuint source) const {
+	if (!source || !alIsSource(source)) return;
+
+	alSourceStop(source);
+	checkALError("Failed to stop source", WARNING);
+}
+
+void AudioStream::StopLooping() const {
+	alSourcei(sources.first, AL_LOOPING, 0);
+	if (sources.second) {
+		alSourcei(sources.second, AL_LOOPING, 0);
+	}
+	checkALError("Unable to stop audio loop", WARNING);
+}
+
+void AudioStream::SetPitch(int pitch) const {
+	float fPitch = 0.01f * pitch;
+
+	alSourcef(sources.first, AL_PITCH, fPitch);
+	if (sources.second) {
+		alSourcef(sources.second, AL_PITCH, fPitch);
+	}
+	checkALError("Unable to set ambient pitch", WARNING);
+}
+
+void AudioStream::SetPos(const Point& p) const {
+	ALfloat SourcePos[] = {
+		float(p.x), float(p.y), 0.0f
+	};
+
+	alSourcefv(sources.first, AL_POSITION, SourcePos);
+	if (sources.second) {
+		alSourcefv(sources.second, AL_POSITION, SourcePos);
+	}
+	checkALError("Unable to set source position", WARNING);
+}
+
+void AudioStream::SetVolume(int volume) const {
+	float fVolume = 0.01f * volume;
+
+	alSourcef(sources.first, AL_GAIN, fVolume);
+	if (sources.second) {
+		alSourcef(sources.second, AL_GAIN, fVolume);
+	}
+	checkALError("Unable to set ambient volume", WARNING);
 }
 
 OpenALAudioDriver::OpenALAudioDriver(void)
@@ -373,12 +444,10 @@ OpenALAudioDriver::~OpenALAudioDriver(void)
 	delete ambim;
 }
 
-ALuint OpenALAudioDriver::loadSound(StringView ResRef, tick_t &time_length)
+std::pair<ALuint, ALuint> OpenALAudioDriver::loadSound(StringView ResRef, tick_t &time_length, bool spatial)
 {
-	ALuint Buffer = 0;
-
 	if (ResRef.empty()) {
-		return 0;
+		return {0, 0};
 	}
 
 	auto entry = buffercache.Lookup(ResRef);
@@ -387,52 +456,70 @@ ALuint OpenALAudioDriver::loadSound(StringView ResRef, tick_t &time_length)
 		return entry->Buffer;
 	}
 
-	//no cache entry...
-	alGenBuffers(1, &Buffer);
-	if (checkALError("Unable to create sound buffer", ERROR)) {
-		return 0;
-	}
+	ALuint buffers[2] = {0, 0};
 
 	ResourceHolder<SoundMgr> acm = gamedata->GetResourceHolder<SoundMgr>(ResRef);
 	if (!acm) {
-		alDeleteBuffers( 1, &Buffer );
-		checkALError("Unable to delete buffer!", ERROR);
-		return 0;
+		return {0, 0};
 	}
-	int cnt = acm->get_length();
-	unsigned int riff_chans = acm->get_channels();
+
+	unsigned int channels = acm->get_channels();
+	assert(channels <= 2);
+	bool spatialStereo = channels > 1 && spatial;
+
+	alGenBuffers(spatialStereo ? 2 : 1, buffers);
+	if (checkALError("Unable to create sound buffer", ERROR)) {
+		return {0, 0};
+	}
+
 	int samplerate = acm->get_samplerate();
-	//multiply always by 2 because it is in 16 bits
-	int rawsize = cnt * 2;
-	short* memory = (short*) malloc(rawsize);
-	//multiply always with 2 because it is in 16 bits
-	unsigned int cnt1 = acm->read_samples( memory, cnt ) * 2;
-	//Sound Length in milliseconds
-	time_length = ((cnt / riff_chans) * 1000) / samplerate;
-	//it is always reading the stuff into 16 bits
-	alBufferData( Buffer, GetFormatEnum( riff_chans, 16 ), memory, cnt1, samplerate );
-	free(memory);
+	auto numSamples = acm->get_length();
+	auto totalBytesPerChannel = numSamples * 2;
+
+	// Positional sound doesn't work for stereo in all known implementations
+	// so make two sources and play them in parallel: https://openal.org/pipermail/openal/2016-August/000527.html
+	if (spatialStereo) {
+		std::vector<char> channel1;
+		std::vector<char> channel2;
+		channel1.resize(totalBytesPerChannel);
+		channel2.resize(totalBytesPerChannel);
+		auto actualSamples = acm->ReadSamplesIntoChannels(channel1.data(), channel2.data(), numSamples);
+
+		auto format = GetFormatEnum(1, 16);
+		alBufferData(buffers[0], format, channel1.data(), actualSamples * 2, samplerate);
+		alBufferData(buffers[1], format, channel2.data(), actualSamples * 2, samplerate);
+	} else {
+		short* memory = (short*) malloc(totalBytesPerChannel);
+		//multiply always with 2 because it is in 16 bits
+		unsigned int cnt1 = acm->read_samples(memory, numSamples) * 2;
+		//it is always reading the stuff into 16 bits
+		alBufferData(buffers[0], GetFormatEnum(channels, 16), memory, cnt1, samplerate);
+		free(memory);
+	}
+
+	// Sound length in milliseconds
+	time_length = ((numSamples / channels) * 1000) / samplerate;
 
 	if (checkALError("Unable to fill buffer", ERROR)) {
-		alDeleteBuffers( 1, &Buffer );
+		alDeleteBuffers(spatialStereo ? 2 : 1, buffers);
 		checkALError("Error deleting buffer", WARNING);
-		return 0;
+		return {0, 0};
 	}
 
-	buffercache.SetAt(ResRef, Buffer, time_length);
+	std::pair<ALuint, ALuint> bufferPair {buffers[0], buffers[1]};
+	buffercache.SetAt(ResRef, bufferPair, time_length);
 
-	return Buffer;
+	return bufferPair;
 }
 
 Holder<SoundHandle> OpenALAudioDriver::Play(StringView ResRef, SFXChannel channel, const Point& p,
 	unsigned int flags, tick_t *length)
 {
-	ALuint Buffer;
-
 	if (ResRef.empty()) {
-		if((flags & GEM_SND_SPEECH) && (speech.Source && alIsSource(speech.Source))) {
+		auto source = speech.sources.first;
+		if ((flags & GEM_SND_SPEECH) && (source && alIsSource(source))) {
 			//So we want him to be quiet...
-			alSourceStop( speech.Source );
+			alSourceStop(source);
 			checkALError("Unable to stop speech", WARNING);
 			speech.ClearProcessedBuffers();
 		}
@@ -440,21 +527,14 @@ Holder<SoundHandle> OpenALAudioDriver::Play(StringView ResRef, SFXChannel channe
 	}
 
 	tick_t time_length;
-	Buffer = loadSound( ResRef, time_length );
-	if (Buffer == 0) {
+	auto buffers = loadSound(ResRef, time_length, flags & GEM_SND_SPATIAL);
+	if (buffers.first == 0) {
 		return Holder<SoundHandle>();
 	}
 
 	if (length) {
 		*length = time_length;
 	}
-
-	ALfloat SourcePos[] = {
-		float(p.x), float(p.y), GetHeight(channel)
-	};
-	ALfloat SourceVel[] = {
-		0.0f, 0.0f, 0.0f
-	};
 
 	ieDword volume = 100;
 	ALint loop = (flags & GEM_SND_LOOPING) ? 1 : 0;
@@ -468,8 +548,9 @@ Holder<SoundHandle> OpenALAudioDriver::Play(StringView ResRef, SFXChannel channe
 			//speech has a single channel, if a new speech started
 			//we stop the previous one
 
-			if(!speech.free && (speech.Source && alIsSource(speech.Source))) {
-				alSourceStop( speech.Source );
+			auto source = speech.sources.first;
+			if (!speech.free && (source && alIsSource(source))) {
+				alSourceStop(source);
 				checkALError("Unable to stop speech", WARNING);
 				speech.ClearProcessedBuffers();
 			}
@@ -498,30 +579,63 @@ Holder<SoundHandle> OpenALAudioDriver::Play(StringView ResRef, SFXChannel channe
 	}
 
 	assert(stream);
-	ALuint Source = stream->Source;
 
-	if(!Source || !alIsSource(Source)) {
-		alGenSources( 1, &Source );
+	auto& sources = stream->sources;
+	sources.first = CreateAndConfigSource(sources.first, volume, loop, flags, p, channel);
+	if (buffers.second) {
+		sources.second = CreateAndConfigSource(sources.second, volume, loop, flags, p, channel);
+	}
+
+	assert(!stream->delete_buffers);
+	stream->free = false;
+
+	if (QueueALBuffers(stream->sources, buffers) != GEM_OK) {
+		return Holder<SoundHandle>();
+	}
+
+	stream->handle = MakeHolder<OpenALSoundHandle>(stream);
+	return stream->handle;
+}
+
+ALuint OpenALAudioDriver::CreateAndConfigSource(ALuint source, ieDword volume, ALint loop, unsigned int flags, const Point& p, SFXChannel channel) const {
+	if (!source || !alIsSource(source)) {
+		alGenSources(1, &source);
+
 		if (checkALError("Error creating source", ERROR)) {
-			return Holder<SoundHandle>();
+			return 0;
 		}
 	}
 
-	alSourcef(Source, AL_PITCH, 1.0f);
-	alSourcefv(Source, AL_VELOCITY, SourceVel);
-	alSourcei(Source, AL_LOOPING, loop);
-	alSourcef(Source, AL_REFERENCE_DISTANCE, REFERENCE_DISTANCE);
-	alSourcef(Source, AL_GAIN, 0.01f * (volume / 100.0f) * GetVolume(channel));
-	// AL_SOURCE_RELATIVE = source pos & co to be interpreted as if listener was at (0, 0, 0)
-	alSourcei(Source, AL_SOURCE_RELATIVE, !(flags & GEM_SND_SPATIAL));
-	alSourcefv(Source, AL_POSITION, SourcePos);
+	ConfigSource(source, volume, loop, flags, p, channel);
 
-	if (flags & GEM_SND_SPATIAL) {
+	return source;
+}
+
+void OpenALAudioDriver::ConfigSource(ALuint source, ieDword volume, ALint loop, unsigned int flags, const Point& p, SFXChannel channel) const {
+	ALfloat sourceVel[] = {
+		0.0f, 0.0f, 0.0f
+	};
+
+	ALfloat sourcePos[] = {
+		float(p.x), float(p.y), GetHeight(channel)
+	};
+
+	bool spatial = flags & GEM_SND_SPATIAL;
+	alSourcef(source, AL_PITCH, 1.0f);
+	alSourcefv(source, AL_VELOCITY, sourceVel);
+	alSourcei(source, AL_LOOPING, loop);
+	alSourcef(source, AL_REFERENCE_DISTANCE, REFERENCE_DISTANCE);
+	alSourcef(source, AL_GAIN, 0.01f * (volume / 100.0f) * GetVolume(channel));
+	// AL_SOURCE_RELATIVE = source pos & co to be interpreted as if listener was at (0, 0, 0)
+	alSourcei(source, AL_SOURCE_RELATIVE, !spatial);
+	alSourcefv(source, AL_POSITION, sourcePos);
+
+	if (spatial) {
 		auto keepDistance = std::max(screenSize.w, screenSize.h);
 		auto offsetDistance = keepDistance * 4;
-		alSourcei(Source, AL_REFERENCE_DISTANCE, keepDistance);
-		alSourcei(Source, AL_MAX_DISTANCE, offsetDistance);
-		alSourcei(Source, AL_ROLLOFF_FACTOR, 25);
+		alSourcei(source, AL_REFERENCE_DISTANCE, keepDistance);
+		alSourcei(source, AL_MAX_DISTANCE, offsetDistance);
+		alSourcei(source, AL_ROLLOFF_FACTOR, 25);
 	}
 
 	checkALError("Unable to set audio parameters", WARNING);
@@ -530,23 +644,11 @@ Holder<SoundHandle> OpenALAudioDriver::Play(StringView ResRef, SFXChannel channe
 	ieDword efxSetting = core->GetDictionary().Get("Environmental Audio", 0);
 
 	if (efxSetting && hasReverbProperties && (flags & (GEM_SND_SPATIAL | GEM_SND_EFX))) {
-		alSource3i(Source, AL_AUXILIARY_SEND_FILTER, efxEffectSlot, 0, 0);
+		alSource3i(source, AL_AUXILIARY_SEND_FILTER, efxEffectSlot, 0, 0);
 	} else {
-		alSource3i(Source, AL_AUXILIARY_SEND_FILTER, 0, 0, 0);
+		alSource3i(source, AL_AUXILIARY_SEND_FILTER, 0, 0, 0);
 	}
 #endif
-
-	assert(!stream->delete_buffers);
-
-	stream->Source = Source;
-	stream->free = false;
-
-	if (QueueALBuffer(Source, Buffer) != GEM_OK) {
-		return Holder<SoundHandle>();
-	}
-
-	stream->handle = MakeHolder<OpenALSoundHandle>(stream);
-	return stream->handle;
 }
 
 void OpenALAudioDriver::UpdateVolume(unsigned int flags)
@@ -704,20 +806,19 @@ Point OpenALAudioDriver::GetListenerPos()
 	return Point(listen[0], listen[1]);
 }
 
-bool OpenALAudioDriver::ReleaseStream(int stream, bool HardStop)
+bool OpenALAudioDriver::ReleaseStream(int streamIdx, bool HardStop)
 {
-	if (stream < 0 || streams[stream].free || !streams[stream].locked)
+	auto& stream = streams[streamIdx];
+	if (stream.free || !stream.locked)
 		return false;
-	streams[stream].locked = false;
+	stream.locked = false;
 	if (!HardStop) {
 		// it's now unlocked, so it will automatically be reclaimed when needed
 		return true;
 	}
 
-	ALuint Source = streams[stream].Source;
-	alSourceStop(Source);
-	checkALError("Unable to stop source", WARNING);
-	streams[stream].ClearIfStopped();
+	stream.Stop();
+	stream.ClearIfStopped();
 	return true;
 }
 
@@ -726,15 +827,15 @@ int OpenALAudioDriver::SetupNewStream(int x, int y, int z,
 		            ieWord gain, bool point, int ambientRange)
 {
 	// Find a free (or finished) stream for this sound
-	int stream = -1;
+	int streamIdx = -1;
 	for (int i = 0; i < num_streams; i++) {
 		streams[i].ClearIfStopped();
 		if (streams[i].free) {
-			stream = i;
+			streamIdx = i;
 			break;
 		}
 	}
-	if (stream == -1) {
+	if (streamIdx == -1) {
 		Log(ERROR, "OpenAL", "No available audio streams out of {}", num_streams);
 		return -1;
 	}
@@ -759,58 +860,58 @@ int OpenALAudioDriver::SetupNewStream(int x, int y, int z,
 	alSourcei( source, AL_ROLLOFF_FACTOR, point ? 1 : 0 );
 	checkALError("Unable to set stream parameters", WARNING);
 
-	streams[stream].Buffer = 0;
-	streams[stream].Source = source;
-	streams[stream].free = false;
-	streams[stream].ambient = ambientRange > 0;
-	streams[stream].locked = true;
+	auto& stream = streams[streamIdx];
+	stream.buffers = {0, 0};
+	stream.sources = {source, 0};
+	stream.free = false;
+	stream.ambient = ambientRange > 0;
+	stream.locked = true;
 
-	return stream;
+	return streamIdx;
 }
 
-tick_t OpenALAudioDriver::QueueAmbient(int stream, const ResRef& sound)
+tick_t OpenALAudioDriver::QueueAmbient(int streamIdx, const ResRef& sound)
 {
-	if (streams[stream].free || !streams[stream].ambient)
+	auto& stream = streams[streamIdx];
+	if (stream.free || !stream.ambient)
 		return -1;
 
-	ALuint source = streams[stream].Source;
+	ALuint source = stream.sources.first;
 
 	// first dequeue any processed buffers
-	streams[stream].ClearProcessedBuffers();
+	stream.ClearProcessedBuffers();
 
 	tick_t time_length;
-	ALuint Buffer = loadSound(sound, time_length);
+	ALuint Buffer = loadSound(sound, time_length).first;
 	if (0 == Buffer) {
 		return -1;
 	}
 
-	assert(!streams[stream].delete_buffers);
+	assert(!stream.delete_buffers);
 
-	if (QueueALBuffer(source, Buffer) != GEM_OK) {
+	if (QueueALBuffers({source, 0}, {Buffer, 0}) != GEM_OK) {
 		return GEM_ERROR;
 	}
 
 	return time_length;
 }
 
-void OpenALAudioDriver::SetAmbientStreamVolume(int stream, int volume)
+void OpenALAudioDriver::SetAmbientStreamVolume(int streamIdx, int volume)
 {
-	if (streams[stream].free || !streams[stream].ambient)
+	auto& stream = streams[streamIdx];
+	if (stream.free || !stream.ambient)
 		return;
 
-	ALuint source = streams[stream].Source;
-	alSourcef( source, AL_GAIN, 0.01f * volume );
-	checkALError("Unable to set ambient volume", WARNING);
+	stream.SetVolume(volume);
 }
 
-void OpenALAudioDriver::SetAmbientStreamPitch(int stream, int pitch)
+void OpenALAudioDriver::SetAmbientStreamPitch(int streamIdx, int pitch)
 {
-	if (streams[stream].free || !streams[stream].ambient)
+	auto& stream = streams[streamIdx];
+	if (stream.free || !stream.ambient)
 		return;
 
-	ALuint source = streams[stream].Source;
-	alSourcef( source, AL_PITCH, 0.01f * pitch );
-	checkALError("Unable to set ambient pitch", WARNING);
+	stream.SetPitch(pitch);
 }
 
 ALenum OpenALAudioDriver::GetFormatEnum(int channels, int bits) const
@@ -943,12 +1044,13 @@ int OpenALAudioDriver::MusicManager(void* arg)
 }
 
 //This one is used for movies, might be useful for others ?
-void OpenALAudioDriver::QueueBuffer(int stream, unsigned short bits,
+void OpenALAudioDriver::QueueBuffer(int streamIdx, unsigned short bits,
 		        int channels, short* memory,
 		        int size, int samplerate)
 {
-	streams[stream].delete_buffers = true;
-	streams[stream].ClearProcessedBuffers();
+	auto& stream = streams[streamIdx];
+	stream.delete_buffers = true;
+	stream.ClearProcessedBuffers();
 
 	ALuint Buffer;
 	alGenBuffers(1, &Buffer);
@@ -962,29 +1064,47 @@ void OpenALAudioDriver::QueueBuffer(int stream, unsigned short bits,
 		return;
 	}
 
-	QueueALBuffer(streams[stream].Source, Buffer);
+	QueueALBuffers({stream.sources.first, 0}, {Buffer, 0});
 }
 
-// !!!!!!!!!!!!!!!
-// Private Methods
-// !!!!!!!!!!!!!!!
-
-int OpenALAudioDriver::QueueALBuffer(ALuint source, ALuint buffer) const
+int OpenALAudioDriver::QueueALBuffers(OpenALuintPair sources, OpenALuintPair buffers) const
 {
-#ifdef DEBUG_AUDIO
-	ALint frequency;
-	ALint bits;
-	ALint channels;
-	alGetBufferi(buffer, AL_FREQUENCY, &frequency);
-	alGetBufferi(buffer, AL_BITS, &bits);
-	alGetBufferi(buffer, AL_CHANNELS, &channels);
-	checkALError("Error querying buffer properties.", WARNING);
-	Log(DEBUG, "OpenAL", "Attempting to buffer audio source: {}\nFrequency: {}\nBits: {}\nChannels: {}",
-		source, frequency, bits, channels);
-#endif
+	ALenum state;
+	auto result = QueueALBuffer(sources.first, buffers.first);
+	if (result == GEM_ERROR) {
+		return GEM_ERROR;
+	}
+
+	if (sources.second) {
+		auto result = QueueALBuffer(sources.second, buffers.second);
+		if (result == GEM_ERROR) {
+			return GEM_ERROR;
+		}
+	}
+
+	alGetSourcei(sources.first, AL_SOURCE_STATE, &state);
+	if (checkALError("Unable to query source state", ERROR)) {
+		return GEM_ERROR;
+	}
+
+	// queueing always implies playing for us
+	if (state != AL_PLAYING) {
+		ALuint alSources[2] = { sources.first, sources.second };
+		alSourcePlayv(sources.second ? 2 : 1, alSources);
+
+		if (checkALError("Unable to play source", ERROR)) {
+			return GEM_ERROR;
+		}
+	}
+
+	return GEM_OK;
+}
+
+int OpenALAudioDriver::QueueALBuffer(ALuint source, ALuint buffer) const {
 	ALint type;
+
 	alGetSourcei(source, AL_SOURCE_TYPE, &type);
-	if (type == AL_STATIC || checkALError("Cannot get AL source type.", ERROR)) {
+	if (checkALError("Cannot get AL source type.", ERROR) || type == AL_STATIC) {
 		Log(ERROR, "OpenAL", "Cannot queue a buffer to a static source.");
 		return GEM_ERROR;
 	}
@@ -993,19 +1113,6 @@ int OpenALAudioDriver::QueueALBuffer(ALuint source, ALuint buffer) const
 		return GEM_ERROR;
 	}
 
-	ALenum state;
-	alGetSourcei(source, AL_SOURCE_STATE, &state);
-	if (checkALError("Unable to query source state", ERROR)) {
-		return GEM_ERROR;
-	}
-
-	// queueing always implies playing for us
-	if (state != AL_PLAYING ) {
-		alSourcePlay(source);
-		if (checkALError("Unable to play source", ERROR)) {
-			return GEM_ERROR;
-		}
-	}
 	return GEM_OK;
 }
 

--- a/gemrb/plugins/WAVReader/WAVReader.h
+++ b/gemrb/plugins/WAVReader/WAVReader.h
@@ -46,6 +46,7 @@ public:
 
 	bool Import(DataStream* stream) override;
 	int read_samples(short* buffer, int count) override;
+	int ReadSamplesIntoChannels(char *channel1, char *channel2, int numSamples) override;
 };
 
 // WAV files


### PR DESCRIPTION
## Description
Looking at what has been fixed by 95d258a34a9b98f62f13fb4db325f634aa6ad818 and what was haunting me in https://github.com/gemrb/gemrb/issues/2166, I'd like to propose three sound improvements:

1. Walking sounds were not spatial but were vague all over the map, now they are. Unfortunately they are very loud this way compared to other sounds of the same volume setting. That's why I added some multiplier. Feel free to test and compare to the original.
2. Spatial sounds were not rolling off over distance. Now they do over while not turning fully mute technically (that's also a matter of the OpenAL distance model) but you can now hear things coming close and going away depending on the camera/listener's position. That's way more immersive hearing the enemies finding their way and coming closer. :slightly_smiling_face: 
3. OpenAL mostly doesn't support stereo data being spatialized, so many area affects stay as loud and centered no matter where you are on the map (see annoying thrall invisibility attempts). Now we can have these effects in the same way as everything else, following the official idea: splitting stereo into two mono channels and vector-play them.

Please feel free to test and give some feedback.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
