### PR TITLE
Audio: directional sound for spell casting

### DIFF
--- a/gemrb/core/Audio/AudioSettings.cpp
+++ b/gemrb/core/Audio/AudioSettings.cpp
@@ -143,6 +143,24 @@ AudioPlaybackConfig AudioSettings::ConfigPresetDialog(SFXChannel channel) const
 	return config;
 }
 
+// Directional (casting voices)
+AudioPlaybackConfig AudioSettings::ConfigPresetDirectional(SFXChannel channel, const Point& p, orient_t orientation) const
+{
+	auto config = ConfigPresetSpatialVoice(channel, p);
+	config.directional = true;
+	config.cone = 120;
+
+	using t = std::underlying_type_t<orient_t>;
+	// 0 is south, and 90 deg turn is west
+	float rot = (static_cast<t>(orientation) / (1.0f * static_cast<t>(orient_t::MAX)) * 360.0f) * (M_PI / 180.0f);
+	rot = rot * -1.0f - M_PI * 0.5f;
+	float x = std::cos(rot);
+	float y = std::sin(rot);
+	config.direction = { x, y, 0.0f };
+
+	return config;
+}
+
 // Ambient with a location and range by IE data
 AudioPlaybackConfig AudioSettings::ConfigPresetPointAmbient(int gain, const Point& p, uint16_t range, bool loop) const
 {

--- a/gemrb/core/Audio/AudioSettings.h
+++ b/gemrb/core/Audio/AudioSettings.h
@@ -21,6 +21,7 @@
 #define H_AUDIO_SETTINGS
 
 #include "EnumIndex.h"
+#include "Orientation.h"
 #include "PlaybackConfig.h"
 
 namespace GemRB {
@@ -67,6 +68,7 @@ class GEM_EXPORT AudioSettings {
 public:
 	AudioPlaybackConfig ConfigPresetByChannel(SFXChannel channel, const Point& point) const;
 	AudioPlaybackConfig ConfigPresetDialog(SFXChannel channel = SFXChannel::Dialog) const;
+	AudioPlaybackConfig ConfigPresetDirectional(SFXChannel channel, const Point& point, orient_t orientation) const;
 	AudioPlaybackConfig ConfigPresetMusic() const;
 	AudioPlaybackConfig ConfigPresetMovie() const;
 	AudioPlaybackConfig ConfigPresetPointAmbient(int gain, const Point& point, uint16_t range, bool loop) const;

--- a/gemrb/core/Audio/Playback.cpp
+++ b/gemrb/core/Audio/Playback.cpp
@@ -96,6 +96,11 @@ Holder<PlaybackHandle> AudioPlayback::Play(StringView resource, AudioPreset pres
 	return Play(resource, config);
 }
 
+Holder<PlaybackHandle> AudioPlayback::PlayDirectional(StringView resource, SFXChannel channel, const Point& point, orient_t orientation)
+{
+	return Play(resource, core->GetAudioSettings().ConfigPresetDirectional(channel, point, orientation));
+}
+
 Holder<PlaybackHandle> AudioPlayback::Play(StringView resource, const AudioPlaybackConfig& config)
 {
 	Housekeeping();

--- a/gemrb/core/Audio/Playback.h
+++ b/gemrb/core/Audio/Playback.h
@@ -56,6 +56,7 @@ public:
 	Holder<PlaybackHandle> Play(StringView resource, AudioPreset preset, SFXChannel channel, const Point& point);
 	Holder<PlaybackHandle> Play(StringView resource, AudioPreset preset, SFXChannel channel);
 	Holder<PlaybackHandle> Play(StringView resource, const AudioPlaybackConfig& config);
+	Holder<PlaybackHandle> PlayDirectional(StringView resource, SFXChannel channel, const Point& point, orient_t orientation);
 	Holder<PlaybackHandle> PlayDefaultSound(size_t index, SFXChannel channel);
 	Holder<PlaybackHandle> PlayDefaultSound(size_t index, const AudioPlaybackConfig& config);
 	time_t PlaySpeech(StringView resource, const AudioPlaybackConfig& config, bool interrupt = true);

--- a/gemrb/core/Audio/PlaybackConfig.h
+++ b/gemrb/core/Audio/PlaybackConfig.h
@@ -24,6 +24,8 @@
 
 #include "Region.h"
 
+#include <array>
+
 namespace GemRB {
 
 struct AudioPoint {
@@ -52,6 +54,11 @@ struct GEM_EXPORT AudioPlaybackConfig {
 	AudioPoint position;
 
 	uint16_t muteDistance;
+
+	bool directional = false;
+	std::array<float, 3> direction = { 0.0f, 0.0f, 0.0f };
+	// 0 to 360
+	int32_t cone = 0;
 };
 
 }

--- a/gemrb/core/Spell.cpp
+++ b/gemrb/core/Spell.cpp
@@ -144,7 +144,7 @@ void Spell::AddCastingGlow(EffectQueue* fxqueue, ieDword duration, int gender) c
 		}
 		// only actors have fxqueue's and also the parent function checks for that
 		Actor* caster = (Actor*) fxqueue->GetOwner();
-		caster->casting_sound = core->GetAudioPlayback().Play(Resource, AudioPreset::Spatial, SFXChannel::Casting, caster->Pos);
+		caster->casting_sound = core->GetAudioPlayback().PlayDirectional(Resource, SFXChannel::Casting, caster->Pos, caster->GetOrientation());
 	}
 
 	fx = EffectQueue::CreateEffect(fx_casting_glow_ref, 0, CastingGraphics, FX_DURATION_ABSOLUTE);

--- a/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
+++ b/gemrb/plugins/OpenALAudio/OpenALAudio.cpp
@@ -99,6 +99,18 @@ static void ConfigureSource(ALuint source, const AudioPlaybackConfig& config)
 		sourcePos[2] = float(config.position.z);
 	}
 
+	if (config.directional) {
+		alSourcefv(source, AL_DIRECTION, config.direction.data());
+		alSourcei(source, AL_CONE_INNER_ANGLE, config.cone);
+		alSourcei(source, AL_CONE_OUTER_ANGLE, 360);
+		alSourcef(source, AL_CONE_OUTER_GAIN, 0.25f);
+#ifdef HAVE_OPENAL_EFX_H
+		if (hasEFX) {
+			alSourcef(source, AL_CONE_OUTER_GAINHF, 0.5f);
+		}
+#endif
+	}
+
 	alSourcefv(source, AL_VELOCITY, sourceVel.data());
 	alSourcei(source, AL_LOOPING, config.loop);
 	alSourcef(source, AL_GAIN, 0.0001f * (config.channelVolume * config.masterVolume));


### PR DESCRIPTION
## Description

A minor experiment after reading #2361. It's even dampening (as in the example) and makes use of something OpenAL provides and that we can use umambiguously.

![directional_sound](https://github.com/user-attachments/assets/91c6bad8-c863-4218-8cb8-8ae521df4eaf)

So having the screen at the same position, the direction determines some interpolated loss of gain when outside of the purple cone. Sounds like this when considering the three directions (E, S, W) on the screenshot.
[out.webm](https://github.com/user-attachments/assets/6e09410e-6f46-4b31-b47f-334a4af39f5f)


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
