### PR TITLE
Fix detection of RaspberryPi OS

### DIFF
--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -534,8 +534,8 @@ FUNCTION(CONFIGURE_UNIX_SPECIFICS)
 ENDFUNCTION()
 
 FUNCTION(CONFIGURE_RPI_SPECIFICS)
-	# check for RaspberryPi
-	FIND_FILE(RPI NAMES bcm_host.h PATHS "/opt/vc/include")
+	# check for RaspberryPi; on newer 64 bit RaspberryPi OS there is no /opt/vc/, check for raspi.list in /etc/apt/sources.list.d/
+	FIND_FILE(RPI NAMES bcm_host.h raspi.list PATHS "/opt/vc/include" "/etc/apt/sources.list.d/")
 
 	IF(RPI AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 		MESSAGE(FATAL_ERROR


### PR DESCRIPTION
Old check is not sufficient in the new RaspberryPi OS, which can lead to building a broken build, as the default compiler on this OS is currently GCC 12.
Extended file check to additionally look for '/etc/apt/sources.list.d/raspi.list'.