### PR TITLE
Logger: Flush after write

### DIFF
--- a/gemrb/core/Logging/Logger.cpp
+++ b/gemrb/core/Logging/Logger.cpp
@@ -81,6 +81,9 @@ void Logger::ProcessMessages(QueueType queue)
 		}
 		queue.pop_front();
 	}
+	for (const auto& writer : writers) {
+		writer->Flush();
+	}
 }
 
 void Logger::LogMsg(LogLevel level, const char* owner, const char* message, LOG_FMT fmt)
@@ -95,6 +98,7 @@ void Logger::LogMsg(LogMessage&& msg)
 		std::lock_guard<std::mutex> l(writerLock);
 		for (const auto& writer : writers) {
 			writer->WriteLogMessage(msg);
+			writer->Flush();
 		}
 	} else {
 		std::lock_guard<std::mutex> l(queueLock);


### PR DESCRIPTION
## Description
This pull request attempts to fix an issue I have been encountering with console output, where log statements often fail to get flushed to the console until a subsequent log occurs.

Example of the console window when launching an oBG2 game before / after the fix:
**Before:**
![before](https://github.com/user-attachments/assets/e6d98159-9304-40d1-a96c-cab5e172fa21)
**After:**
![after](https://github.com/user-attachments/assets/d387e968-c5e8-4d6d-b312-eb1e2b845c45)


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
