### PR TITLE
bg1 GUIRECCommon.py: fixed character record when bonus priest spells are present

### DIFF
--- a/gemrb/GUIScripts/GUIRECCommon.py
+++ b/gemrb/GUIScripts/GUIRECCommon.py
@@ -761,7 +761,7 @@ def GetBonusSpells(pc, expand = True):
 			if GameCheck.IsPST ():
 				stats.append ((4239, bonus, 'p'))
 			else:
-				stats.append ((GemRB.GetString (10345), bonus, 'r'))
+				stats.append ((GemRB.GetString (10345), bonus, 'p'))
 
 	if expand:
 		stats.append ("\n")
@@ -801,10 +801,14 @@ def TypeSetStats (stats, pc, recolor = False):
 			elif stattype == 'd': # strref is an already resolved string
 				res.append (strref)
 			elif stattype == 'p': # a plus prefix if positive
+				# special handling to cover bonus priest spells where string is resolved earlier
+				resolvedString = strref
+				if isinstance (strref, int):
+					resolvedString = GemRB.GetString (strref)
 				if val > 0:
-					res.append (GemRB.GetString (strref) + ': +' + str (val))
+					res.append (resolvedString + ': +' + str (val))
 				else:
-					res.append (GemRB.GetString (strref) + ': ' + str (val))
+					res.append (resolvedString + ': ' + str (val))
 			elif stattype == 's': # both base and (modified) stat, but only if they differ
 				base = GB (val)
 				stat = GS (val)
@@ -840,7 +844,7 @@ def TypeSetStats (stats, pc, recolor = False):
 					if res:
 						res[-1] += s
 				else:
-					res.append (s);
+					res.append (s)
 			elif recolor:
 				res.append (won + GemRB.GetString (s) + woff)
 			else:


### PR DESCRIPTION
## Description
In BG1, opening up character record for a non-priest character, then selecting a cleric/druid (e.g. Jaheira) results in the following Python stack trace:

[Python/ERROR]: TypeError: an integer is required (got type str)
[Python/ERROR]: 
The above exception was the direct cause of the following exception:
[Python/ERROR]: Traceback (most recent call last):
[Python/ERROR]:   File "/usr/local/share/gemrb/GUIScripts/GUIRECCommon.py", line 829, in TypeSetStats
[Python/ERROR]:     res.append (GemRB.GetString (strref) + ': ' + str (val) + stattype)
[Python/ERROR]: SystemError: <built-in function GetString> returned a result with an error set
[Python/ERROR]: 
During handling of the above exception, another exception occurred:
[Python/ERROR]: TypeError: an integer is required (got type tuple)
[Python/ERROR]: 
The above exception was the direct cause of the following exception:
[Python/ERROR]: Traceback (most recent call last):
[Python/ERROR]:   File "/usr/local/share/gemrb/GUIScripts/GUICommonWindows.py", line 670, in SelectionChanged
[Python/ERROR]:     SelectionChangeHandler ()
[Python/ERROR]:   File "/usr/local/share/gemrb/GUIScripts/GUICommonWindows.py", line 569, in <lambda>
[Python/ERROR]:     selectionHandler = lambda win=window, fn=selectionHandler: fn(win)
[Python/ERROR]:   File "/usr/local/share/gemrb/GUIScripts/GUIREC.py", line 214, in UpdateRecordsWindow
[Python/ERROR]:     Text.SetText (GetStatOverview (pc))
[Python/ERROR]:   File "/usr/local/share/gemrb/GUIScripts/GUIREC.py", line 272, in GetStatOverview
[Python/ERROR]:     outputtext+= GUIRECCommon.GetBonusSpells (pc)
[Python/ERROR]:   File "/usr/local/share/gemrb/GUIScripts/GUIRECCommon.py", line 768, in GetBonusSpells
[Python/ERROR]:     return TypeSetStats (stats, pc)
[Python/ERROR]:   File "/usr/local/share/gemrb/GUIScripts/GUIRECCommon.py", line 847, in TypeSetStats
[Python/ERROR]:     res.append (GemRB.GetString (s))
[Python/ERROR]: SystemError: <built-in function GetString> returned a result with an error set

Issue is that GetBonusSpells() on line 764 resolves the strref string with what looks like the SPELLLEVEL token, then passes in the stattype: 'r'. So stattype 'r' wasn't covered and GemRB.GetString was being called on a string and failing.

### Other issues observed - probably for a different PR:

Original game:
<img width="640" height="480" alt="Original BG1 char record" src="https://github.com/user-attachments/assets/c7ffba94-47b9-408e-a636-94c5db293a90" />

GemRB (with fix):
<img width="1920" height="1080" alt="GemRB BG1 char record with fix" src="https://github.com/user-attachments/assets/356cc64e-3e36-4d98-992d-f6f352f475b9" />

Newline formatting appears to be different in GemRB, but I haven't worked out why yet. The [p]...[/p] tags seem to be created correctly, but leaving for another time.

Additionally, the "Reaction" is +3 in the original game, but 11 in GemRB, again for reasons that currently elude me.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [ ] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
