### PR TITLE
Fix for `nullptr_t` confusion

### DIFF
--- a/gemrb/plugins/GUIScript/GUIScript.cpp
+++ b/gemrb/plugins/GUIScript/GUIScript.cpp
@@ -13293,7 +13293,7 @@ static PyObject* ParamToPython(const GUIScript::Parameter& p)
 		return PyLong_FromLong(p.Value<long>());
 	} else if (type == typeid(unsigned long)) {
 		return PyLong_FromUnsignedLong(p.Value<unsigned long>());
-	} else if (type == typeid(nullptr_t)) {
+	} else if (type == typeid(std::nullptr_t)) {
 		Py_RETURN_NONE;
 	} else if (type == typeid(bool)) {
 		return PyBool_FromLong(p.Value<bool>());


### PR DESCRIPTION
## Description
Not sure why it has worked, but it no longer does on my MSYS2 gcc.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
