### PR TITLE
Fix for some bad pixels in TIS sprites

### DIFF
--- a/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.cpp
+++ b/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.cpp
@@ -178,8 +178,10 @@ void SDLSurfaceSprite2D::EnsureShadedPalette() const noexcept
 void SDLSurfaceSprite2D::ShadePalette(BlitFlags renderflags, const Color* tint) const noexcept
 {
 	Palette::Colors buffer;
+	buffer[0] = format.palette->GetColorAt(0);
 
-	for (size_t i = 1; i < 256; ++i) {
+	size_t startIndex = format.HasColorKey ? 1 : 0;
+	for (size_t i = startIndex; i < 256; ++i) {
 		buffer[i] = format.palette->GetColorAt(i);
 
 		if (renderflags & BlitFlags::COLOR_MOD && tint) {
@@ -197,7 +199,7 @@ void SDLSurfaceSprite2D::ShadePalette(BlitFlags renderflags, const Color* tint) 
 		}
 	}
 
-	shadedPalette->CopyColors(1, buffer.cbegin() + 1, buffer.cend());
+	shadedPalette->CopyColors(0, buffer.cbegin(), buffer.cend());
 }
 
 bool SDLSurfaceSprite2D::NeedToUpdatePalette() const noexcept


### PR DESCRIPTION
## Description
See #2176

![tis_pixels](https://github.com/user-attachments/assets/fd862904-0b40-4a79-b236-d9fce949cb33)

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [] The proposed change builds also on our build bots (check after submission)
