### PR TITLE
GUIScript: GemRB_ExecuteString() can use object under cursor as script context

### DIFF
--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -2683,6 +2683,12 @@ void GameControl::SetLastActor(Actor* lastActor)
 	}
 }
 
+Scriptable* GameControl::GetHoverObject() const
+{
+	Scriptable* const lastActor = lastActorID != 0 ? GetLastActor() : nullptr;
+	return lastActor != nullptr ? lastActor : overMe;
+}
+
 //Set up an item use which needs targeting
 //Slot is an inventory slot
 //header is the used item extended header

--- a/gemrb/core/GUI/GameControl.h
+++ b/gemrb/core/GUI/GameControl.h
@@ -209,6 +209,8 @@ public:
 	void DisplayString(const Point& p, const char* Text);
 	Actor* GetLastActor() const;
 	void SetLastActor(Actor* lastActor);
+	/** Gets the Scriptable currently under the cursor */
+	Scriptable* GetHoverObject() const;
 	/** changes map to the current PC */
 	void ChangeMap(const Actor* pc, bool forced);
 	/** Sets up targeting with spells or items */


### PR DESCRIPTION
## Description
This pull request allows `ExecuteString()` to use the object under the cursor as the script context, which is a pretty nifty feature lifted from the EE's `Eval()` debug console command.

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)