### PR TITLE
Fixing rumour window dismissal in bg1

### DIFF
--- a/gemrb/GUIScripts/GUISTORE.py
+++ b/gemrb/GUIScripts/GUISTORE.py
@@ -873,7 +873,7 @@ def UpdateStoreRumourWindow (Window):
 				CostLabel = Window.GetControl (0x10000000+29+i)
 				CostLabel.SetText ("")
 			elif GameCheck.IsBG1 ():
-				CostLabel = Window.GetControl (0x100000005 + i)
+				CostLabel = Window.GetControl (0x10000005 + i)
 				CostLabel.SetText ("")
 	return
 


### PR DESCRIPTION
## Description
Issue seen in BG1 (at Jovial Juggler, but would occur at any tavern that provides rumours window). After navigating to rumours window, upon closing the interaction with the relevant NPC the rumours window is still visible, even if it was not the last active window.

Error seen in console:
```
[Python/ERROR]: Traceback (most recent call last):
[Python/ERROR]:   File "/usr/local/share/gemrb/GUIScripts/GUISTORE.py", line 203, in <lambda>
[Python/ERROR]:     lambda: ChangeStoreView(OpenStoreRumourWindow),
[Python/ERROR]:   File "/usr/local/share/gemrb/GUIScripts/GUISTORE.py", line 196, in ChangeStoreView
[Python/ERROR]:     return func()
[Python/ERROR]:   File "/usr/local/share/gemrb/GUIScripts/GUICommonWindows.py", line 513, in ret
[Python/ERROR]:     initer(window)
[Python/ERROR]:   File "/usr/local/share/gemrb/GUIScripts/GUISTORE.py", line 839, in InitStoreRumourWindow
[Python/ERROR]:     UpdateStoreRumourWindow(Window)
[Python/ERROR]:   File "/usr/local/share/gemrb/GUIScripts/GUISTORE.py", line 877, in UpdateStoreRumourWindow
[Python/ERROR]:     CostLabel.SetText ("")
[Python/ERROR]: AttributeError: 'NoneType' object has no attribute 'SetText'
```

Issue found to be a typo in call to get window control, one too many ‘0’ characters, should be: “0x10000005 + I” to match same reference above on line 864.

Retested after change and rumours window is dismissed at the end of the interaction as expected and no error message seen in console.

I'm not aware of an existing Github issue for this but suggesting this PR anyway. I'm not sure of your dev processes, so if you'd like me to raise an issue for traceability then please let me know.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
