### PR TITLE
Improve FreeDesktop launcher and metadata files

### DIFF
--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -644,7 +644,7 @@ FUNCTION(MAKE_APPIMAGE_TARGET)
 		COMMAND
 			mv AppDir/usr/usr/share/gemrb ${SHARE}/ || true # not always needed
 		COMMAND
-			sed -i 's,X-AppImage-Version.*,X-AppImage-Version='`date +%F`-$ENV{GITHUB_SHA}',' ${SHARE}/applications/gemrb.desktop
+			sed -i 's,X-AppImage-Version.*,X-AppImage-Version='`date +%F`-$ENV{GITHUB_SHA}',' ${SHARE}/applications/org.gemrb.gemrb.desktop
 		# bundle core python modules
 		# AppRun defaults PYTHONPATH to this destination
 		# source is probably available in Python3_STDLIB once we switch to newer cmake
@@ -685,9 +685,9 @@ FUNCTION(INSTALL_APP_RESOURCES)
 			SET(ARTWORK_PATH ${CMAKE_SOURCE_DIR}/artwork)
 			SET(LINUX_PATH ${CMAKE_SOURCE_DIR}/platforms/linux)
 
-			INSTALL(FILES ${ARTWORK_PATH}/gemrb-logo.png DESTINATION ${ICON_DIR} RENAME gemrb.png)
-			INSTALL(FILES ${ARTWORK_PATH}/logo04-rb_only.svg DESTINATION ${SVG_DIR} RENAME gemrb.svg)
-			INSTALL(FILES ${LINUX_PATH}/gemrb.desktop DESTINATION ${MENU_DIR})
+			INSTALL(FILES ${ARTWORK_PATH}/gemrb-logo.png DESTINATION ${ICON_DIR} RENAME org.gemrb.gemrb.png)
+			INSTALL(FILES ${ARTWORK_PATH}/logo04-rb_only.svg DESTINATION ${SVG_DIR} RENAME org.gemrb.gemrb.svg)
+			INSTALL(FILES ${LINUX_PATH}/org.gemrb.gemrb.desktop DESTINATION ${MENU_DIR})
 			INSTALL(FILES ${LINUX_PATH}/org.gemrb.gemrb.metainfo.xml DESTINATION ${METAINFO_DIR})
 		ENDIF()
 		INSTALL(FILES ${CMAKE_SOURCE_DIR}/README.md INSTALL COPYING NEWS AUTHORS DESTINATION ${DOC_DIR})

--- a/platforms/linux/org.gemrb.gemrb.desktop
+++ b/platforms/linux/org.gemrb.gemrb.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
 Version=1.0
 Name=GemRB
-GenericName=Game engine
-Comment=a portable opensource implementation of Bioware's Infinity Engine
+GenericName=Retro role-playing game engine
+Comment=Open-source reimplementation of BioWare's Infinity Engine used in Baldur's Gate
 Type=Application
-Icon=gemrb
+Icon=org.gemrb.gemrb
 Terminal=true
 Exec=gemrb
 Categories=Game;RolePlaying;

--- a/platforms/linux/org.gemrb.gemrb.desktop
+++ b/platforms/linux/org.gemrb.gemrb.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Name=GemRB
 GenericName=Retro role-playing game engine
-Comment=Open-source reimplementation of BioWare's Infinity Engine used in Baldur's Gate
+Comment=Open-source reimplementation of Bioware's Infinity Engine
 Type=Application
 Icon=org.gemrb.gemrb
 Terminal=true

--- a/platforms/linux/org.gemrb.gemrb.metainfo.xml
+++ b/platforms/linux/org.gemrb.gemrb.metainfo.xml
@@ -1,33 +1,101 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>org.gemrb.gemrb</id>
-  
   <name>GemRB</name>
+  <developer id="org.gemrb.gemrb">
+    <name>GemRB Contributors</name>
+    <url>https://github.com/gemrb/gemrb/blob/master/AUTHORS</url>
+  </developer>
+  <url type="homepage">https://gemrb.org/</url>
+  <url type="vcs-browser">https://github.com/gemrb/gemrb</url>
+  <url type="bugtracker">https://github.com/gemrb/gemrb/issues</url>
+  <url type="contact">https://gemrb.org/Feedback.html</url>
+  <url type="contribute">https://github.com/gemrb/gemrb/blob/master/CONTRIBUTING.md</url>
+  <url type="faq">https://gemrb.org/Common-problems.html</url>
+  <url type="help">https://gemrb.org/Documentation.html</url>
+  <branding>
+    <color type="primary" scheme_preference="light">#e8d5b7</color>
+    <color type="primary" scheme_preference="dark">#7e764d</color>
+  </branding>
   <summary>GemRB is a portable open-source implementation of Bioware’s Infinity Engine</summary>
-  
   <metadata_license>CC-BY-SA-4.0</metadata_license>
   <project_license>GPL-2.0-or-later</project_license>
-  
   <recommends>
     <control>pointing</control>
     <control>keyboard</control>
+  </recommends>
+  <supports>
     <control>touch</control>
     <control>gamepad</control>
-  </recommends>
-  
+  </supports>
   <description>
