### PR TITLE
DirectoryIterator: Fix move constructor

### DIFF
--- a/gemrb/core/System/VFS.cpp
+++ b/gemrb/core/System/VFS.cpp
@@ -583,6 +583,20 @@ DirectoryIterator::DirectoryIterator(path_t path)
 	Rewind();
 }
 
+DirectoryIterator::DirectoryIterator(DirectoryIterator&& other) noexcept
+{
+	predicate = std::move(other.predicate);
+
+	Directory = std::move(other.Directory);
+	other.Directory = nullptr;
+
+	Entry = std::move(other.Entry);
+	other.Entry = nullptr;
+
+	Path = std::move(other.Path);
+	entrySkipFlags = std::move(other.entrySkipFlags);
+}
+
 DirectoryIterator::~DirectoryIterator()
 {
 	if (Directory)

--- a/gemrb/core/System/VFS.h
+++ b/gemrb/core/System/VFS.h
@@ -173,7 +173,10 @@ public:
 	 */
 	explicit DirectoryIterator(path_t path);
 	DirectoryIterator(const DirectoryIterator&) = delete;
-	DirectoryIterator(DirectoryIterator&&) noexcept = default;
+	// Manual move constructor needed to properly take ownership of DirectoryIterator::Directory.
+	// Without a manual implementation DirectoryIterator::Directory is improperly closed when the
+	// moving instance is destructed.
+	DirectoryIterator(DirectoryIterator&&) noexcept;
 	~DirectoryIterator();
 	DirectoryIterator& operator=(const DirectoryIterator&) = delete;
 


### PR DESCRIPTION
## Description
`DirectoryIterator(DirectoryIterator&&)` failed to take ownership of `DirectoryIterator::Directory`, which without copy elision (debug build) caused `DirectoryIterator::Directory` to be incorrectly closed. I experienced this manifesting as crashes during character creation when importing a character file / when hitting the name stage.

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)