### PR TITLE
Screen tinting

### DIFF
--- a/gemrb/core/GUI/WindowManager.cpp
+++ b/gemrb/core/GUI/WindowManager.cpp
@@ -608,6 +608,10 @@ void WindowManager::DrawWindows() const
 	// draw the game window now (beneath everything else); it's not part of the windows collection
 	if (gameWin->IsVisible()) {
 		gameWin->Draw();
+
+		if (FadeColor.a > 0) {
+			video->DrawRect(screen, FadeColor, true, BlitFlags::BLENDED);
+		}
 	} else {
 		// something must get drawn or else we get smearing
 		// this is kind of a hacky way to clear it, but it works
@@ -684,10 +688,6 @@ void WindowManager::DrawWindows() const
 			r.ExpandAllSides(10);
 			video->DrawRect(r, ColorWhite, false);
 		}
-	}
-
-	if (!modalWin && !drawFrame && FadeColor.a > 0) {
-		video->DrawRect(screen, FadeColor, true);
 	}
 
 	DrawMouse();


### PR DESCRIPTION
## Description
See #2314. I'm aware of PST's `FadeToBlack` and also the opcode 0xC3 as far as it concerns some spells. For the fading, it now matches the original that leaves the UI presented, and the spells also only touch the game world. So is there some case where this wouldn't help or needs more attention?

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
