### PR TITLE
GameControl: Implement smooth keyboard scrolling

### DIFF
--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -712,7 +712,7 @@ bool GameControl::OnKeyPress(const KeyboardEvent& Key, unsigned short mod)
 				if (Flags() & IgnoreEvents) {
 					break;
 				}
-				ushort arrowKey = 1 << (keycode - GEM_LEFT);
+				unsigned int arrowKey = 1 << (keycode - GEM_LEFT);
 
 				// don't reprocess repeating keystrokes
 				if (scrollKeysDown & arrowKey) {
@@ -723,7 +723,7 @@ bool GameControl::OnKeyPress(const KeyboardEvent& Key, unsigned short mod)
 				scrollKeysActive |= arrowKey;
 
 				// If the opposite arrow key is held down, the new key press overrides it:
-				ushort oppositeKey = (arrowKey & 1) ? arrowKey << 1 : arrowKey >> 1;
+				unsigned int oppositeKey = (arrowKey & 1) ? arrowKey << 1 : arrowKey >> 1;
 				scrollKeysActive &= ~oppositeKey;
 
 				ApplyKeyScrolling();
@@ -1137,12 +1137,12 @@ bool GameControl::OnKeyRelease(const KeyboardEvent& Key, unsigned short Mod)
 		case GEM_LEFT:
 		case GEM_RIGHT:
 			{
-				ushort releasedKey = 1 << (Key.keycode - GEM_LEFT);
+				unsigned int releasedKey = 1 << (Key.keycode - GEM_LEFT);
 				scrollKeysDown &= ~releasedKey;
 				scrollKeysActive &= ~releasedKey;
 
 				// If the opposite arrow key is still held down, switch to that direction:
-				ushort oppositeKey = releasedKey & 1 ? releasedKey << 1 : releasedKey >> 1;
+				unsigned int oppositeKey = releasedKey & 1 ? releasedKey << 1 : releasedKey >> 1;
 				if (scrollKeysDown & oppositeKey) {
 					scrollKeysActive |= oppositeKey;
 				}

--- a/gemrb/core/GUI/GameControl.cpp
+++ b/gemrb/core/GUI/GameControl.cpp
@@ -714,6 +714,9 @@ bool GameControl::OnKeyPress(const KeyboardEvent& Key, unsigned short mod)
 				}
 				unsigned int arrowKey = 1 << (keycode - GEM_LEFT);
 
+				// You only get repeating OnKeyPress events for the last key pressed.
+				// More than one direction can be held down for diagonal scrolling, so we have
+				// to track which keys are pressed/released instead of relying on continuous events.
 				// don't reprocess repeating keystrokes
 				if (scrollKeysDown & arrowKey) {
 					break;
@@ -726,6 +729,7 @@ bool GameControl::OnKeyPress(const KeyboardEvent& Key, unsigned short mod)
 				unsigned int oppositeKey = (arrowKey & 1) ? arrowKey << 1 : arrowKey >> 1;
 				scrollKeysActive &= ~oppositeKey;
 
+				// Update the vector to start scrolling in the direction that was pressed:
 				ApplyKeyScrolling();
 			}
 			break;
@@ -1147,6 +1151,7 @@ bool GameControl::OnKeyRelease(const KeyboardEvent& Key, unsigned short Mod)
 					scrollKeysActive |= oppositeKey;
 				}
 
+				// Update the vector to stop scrolling in the direction that was released:
 				ApplyKeyScrolling();
 				break;
 			}
@@ -2427,6 +2432,8 @@ bool GameControl::OnControllerButtonDown(const ControllerEvent& ce)
 
 void GameControl::ApplyKeyScrolling()
 {
+	// Use the scrollKeysActive flags to set the vector values.
+	// This vector is then used in WillDraw to perform scrolling.
 	vpVector.reset();
 	auto keyScrollSpd = core->GetDictionary().Get("Keyboard Scroll Speed", 64);
 

--- a/gemrb/core/GUI/GameControl.h
+++ b/gemrb/core/GUI/GameControl.h
@@ -76,8 +76,8 @@ private:
 	Point vpVector;
 	int numScrollCursor = 0;
 	EnumBitset<ScreenFlags> screenFlags { ScreenFlags::CenterOnActor };
-	ushort scrollKeysActive = 0;
-	ushort scrollKeysDown = 0;
+	unsigned int scrollKeysActive = 0;
+	unsigned int scrollKeysDown = 0;
 	unsigned int DialogueFlags = DF_FREEZE_SCRIPTS;
 	String DisplayText;
 	unsigned int DisplayTextTime = 0;

--- a/gemrb/core/GUI/GameControl.h
+++ b/gemrb/core/GUI/GameControl.h
@@ -76,6 +76,8 @@ private:
 	Point vpVector;
 	int numScrollCursor = 0;
 	EnumBitset<ScreenFlags> screenFlags { ScreenFlags::CenterOnActor };
+	ushort scrollKeysActive = 0;
+	ushort scrollKeysDown = 0;
 	unsigned int DialogueFlags = DF_FREEZE_SCRIPTS;
 	String DisplayText;
 	unsigned int DisplayTextTime = 0;
@@ -113,6 +115,7 @@ private:
 	Point GetFormationPoint(const Point& origin, size_t pos, float_t angle, const FormationPoints& exclude = FormationPoints()) const;
 	FormationPoints GetFormationPoints(const Point& origin, const std::vector<Actor*>& actors, float_t angle) const;
 
+	void ApplyKeyScrolling();
 	void Scroll(const Point& amt);
 
 	void HandleContainer(Container* container, Actor* actor);

--- a/gemrb/core/GUI/GameControlDefs.h
+++ b/gemrb/core/GUI/GameControlDefs.h
@@ -32,10 +32,10 @@
 #define DF_POSTPONE_SCRIPTS   256
 
 // scroll flags for tracking arrow key scrolling
-#define SK_LEFT  1
-#define SK_RIGHT 2
-#define SK_UP    4
-#define SK_DOWN  8
+static constexpr unsigned int SK_LEFT = 1;
+static constexpr unsigned int SK_RIGHT = 2;
+static constexpr unsigned int SK_UP = 4;
+static constexpr unsigned int SK_DOWN = 8;
 
 // screen flags
 // !!! Keep these synchronized with GUIDefines.py !!!

--- a/gemrb/core/GUI/GameControlDefs.h
+++ b/gemrb/core/GUI/GameControlDefs.h
@@ -31,6 +31,12 @@
 #define DF_OPENENDWINDOW      128
 #define DF_POSTPONE_SCRIPTS   256
 
+// scroll flags for tracking arrow key scrolling
+#define SK_LEFT  1
+#define SK_RIGHT 2
+#define SK_UP    4
+#define SK_DOWN  8
+
 // screen flags
 // !!! Keep these synchronized with GUIDefines.py !!!
 enum class ScreenFlags : unsigned int {


### PR DESCRIPTION
## Description
This resolves #2316. Previous behavior is that on pressing an arrow key the viewport would jump in the direction of the arrow key, repeating if key was held down. Diagonal key scrolling did not work. This commit changes to a smooth scroll with diagonal support that matches original IE behavior. Tested with IWD2 and PST.

This is my first PR ever, so any feedback is appreciated. Thanks!

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
