### PR TITLE
Reword metainfo summary

### DIFF
--- a/platforms/linux/org.gemrb.gemrb.metainfo.xml
+++ b/platforms/linux/org.gemrb.gemrb.metainfo.xml
@@ -17,7 +17,7 @@
     <color type="primary" scheme_preference="light">#e8d5b7</color>
     <color type="primary" scheme_preference="dark">#7e764d</color>
   </branding>
-  <summary>GemRB is a portable open-source implementation of Bioware’s Infinity Engine</summary>
+  <summary>A retro role-playing game engine</summary>
   <metadata_license>CC-BY-SA-4.0</metadata_license>
   <project_license>GPL-2.0-or-later</project_license>
   <recommends>
@@ -29,6 +29,8 @@
     <control>gamepad</control>
   </supports>
   <description>
+		<p>GemRB is a portable, open-source implementation of Bioware's Infinity Engine, used in a number of
+			classic computer role playing games such as Baldur's Gate, Icewind Dale and Planescape Torment.</p>
     <p>The goal of the project is to make the Infinity Engine games available on a wide range of platforms
       forever, fix or avoid old bugs, add new features and provide a superb platform for mod development.</p>
     <p><em>PLEASE NOTE:</em> GemRB does <em>not</em> include game data for any of the supported commercial

--- a/platforms/linux/org.gemrb.gemrb.metainfo.xml
+++ b/platforms/linux/org.gemrb.gemrb.metainfo.xml
@@ -17,7 +17,7 @@
     <color type="primary" scheme_preference="light">#e8d5b7</color>
     <color type="primary" scheme_preference="dark">#7e764d</color>
   </branding>
-  <summary>A retro role-playing game engine</summary>
+  <summary>Classic role-playing game engine</summary>
   <metadata_license>CC-BY-SA-4.0</metadata_license>
   <project_license>GPL-2.0-or-later</project_license>
   <recommends>
@@ -29,8 +29,8 @@
     <control>gamepad</control>
   </supports>
   <description>
-		<p>GemRB is a portable, open-source implementation of Bioware's Infinity Engine, used in a number of
-			classic computer role playing games such as Baldur's Gate, Icewind Dale and Planescape Torment.</p>
+    <p>GemRB is a portable, open-source implementation of Bioware's Infinity Engine, used in a number of
+      classic computer role playing games such as Baldur's Gate, Icewind Dale and Planescape Torment.</p>
     <p>The goal of the project is to make the Infinity Engine games available on a wide range of platforms
       forever, fix or avoid old bugs, add new features and provide a superb platform for mod development.</p>
     <p><em>PLEASE NOTE:</em> GemRB does <em>not</em> include game data for any of the supported commercial


### PR DESCRIPTION
## Description

Flathub recommends the `<summary>` field in metainfo is short and easily understandable - under 35 characters, "Understandable for a non-technical person", "Doesn't repeat the app name" and "Doesn't start with an article". Currently the summary is so long it raises a "Listing Quality" check failure on the listing as a warning, so I've reworded it to fix this.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
