### PR TITLE
Improvement to drawing speed

### DIFF
--- a/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.cpp
+++ b/gemrb/plugins/SDLVideo/SDLSurfaceSprite2D.cpp
@@ -116,7 +116,7 @@ bool SDLSurfaceSprite2D::HasTransparency() const noexcept
 {
 	const SDL_PixelFormat* fmt = surface->format;
 #if SDL_VERSION_ATLEAST(1, 3, 0)
-	return SDL_ISPIXELFORMAT_ALPHA(fmt->format) || SDL_GetColorKey(surface, NULL) != -1;
+	return SDL_ISPIXELFORMAT_ALPHA(fmt->format) || format.HasColorKey;
 #else
 	return fmt->Amask > 0 || ((surface)->flags & SDL_SRCCOLORKEY);
 #endif


### PR DESCRIPTION
With zooming and something like FullHD settings, we can exert some more pressure to the renderer and see some potential bottlenecks. What you see here is the profiling of one single map tile:

![tracy_perf_transparency](https://github.com/user-attachments/assets/33bde51c-0a82-4011-979a-2c965336032c)

On a fast computer, the drawing is faster than a call to `HasTransparency` that takes around 50% of map drawing time, even falling below my display Hz on debug builds.

We don't need this call to `SDL_GetColorKey`, we have all we need to know in the format descriptor already, and there is no change to this from outside the sprite class, resulting in some 80 to 100% improvement in some circumstances.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
