### PR TITLE
iwd2: fix object selector value order

### DIFF
--- a/gemrb/core/GameScript/GSUtils.cpp
+++ b/gemrb/core/GameScript/GSUtils.cpp
@@ -69,6 +69,7 @@ std::array<uint16_t, MAX_ACTIONS> actionflags;
 std::array<short, MAX_TRIGGERS> triggerflags;
 ResRefRCCache<Script> BcsCache; //cache for scripts
 int ObjectIDSCount = 7;
+int DialogObjectIDSCount = 7;
 int MaxObjectNesting = 5;
 bool HasAdditionalRect = false;
 bool HasTriggerPoint = false;
@@ -76,6 +77,8 @@ bool HasTriggerPoint = false;
 bool NoCreate = false;
 bool HasKaputz = false;
 std::vector<ResRef> ObjectIDSTableNames;
+std::vector<int> DialogObjectIDSOrder;
+std::vector<ResRef> DialogObjectIDSTableNames;
 int ObjectFieldsCount = 7;
 int ExtraParametersCount = 0;
 int RandomNumValue;

--- a/gemrb/core/GameScript/GSUtils.h
+++ b/gemrb/core/GameScript/GSUtils.h
@@ -54,12 +54,15 @@ extern std::array<uint16_t, MAX_ACTIONS> actionflags;
 extern std::array<short, MAX_TRIGGERS> triggerflags;
 extern ResRefRCCache<Script> BcsCache; //cache for scripts
 extern int ObjectIDSCount;
+extern int DialogObjectIDSCount;
 extern int MaxObjectNesting;
 extern bool HasAdditionalRect;
 extern bool HasTriggerPoint;
 extern bool NoCreate;
 extern bool HasKaputz;
 extern std::vector<ResRef> ObjectIDSTableNames;
+extern std::vector<int> DialogObjectIDSOrder;
+extern std::vector<ResRef> DialogObjectIDSTableNames;
 extern int ObjectFieldsCount;
 extern int ExtraParametersCount;
 extern Gem_Polygon** polygons;

