### PR TITLE
Fix demo script.2da

### DIFF
--- a/demo/override/script.2da
+++ b/demo/override/script.2da
@@ -1,8 +1,8 @@
 2DA V1.0
 *
-        RESREF
-OBJECT_IDS_COUNT	7	ea	general	race	class	specific	gender	alignmen
-MAX_OBJECT_NESTING	5
-ADDITIONAL_RECT		0
-EXTRA_PARAMETERS_COUNT	0
-TRIGGER_POINT           0
+                          RESREF
+OBJECT_IDS_COUNT          7         ea    general    race    class    specific    gender    alignmen
+MAX_OBJECT_NESTING        5
+ADDITIONAL_RECT           0
+EXTRA_PARAMETERS_COUNT    0
+TRIGGER_POINT             0

--- a/demo/override/script.2da
+++ b/demo/override/script.2da
@@ -1,7 +1,7 @@
 2DA V1.0
-*
-                          RESREF
-OBJECT_IDS_COUNT          7         ea    general    race    class    specific    gender    alignmen
+0
+                          DATA    1     2          3       4        5           6         7
+OBJECT_IDS_COUNT          7       ea    general    race    class    specific    gender    alignmen
 MAX_OBJECT_NESTING        5
 ADDITIONAL_RECT           0
 EXTRA_PARAMETERS_COUNT    0

--- a/gemrb/unhardcoded/bg1/script.2da
+++ b/gemrb/unhardcoded/bg1/script.2da
@@ -1,8 +1,8 @@
 2DA V1.0
 0
-			DATA	1	2	3	4	5		6	7
-OBJECT_IDS_COUNT	7	ea	general	race	class	specific	gender	alignmen
-MAX_OBJECT_NESTING	5
-ADDITIONAL_RECT		0
-EXTRA_PARAMETERS_COUNT	0
-TRIGGER_POINT           0
+                          DATA    1     2          3       4        5           6         7
+OBJECT_IDS_COUNT          7       ea    general    race    class    specific    gender    alignmen
+MAX_OBJECT_NESTING        5
+ADDITIONAL_RECT           0
+EXTRA_PARAMETERS_COUNT    0
+TRIGGER_POINT             0

--- a/gemrb/unhardcoded/bg2/script.2da
+++ b/gemrb/unhardcoded/bg2/script.2da
@@ -1,9 +1,8 @@
 2DA V1.0
 0
-			DATA	1	2	3	4	5		6	7
-OBJECT_IDS_COUNT	7	ea	general	race	class	specific	gender	alignmen
-MAX_OBJECT_NESTING	5
-ADDITIONAL_RECT		0
-EXTRA_PARAMETERS_COUNT	0
-TRIGGER_POINT           0
-
+                          DATA    1     2          3       4        5           6         7
+OBJECT_IDS_COUNT          7       ea    general    race    class    specific    gender    alignmen
+MAX_OBJECT_NESTING        5
+ADDITIONAL_RECT           0
+EXTRA_PARAMETERS_COUNT    0
+TRIGGER_POINT             0

--- a/gemrb/unhardcoded/bg2ee/script.2da
+++ b/gemrb/unhardcoded/bg2ee/script.2da
@@ -1,9 +1,8 @@
 2DA V1.0
 0
-			DATA	1	2	3	4	5		6	7
-OBJECT_IDS_COUNT	7	ea	general	race	class	specific	gender	alignmen
-MAX_OBJECT_NESTING	5
-ADDITIONAL_RECT		0
-EXTRA_PARAMETERS_COUNT	0
-TRIGGER_POINT           0
-
+                          DATA    1     2          3       4        5           6         7
+OBJECT_IDS_COUNT          7       ea    general    race    class    specific    gender    alignmen
+MAX_OBJECT_NESTING        5
+ADDITIONAL_RECT           0
+EXTRA_PARAMETERS_COUNT    0
+TRIGGER_POINT             0

--- a/gemrb/unhardcoded/how/script.2da
+++ b/gemrb/unhardcoded/how/script.2da
@@ -1,8 +1,8 @@
 2DA V1.0
 0
-			DATA	1	2	3	4	5		6	7
-OBJECT_IDS_COUNT	7	ea	general	race	class	specific	gender	align
-MAX_OBJECT_NESTING	5
-ADDITIONAL_RECT		1
-EXTRA_PARAMETERS_COUNT	0
-TRIGGER_POINT           0
+                          DATA    1     2          3       4        5           6         7
+OBJECT_IDS_COUNT          7       ea    general    race    class    specific    gender    align
+MAX_OBJECT_NESTING        5
+ADDITIONAL_RECT           1
+EXTRA_PARAMETERS_COUNT    0
+TRIGGER_POINT             0

--- a/gemrb/unhardcoded/iwd/script.2da
+++ b/gemrb/unhardcoded/iwd/script.2da
@@ -1,8 +1,8 @@
 2DA V1.0
 0
-			DATA	1	2	3	4	5		6	7
-OBJECT_IDS_COUNT	7	ea	general	race	class	specific	gender	align
-MAX_OBJECT_NESTING	5
-ADDITIONAL_RECT		1
-EXTRA_PARAMETERS_COUNT	0
-TRIGGER_POINT           0
+                          DATA    1     2          3       4        5           6         7
+OBJECT_IDS_COUNT          7       ea    general    race    class    specific    gender    align
+MAX_OBJECT_NESTING        5
+ADDITIONAL_RECT           1
+EXTRA_PARAMETERS_COUNT    0
+TRIGGER_POINT             0

--- a/gemrb/unhardcoded/pst/script.2da
+++ b/gemrb/unhardcoded/pst/script.2da
@@ -1,8 +1,8 @@
 2DA V1.0
 0
-			DATA	1	2	3	4	5		6	7	8	9
-OBJECT_IDS_COUNT	9	ea	faction	team	general	race	class	specific	gender	align
-MAX_OBJECT_NESTING	5
-ADDITIONAL_RECT		1
-EXTRA_PARAMETERS_COUNT	0
-TRIGGER_POINT           1
+                          DATA    1     2          3       4          5       6        7           8         9
+OBJECT_IDS_COUNT          9       ea    faction    team    general    race    class    specific    gender    align
+MAX_OBJECT_NESTING        5
+ADDITIONAL_RECT           1
+EXTRA_PARAMETERS_COUNT    0
+TRIGGER_POINT             1


### PR DESCRIPTION
## Description
Accessing `script.2da`'s `DATA` column by name (introduced in b413f853213b1728c647c1b3e1946c664ddd78c0) caused a regression in parsing the demo's `script.2da`. This PR should fix #2243.

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)