### PR TITLE
WriteCharacter: if GamePath is R/O use SavePath

### DIFF
--- a/gemrb/core/GameData.cpp
+++ b/gemrb/core/GameData.cpp
@@ -80,7 +80,10 @@ int GameData::LoadCreature(const ResRef& creature, unsigned int PartySlot, bool 
 	Actor* actor;
 	if (character) {
 		path_t file = fmt::format("{}.chr", creature);
-		path_t nPath = PathJoin(core->config.GamePath, "characters", file);
+		path_t nPath = PathJoin(core->config.GamePath, core->config.GameCharactersPath, file);
+		if (!FileExists(nPath)) {
+			nPath = PathJoin(core->config.SavePath, core->config.GameCharactersPath, file);
+		}
 		stream = FileStream::OpenFile(nPath);
 		auto actormgr = GetImporter<ActorMgr>(IE_CRE_CLASS_ID, stream);
 		if (!actormgr) {

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -3703,8 +3703,22 @@ int Interface::WriteCharacter(StringView name, const Actor* actor) const
 
 	FileStream str;
 	if (!str.Create(Path, name.c_str(), IE_CHR_CLASS_ID) || gm->PutActor(&str, actor, true) < 0) {
-		Log(WARNING, "Core", "Character cannot be saved: {}", name);
-		return -1;
+		if (config.GamePath != config.SavePath) {
+			//If GamePath is not writable, try SavePath
+			Path = PathJoin(config.SavePath, config.GameCharactersPath);
+			if (!DirExists(Path)) {
+				if (MakeDirectory(Path)) {
+					Log(WARNING, "Core", "Making new characters folder at: {}", Path);
+				}
+			}
+			if (!str.Create(Path, name.c_str(), IE_CHR_CLASS_ID) || gm->PutActor(&str, actor, true) < 0) {
+				Log(WARNING, "Core", "Character cannot be saved: {}", name);
+				return -1;
+			}
+		} else {
+			Log(WARNING, "Core", "Character cannot be saved: {}", name);
+			return -1;
+		}
 	}
 
 	//write the BIO string


### PR DESCRIPTION
## Description
I tend to use game data from read-only partitions, in the case of GemRB this means that exported characters won't be saved by default.

The following changes make it so that if a character can't be saved at `GamePath/characters` it will be saved at `SavePath/characters` instead.

The changes to `GemRB_TextArea_ListResources` and `GameData::LoadCreature` also allow loading characters from `SavePath/characters` if SavePath is different than GamePath (so not undefined) and `SavePath/characters` exists.

This approach doesn't take care of duplicate entries between these folders but that would take a bunch of extra code afaik.

The man entries for `SavePath` and `GameCharactersPath` could be tweaked accordingly, I don't know of other pieces of documentation needing changes for this.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [ ] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