--- a/gemrb/core/GameScript/GameScript.cpp
+++ b/gemrb/core/GameScript/GameScript.cpp
@@ -1302,7 +1302,7 @@ static const L* FindLink(StringView name, const L2& names)
 
 static const IDSLink* FindIdentifier(const std::string& idsname)
 {
-	int len = static_cast<int>(idsname.size());
+	int len = static_cast<int>(idsname.size() + 1);
 	for (int i = 0; idsnames[i].Name; i++) {
 		if (!strnicmp(idsnames[i].Name, idsname.c_str(), len)) {
 			return idsnames + i;

--- a/gemrb/core/GameScript/GameScript.cpp
+++ b/gemrb/core/GameScript/GameScript.cpp
@@ -1270,7 +1270,7 @@ static const IDSLink idsnames[] = {
 	{ "align", GameScript::ID_Alignment },
 	{ "alignmen", GameScript::ID_Alignment },
 	{ "alignmnt", GameScript::ID_Alignment },
-	{ "class20", GameScript::ID_AVClass },
+	{ "avclass", GameScript::ID_AVClass },
 	{ "class", GameScript::ID_Class },
 	{ "classmsk", GameScript::ID_ClassMask },
 	{ "ea", GameScript::ID_Allegiance },

--- a/gemrb/core/GameScript/GameScript.cpp
+++ b/gemrb/core/GameScript/GameScript.cpp
@@ -1659,6 +1659,38 @@ static void SetupSavedTriggers()
 	}
 }
 
+static void InitializeObjectIDS(const AutoTable& objNameTable)
+{
+	TableMgr::index_t idsRow = objNameTable->GetRowIndex("OBJECT_IDS_COUNT");
+
+	ObjectIDSCount = objNameTable->QueryFieldSigned<int>(idsRow, 0);
+	if (ObjectIDSCount < 0 || ObjectIDSCount > MAX_OBJECT_FIELDS) {
+		error("GameScript", "The IDS Count shouldn't be more than 10!");
+	}
+
+	ObjectIDSTableNames.resize(ObjectIDSCount);
+	for (int i = 0; i < ObjectIDSCount; i++) {
+		const std::string& idsName = objNameTable->QueryField(idsRow, i + 1);
+		const IDSLink* poi = FindIdentifier(idsName.c_str());
+		if (poi == nullptr) {
+			idtargets[i] = nullptr;
+		} else {
+			idtargets[i] = poi->Function;
+		}
+		ObjectIDSTableNames[i] = ResRef(idsName);
+	}
+
+	MaxObjectNesting = objNameTable->QueryFieldSigned<int>("MAX_OBJECT_NESTING", "DATA");
+	if (MaxObjectNesting < 0 || MaxObjectNesting > MAX_NESTING) {
+		error("GameScript", "The Object Nesting Count shouldn't be more than 5!");
+	}
+
+	HasAdditionalRect = objNameTable->QueryFieldSigned<int>("ADDITIONAL_RECT", "DATA") != 0;
+	ExtraParametersCount = objNameTable->QueryFieldSigned<int>("EXTRA_PARAMETERS_COUNT", "DATA");
+	HasTriggerPoint = objNameTable->QueryFieldSigned<int>("TRIGGER_POINT", "DATA") != 0;
+	ObjectFieldsCount = ObjectIDSCount - ExtraParametersCount;
+}
+
 void InitializeIEScript()
 {
 	PluginMgr::Get()->RegisterCleanup(CleanupIEScript);
@@ -1690,31 +1722,7 @@ void InitializeIEScript()
 	}
 
 	/* Loading Script Configuration Parameters */
-
-	ObjectIDSCount = objNameTable->QueryFieldSigned<int>(0, 0);
-	if (ObjectIDSCount < 0 || ObjectIDSCount > MAX_OBJECT_FIELDS) {
-		error("GameScript", "The IDS Count shouldn't be more than 10!");
-	}
-
-	ObjectIDSTableNames.resize(ObjectIDSCount);
-	for (int i = 0; i < ObjectIDSCount; i++) {
-		const std::string& idsName = objNameTable->QueryField(0, i + 1);
-		const IDSLink* poi = FindIdentifier(idsName.c_str());
-		if (poi == nullptr) {
-			idtargets[i] = nullptr;
-		} else {
-			idtargets[i] = poi->Function;
-		}
-		ObjectIDSTableNames[i] = ResRef(idsName);
-	}
-	MaxObjectNesting = objNameTable->QueryFieldSigned<int>(1, 0);
-	if (MaxObjectNesting < 0 || MaxObjectNesting > MAX_NESTING) {
-		error("GameScript", "The Object Nesting Count shouldn't be more than 5!");
-	}
-	HasAdditionalRect = objNameTable->QueryFieldSigned<int>(2, 0) != 0;
-	ExtraParametersCount = objNameTable->QueryFieldSigned<int>(3, 0);
-	HasTriggerPoint = objNameTable->QueryFieldSigned<int>(4, 0) != 0;
-	ObjectFieldsCount = ObjectIDSCount - ExtraParametersCount;
+	InitializeObjectIDS(objNameTable);
 
 	/* Initializing the Script Engine */
 	SetupTriggers();

--- a/gemrb/core/GameScript/Objects.cpp
+++ b/gemrb/core/GameScript/Objects.cpp
@@ -1350,12 +1350,11 @@ int GameScript::ID_ClassMask(const Actor* actor, int parameter)
 	return 0;
 }
 
-// this is only present in iwd2
-// the function is identical to ID_Class, but uses the class20 IDS,
-// iwd2's class.ids is different than the rest, while class20 is identical (remnant)
-int GameScript::ID_AVClass(const Actor* actor, int parameter)
+// Defunct object selector in IWD2. AVCLASS.IDS doesn't exist, and the engine
+// doesn't do anything with the value other than read / write it to sprites.
+int GameScript::ID_AVClass(const Actor*, int)
 {
-	return idclass(actor, parameter, false);
+	return true;
 }
 
 int GameScript::ID_Race(const Actor* actor, int parameter)

--- a/gemrb/core/GameScript/ParseText.cpp
+++ b/gemrb/core/GameScript/ParseText.cpp
@@ -93,8 +93,9 @@ static int ParseIntParam(const char*& src, const char*& str)
 
 static void ParseIdsTarget(const char*& src, Object*& object)
 {
-	for (int i = 0; i < ObjectFieldsCount; i++) {
-		object->objectFields[i] = GetIdsValue(src, ObjectIDSTableNames[i]);
+	for (int i = 0; i < DialogObjectIDSCount; i++) {
+		int fieldIndex = DialogObjectIDSOrder[i];
+		object->objectFields[fieldIndex] = GetIdsValue(src, DialogObjectIDSTableNames[i]);
 		if (*src != '.') {
 			break;
 		}

--- a/gemrb/core/GameScript/Triggers.cpp
+++ b/gemrb/core/GameScript/Triggers.cpp
@@ -209,7 +209,7 @@ int GameScript::ClassEx(Scriptable* Sender, const Trigger* parameters)
 		return 0;
 	}
 
-	return ID_AVClass(actor, parameters->int0Parameter);
+	return ID_Class(actor, parameters->int0Parameter);
 }
 
 int GameScript::Faction(Scriptable* Sender, const Trigger* parameters)

--- a/gemrb/unhardcoded/iwd2/script.2da
+++ b/gemrb/unhardcoded/iwd2/script.2da
@@ -1,8 +1,10 @@
 2DA V1.0
 0
-			DATA	1	2	3	4	5		6	7		8	9	10
-OBJECT_IDS_COUNT	10	ea	general	race	subrace class	specific	gender	alignmnt	class	classmsk
-MAX_OBJECT_NESTING	5
-ADDITIONAL_RECT		1
-EXTRA_PARAMETERS_COUNT	2
-TRIGGER_POINT           0
+                          DATA    1     2          3       4          5           6           7           8           9        10
+OBJECT_IDS_COUNT          10      ea    general    race    class      specific    gender      alignmnt    subrace     class    classmsk
+MAX_OBJECT_NESTING        5
+ADDITIONAL_RECT           1
+EXTRA_PARAMETERS_COUNT    2
+TRIGGER_POINT             0
+DIALOG_IDS_ORDER          *       1     2          3       8          4           5           6           7           9        10
+DIALOG_IDS_COUNT          10      ea    general    race    subrace    class       specific    gender      align       class    classmsk

--- a/gemrb/unhardcoded/iwd2/script.2da
+++ b/gemrb/unhardcoded/iwd2/script.2da
@@ -1,10 +1,10 @@
 2DA V1.0
 0
-                          DATA    1     2          3       4          5           6           7           8           9        10
-OBJECT_IDS_COUNT          10      ea    general    race    class      specific    gender      alignmnt    subrace     class    classmsk
+                          DATA    1     2          3       4          5           6           7           8           9          10
+OBJECT_IDS_COUNT          10      ea    general    race    class      specific    gender      alignmnt    subrace     avclass    classmsk
 MAX_OBJECT_NESTING        5
 ADDITIONAL_RECT           1
 EXTRA_PARAMETERS_COUNT    2
 TRIGGER_POINT             0
-DIALOG_IDS_ORDER          *       1     2          3       8          4           5           6           7           9        10
-DIALOG_IDS_COUNT          10      ea    general    race    subrace    class       specific    gender      align       class    classmsk
+DIALOG_IDS_ORDER          *       1     2          3       8          4           5           6           7           9          10
+DIALOG_IDS_COUNT          10      ea    general    race    subrace    class       specific    gender      align       avclass    classmsk


### PR DESCRIPTION
## Description
IWD2 parses object selectors in differing orders depending on whether it's working with .DLG resources (text) or .BCS resources (compiled). It seems that GemRB is using the dialog order to read .BCS files, which causes incorrect object selector resolution in scripts.

Here's the different orders:
- Dialog:
  ```
  [EA.GENERAL.RACE.SUBRACE.CLASS.SPECIFIC.GENDER.ALIGN.AVCLASS.CLASSMSK]
  ```
- BCS `OB` format:
  ```
  EA GENERAL RACE CLASS SPECIFIC GENDER ALIGNMNT SUBRACE filter1 filter2 filter3 filter4 filter5 [rect1.rect2.rect3.rect4] "scriptname" AVCLASS CLASSMSK
  ```

I've lightly tested the changes, and am opening this pull request as a draft for feedback as to whether the fix method is acceptable. The PR has softcoded the definition of dialog object selector parsing to `script.2da`.

Some uncertainties:
- The second-to-last object selector parameter, `AVCLASS`, is completely unused by IWD2. I've dummied out the relevant filter function to ignore this value.
- IWD2's dialog parser has incorrectly hardcoded `ALIGN` instead of `ALIGNMNT` as to where it pulls symbols from for that value. While the value functionally works off of `ALIGNMNT`, I've altered the listing for dialogs in `script.2da` to pull from the erroneous IDS to maintain compatibility with the original engine.
- IWD2's dialog parser additionally has a bug related to reading the `CLASSMSK` value where it truncates it to a byte. I have **not** replicated that behavior in GemRB.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
