### PR TITLE
WEDImporter: prevents crash when there are no door tiles

### DIFF
--- a/gemrb/plugins/WEDImporter/WEDImporter.cpp
+++ b/gemrb/plugins/WEDImporter/WEDImporter.cpp
@@ -258,7 +258,7 @@ std::vector<ieWord> WEDImporter::GetDoorIndices(const ResRef& resref, bool& Base
 	//Reading Door Tile Cells
 	str->Seek(DoorTilesOffset + (DoorTileStart * 2), GEM_STREAM_START);
 	auto DoorTiles = std::vector<ieWord>(DoorTileCount);
-	str->Read(&DoorTiles[0], DoorTileCount * sizeof(ieWord));
+	str->Read(DoorTiles.data(), DoorTileCount * sizeof(ieWord));
 
 	BaseClosed = DoorClosed != 0;
 	return DoorTiles;


### PR DESCRIPTION
## Description
When there are no door tiles, using `[0]` now raises some assertion error for me.


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code <!-- yet to be formally defined, see issue #161 -->
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
