### PR TITLE
OGG & OpenAL changes

### DIFF
--- a/gemrb/plugins/OGGReader/OGGReader.cpp
+++ b/gemrb/plugins/OGGReader/OGGReader.cpp
@@ -96,7 +96,9 @@ bool OGGReader::Import(DataStream* stream)
 	info = ov_info(&OggStream, -1);
 	channels = info->channels;
 	samplerate = info->rate;
-	samples_left = (samples = ov_pcm_total(&OggStream, -1));
+	samples_left = ov_pcm_total(&OggStream, -1);
+	// align to how WAVReader counts samples (one is per channel)
+	samples = samples_left * channels;
 	return true;
 }
 
@@ -134,6 +136,7 @@ int OGGReader::ReadSamplesIntoChannels(char* channel1, char* channel2, int numSa
 	std::vector<char> buffer;
 	buffer.resize(CHANNEL_SPLIT_BUFFER_SIZE);
 	int streamPos = 0;
+	numSamples /= channels;
 
 	uint8_t bytesPerChannel = 2;
 	uint8_t bytesPerSample = 2 * bytesPerChannel;

--- a/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
+++ b/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
@@ -865,7 +865,7 @@ int OpenALAudioDriver::SetupNewStream(int x, int y, int z,
 
 	alSourcef(source, AL_PITCH, 1.0f);
 	alSourcei(source, AL_LOOPING, 0);
-	alSourcef(source, AL_GAIN, 0.03f * gain);
+	alSourcef(source, AL_GAIN, 0.01f * gain);
 	alSourcei(source, AL_REFERENCE_DISTANCE, REFERENCE_DISTANCE);
 	alSourcei(source, AL_ROLLOFF_FACTOR, 0);
 	alSourcei(source, AL_SOURCE_RELATIVE, !point);
@@ -880,6 +880,7 @@ int OpenALAudioDriver::SetupNewStream(int x, int y, int z,
 		//   gain = AL_REFERENCE_DISTANCE / (AL_REFERENCE_DISTANCE + AL_ROLLOFF_FACTOR * (dist – AL_REFERENCE_DISTANCE) );
 		alSourcei(source, AL_ROLLOFF_FACTOR, 4);
 		alSourcei(source, AL_MAX_DISTANCE, ambientRange);
+		alSourcef(source, AL_GAIN, 0.03f * gain);
 	} else {
 		ALfloat position[] = { 0.0f, 0.0f, 0.0f };
 		alSourcefv(source, AL_POSITION, position);

--- a/gemrb/plugins/OpenALAudio/OpenALAudio.h
+++ b/gemrb/plugins/OpenALAudio/OpenALAudio.h
@@ -195,7 +195,7 @@ private:
 	int num_streams = 0;
 
 	std::atomic_bool stayAlive { true };
-	short* music_memory;
+	std::vector<short> musicBuffer;
 	std::thread musicThread;
 
 	bool hasReverbProperties = false;


### PR DESCRIPTION
## Description
I did three things here:

1. OAL: restricted increased source gain to local ambients, globals were measurably too loud this way.
2. OAL: some little refactoring
3. OGG: changed the way samples are counted to match the WAV reading, fixes #2251 

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