-    <p>
-      The goal of the project is to make the Infinity Engine games available on a wide range of platforms forever, fix or avoid old bugs, add new features and provide a superb platform for mod development.
-    </p>
+    <p>The goal of the project is to make the Infinity Engine games available on a wide range of platforms
+      forever, fix or avoid old bugs, add new features and provide a superb platform for mod development.</p>
+    <p><em>PLEASE NOTE:</em> GemRB does <em>not</em> include game data for any of the supported commercial
+      titles. To play any of the commercial titles, you will need to provide the game data. Please refer to
+      the GemRB documentation for more detail on how to provide it.</p>
   </description>
-  
-  <launchable type="desktop-id">gemrb.desktop</launchable>
+  <launchable type="desktop-id">org.gemrb.gemrb.desktop</launchable>
   <screenshots>
     <screenshot type="default">
-      <image>https://gemrb.org/assets/img/screenshots/iwd2_3.jpg</image>
+      <image>https://gemrb.org/assets/img/screenshots/bg24hires.jpg</image>
+      <caption>Baldur's Gate II running in high resolution</caption>
     </screenshot>
     <screenshot>
-      <image>https://gemrb.org/assets/img/screenshots/10pp6.jpg</image>
+      <image>https://gemrb.org/assets/img/screenshots/bg23.jpg</image>
+      <caption>Baldur's Gate II in French</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://gemrb.org/assets/img/screenshots/fonts.png</image>
+      <caption>Custom fonts for in-game text</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://gemrb.org/assets/img/screenshots/goi.jpg</image>
+      <caption>Support for complex mods, such as Glory of Istar set in Dragonlance</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://gemrb.org/assets/img/screenshots/iwd2-kuldahar-gem.jpg</image>
+      <caption>Icewind Dale II: Kuldahar</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://gemrb.org/assets/img/screenshots/iwd2_3.jpg</image>
+      <caption>Icewind Dale II</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://gemrb.org/assets/img/screenshots/iwd2stylecombat2.jpg</image>
+      <caption>Icewind Dale II-style combat in Baldur's Gate II</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://gemrb.org/assets/img/screenshots/pst.jpg</image>
+      <caption>Planescape: Torment</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://gemrb.org/assets/img/screenshots/sorcerer_monk.jpg</image>
+      <caption>Multiclass builds</caption>
     </screenshot>
   </screenshots>
+  <releases>
+    <release version="0.9.4" date="2025-01-16">
+      <url>https://gemrb.org/2025/01/11/gemrb-0-9-4-released.html</url>
+    </release>
+    <release version="0.9.3" date="2024-07-10">
+      <url>https://gemrb.org/2024/07/10/gemrb-0-9-3-released.html</url>
+    </release>
+    <release version="0.9.2" date="2023-07-08">
+      <url>https://gemrb.org/2023/07/08/gemrb-0-9-2-released.html</url>
+    </release>
+    <release version="0.9.1" date="2022-08-29">
+      <url>https://gemrb.org/2022/08/29/gemrb-0-9-1-released.html</url>
+    </release>
+    <release version="0.9.0" date="2021-06-18">
+      <url>https://gemrb.org/2021/06/18/gemrb-0-9-0-released.html</url>
+    </release>
+  </releases>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-fantasy">intense</content_attribute>
+    <content_attribute id="violence-desecration">mild</content_attribute>
+    <content_attribute id="drugs-alcohol">mild</content_attribute>
+    <content_attribute id="sex-themes">mild</content_attribute>
+    <content_attribute id="language-humor">mild</content_attribute>
+  </content_rating>
 </component>


### PR DESCRIPTION
## Description
This change fixes some compliance issues for the AppStream metadata for use on *nix systems. Most of these are not hard requirements as per the FreeDesktop spec, but cause linter errors for e.g. Flatpak builds:
- launcher: Rename `gemrb.desktop` to `org.gemrb.gemrb.desktop` as per [FreeDesktop spec](https://specifications.freedesktop.org/desktop-entry-spec/latest/file-naming.html)
- launcher: Rename `gemrb.png` and `gemrb.svg` to `org.gemrb.gemrb.[svg|png]` to match
- metainfo: Make the `GenericName` and `Comment` in the desktop file a little nicer
- metainfo: Add [developer tag](https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer)
- metainfo: Add missing [URL tags](https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url) - Flatpak requires there to be at least an `<url type="homepage">`
- metainfo: Add [branding tag](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-branding) to specify colours for use in e.g. graphical package managers. This uses #e8d5b7 for light mode (matching the gemrb.org page background) and #2b261c for dark mode (an average of the hero image at the top of the gemrb.org main page). 
- metainfo: Line-wrap description for readability and add a note about game data
- metainfo: Add [release info](https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-releases) going back to v0.9.0 - Flatpak requires this to be present, and graphical package managers can display it alongside update notifications for the package
- metainfo: Migrate screenshot URLs to using [JSDelivr CDN](https://www.jsdelivr.com/?docs=gh) which is free for open-source projects
- metainfo: Add more screenshots
- metainfo: Add captions to screenshots
- metainfo: Add [OARS content rating](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-content_rating) information

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
