### PR TITLE
Some more sound improvements and fixes

### DIFF
--- a/gemrb/core/AmbientMgr.cpp
+++ b/gemrb/core/AmbientMgr.cpp
@@ -314,7 +314,7 @@ tick_t AmbientMgr::AmbientSource::Enqueue() const
 {
 	if (stream < 0) return -1;
 	// print("Playing ambient %s, %d/%ld on stream %d", ambient->sounds[nextref], nextref, ambient->sounds.size(), stream);
-	return core->GetAudioDrv()->QueueAmbient(stream, ambient->sounds[nextref]);
+	return core->GetAudioDrv()->QueueAmbient(stream, ambient->sounds[nextref], !(ambient->GetFlags() & IE_AMBI_MAIN));
 }
 
 bool AmbientMgr::AmbientSource::IsHeard(const Point& listener) const

--- a/gemrb/core/Audio.h
+++ b/gemrb/core/Audio.h
@@ -145,7 +145,7 @@ public:
 	virtual bool ReleaseStream(int stream, bool HardStop = false) = 0;
 	virtual int SetupNewStream(int x, int y, int z,
 				   ieWord gain, bool point, int ambientRange) = 0;
-	virtual tick_t QueueAmbient(int stream, const ResRef& sound) = 0;
+	virtual tick_t QueueAmbient(int stream, const ResRef& sound, bool spatial) = 0;
 	virtual void SetAmbientStreamVolume(int stream, int volume) = 0;
 	virtual void SetAmbientStreamPitch(int stream, int pitch) = 0;
 	virtual void QueueBuffer(int stream, unsigned short bits,

--- a/gemrb/core/Scriptable/Actor.cpp
+++ b/gemrb/core/Scriptable/Actor.cpp
@@ -3855,7 +3855,7 @@ void Actor::PlayExistenceSounds()
 		ieDword vol = core->GetDictionary().Get("Volume Ambients", 100);
 		int stream = audio->SetupNewStream(Pos.x, Pos.y, 0, ieWord(vol), true, 50); // REFERENCE_DISTANCE
 		if (stream != -1) {
-			tick_t audioLength = audio->QueueAmbient(stream, sb.Sound);
+			tick_t audioLength = audio->QueueAmbient(stream, sb.Sound, true);
 			if (audioLength > 0) {
 				SetAnimatedTalking(audioLength);
 			}

--- a/gemrb/plugins/NullSound/NullSound.cpp
+++ b/gemrb/plugins/NullSound/NullSound.cpp
@@ -95,7 +95,7 @@ int NullSound::SetupNewStream(int, int, int, ieWord, bool, int)
 	return -1;
 }
 
-tick_t NullSound::QueueAmbient(int, const ResRef&)
+tick_t NullSound::QueueAmbient(int, const ResRef&, bool)
 {
 	return -1;
 }

--- a/gemrb/plugins/NullSound/NullSound.h
+++ b/gemrb/plugins/NullSound/NullSound.h
@@ -44,7 +44,7 @@ public:
 	void UpdateVolume(unsigned int) override {}
 
 	int SetupNewStream(int x, int y, int z, ieWord gain, bool point, int ambientRange) override;
-	tick_t QueueAmbient(int stream, const ResRef& sound) override;
+	tick_t QueueAmbient(int stream, const ResRef& sound, bool ambient) override;
 	bool ReleaseStream(int stream, bool hardstop) override;
 	void SetAmbientStreamVolume(int stream, int gain) override;
 	void SetAmbientStreamPitch(int stream, int pitch) override;

--- a/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
+++ b/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
@@ -897,7 +897,7 @@ int OpenALAudioDriver::SetupNewStream(int x, int y, int z,
 	return streamIdx;
 }
 
-tick_t OpenALAudioDriver::QueueAmbient(int streamIdx, const ResRef& sound)
+tick_t OpenALAudioDriver::QueueAmbient(int streamIdx, const ResRef& sound, bool spatial)
 {
 	auto& stream = streams[streamIdx];
 	if (stream.free || !stream.ambient)
@@ -909,7 +909,7 @@ tick_t OpenALAudioDriver::QueueAmbient(int streamIdx, const ResRef& sound)
 	stream.ClearProcessedBuffers();
 
 	tick_t time_length;
-	ALuint Buffer = loadSound(sound, time_length).first;
+	ALuint Buffer = loadSound(sound, time_length, spatial).first;
 	if (0 == Buffer) {
 		return -1;
 	}

--- a/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
+++ b/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
@@ -863,18 +863,28 @@ int OpenALAudioDriver::SetupNewStream(int x, int y, int z,
 		return -1;
 	}
 
-	ALfloat position[] = { (float) x, (float) y, (float) z };
 	alSourcef(source, AL_PITCH, 1.0f);
-	alSourcefv(source, AL_POSITION, position);
 	alSourcei(source, AL_LOOPING, 0);
-	alSourcef(source, AL_GAIN, 0.01f * gain);
-	// under default sound distance model (AL_INVERSE_DISTANCE_CLAMPED) the formula is:
-	//   dist = max(dist, AL_REFERENCE_DISTANCE);
-	//   dist = min(dist, AL_MAX_DISTANCE);
-	//   gain = AL_REFERENCE_DISTANCE / (AL_REFERENCE_DISTANCE + AL_ROLLOFF_FACTOR * (dist – AL_REFERENCE_DISTANCE) );
-	// ambientRange also works as cut-off distance, so reducing the volume earlier
-	alSourcei(source, AL_REFERENCE_DISTANCE, ambientRange > 0 ? (ambientRange / 2) : REFERENCE_DISTANCE);
-	alSourcei(source, AL_ROLLOFF_FACTOR, point ? 1 : 0);
+	alSourcef(source, AL_GAIN, 0.03f * gain);
+	alSourcei(source, AL_REFERENCE_DISTANCE, REFERENCE_DISTANCE);
+	alSourcei(source, AL_ROLLOFF_FACTOR, 0);
+	alSourcei(source, AL_SOURCE_RELATIVE, !point);
+
+	if (point) {
+		ALfloat position[] = { (float) x, (float) y, (float) z };
+		alSourcefv(source, AL_POSITION, position);
+
+		// under default sound distance model (AL_INVERSE_DISTANCE_CLAMPED) the formula is:
+		//   dist = max(dist, AL_REFERENCE_DISTANCE);
+		//   dist = min(dist, AL_MAX_DISTANCE);
+		//   gain = AL_REFERENCE_DISTANCE / (AL_REFERENCE_DISTANCE + AL_ROLLOFF_FACTOR * (dist – AL_REFERENCE_DISTANCE) );
+		alSourcei(source, AL_ROLLOFF_FACTOR, 4);
+		alSourcei(source, AL_MAX_DISTANCE, ambientRange);
+	} else {
+		ALfloat position[] = { 0.0f, 0.0f, 0.0f };
+		alSourcefv(source, AL_POSITION, position);
+	}
+
 	checkALError("Unable to set stream parameters", WARNING);
 
 	auto& stream = streams[streamIdx];

--- a/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
+++ b/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
@@ -182,7 +182,7 @@ bool AudioStream::ClearIfStopped(ALuint Source)
 	alGetSourcei(Source, AL_SOURCE_STATE, &state);
 	if (!checkALError("Failed to check source state", WARNING) &&
 	    state == AL_STOPPED) {
-		ClearProcessedBuffers();
+		ClearProcessedBuffers(Source);
 		alDeleteSources(1, &Source);
 		checkALError("Failed to delete source", WARNING);
 

--- a/gemrb/plugins/OpenALAudio/OpenALAudio.h
+++ b/gemrb/plugins/OpenALAudio/OpenALAudio.h
@@ -170,7 +170,7 @@ public:
 	bool ReleaseStream(int stream, bool HardStop) override;
 	int SetupNewStream(int x, int y, int z,
 			   ieWord gain, bool point, int ambientRange) override;
-	tick_t QueueAmbient(int stream, const ResRef& sound) override;
+	tick_t QueueAmbient(int stream, const ResRef& sound, bool spatial) override;
 	void SetAmbientStreamVolume(int stream, int volume) override;
 	void SetAmbientStreamPitch(int stream, int pitch) override;
 	void QueueBuffer(int stream, unsigned short bits,

--- a/gemrb/plugins/SDLAudio/SDLAudio.cpp
+++ b/gemrb/plugins/SDLAudio/SDLAudio.cpp
@@ -438,7 +438,7 @@ int SDLAudio::SetupNewStream(int x, int y, int z,
 	return 0;
 }
 
-tick_t SDLAudio::QueueAmbient(int stream, const ResRef& sound)
+tick_t SDLAudio::QueueAmbient(int stream, const ResRef& sound, bool spatial)
 {
 	if (stream <= 0 || stream > AMBIENT_CHANNELS) {
 		return -1;
@@ -455,7 +455,7 @@ tick_t SDLAudio::QueueAmbient(int stream, const ResRef& sound)
 		return -1;
 	}
 
-	if (ambientStreams[stream - 1].point) {
+	if (spatial && ambientStreams[stream - 1].point) {
 		SetChannelPosition(listenerPos, ambientStreams[stream - 1].streamPos, stream, AMBIENT_DISTANCE_ROLLOFF_MOD);
 	}
 	Mix_PlayChannel(stream, chunk, 0);

--- a/gemrb/plugins/SDLAudio/SDLAudio.h
+++ b/gemrb/plugins/SDLAudio/SDLAudio.h
@@ -130,7 +130,7 @@ public:
 	void UpdateVolume(unsigned int flags) override;
 
 	int SetupNewStream(int x, int y, int z, ieWord gain, bool point, int ambientRange) override;
-	tick_t QueueAmbient(int stream, const ResRef& sound) override;
+	tick_t QueueAmbient(int stream, const ResRef& sound, bool spatial) override;
 	bool ReleaseStream(int stream, bool hardstop) override;
 	void SetAmbientStreamVolume(int stream, int gain) override;
 	void SetAmbientStreamPitch(int stream, int pitch) override;


### PR DESCRIPTION
## Description
Essentially everything sound-related discussed in #2241.

Regarding the volume roll-off of ambients: Good and easy candidates to compare are the crystal in AR1202 of PST, or the buzzing machine very close to where BG2 starts in the dungeon.

It's not that easy and good to directly try to reflect the original since the sound model there is primitive, i. e.  no spatial magic, but more to somewhat get volume levels roughly between the loudest point (center) and the edge before the ambient mgr stops playback due to radius. Can't do too steep roll-off since that would go low too early.

So please have a test and feel free to suggest different params.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
