### PR TITLE
guibtact.2da: fix button alignment by using wide arrows

### DIFF
--- a/gemrb/unhardcoded/bg1/guibtact.2da
+++ b/gemrb/unhardcoded/bg1/guibtact.2da
@@ -33,5 +33,5 @@ Search     34         35         36         37         4927       guibtact
 29         *          *          *          *          *          *          
 30         *          *          *          *          *          *          
 31         *          *          *          *          *          *          
-Left       44         45         100        100        -1         guibtact   
-Right      42         43         100        100        -1         guibtact   
+Left       64         65         -1         -1         -1         guibtact
+Right      66         67         -1         -1         -1         guibtact

--- a/gemrb/unhardcoded/bg2/guibtact.2da
+++ b/gemrb/unhardcoded/bg2/guibtact.2da
@@ -33,5 +33,5 @@ Search     34         35         36         37         4927       guibtact
 29         *          *          *          *          *          *          
 30         *          *          *          *          *          *          
 QItem5     0          1          2          3          4937       guibtbut
-Left       44         45         -1         -1         -1         guibtact   
-Right      42         43         -1         -1         -1         guibtact   
+Left       64         65         -1         -1         -1         guibtact
+Right      66         67         -1         -1         -1         guibtact

--- a/gemrb/unhardcoded/bg2ee/guibtact.2da
+++ b/gemrb/unhardcoded/bg2ee/guibtact.2da
@@ -33,5 +33,5 @@ Dance      72         73         74         75         103117     guibtact
 29         *          *          *          *          *          *          
 30         *          *          *          *          *          *          
 QItem5     0          1          2          3          4937       guibtbut
-Left       44         45         -1         -1         -1         guibtact   
-Right      42         43         -1         -1         -1         guibtact   
+Left       64         65         -1         -1         -1         guibtact
+Right      66         67         -1         -1         -1         guibtact

--- a/gemrb/unhardcoded/bgee/guibtact.2da
+++ b/gemrb/unhardcoded/bgee/guibtact.2da
@@ -33,5 +33,5 @@ Dance      72         73         74         75         103117     guibtact
 29         *          *          *          *          *          *          
 30         *          *          *          *          *          *          
 QItem5     0          1          2          3          4937       guibtbut
-Left       44         45         -1         -1         -1         guibtact   
-Right      42         43         -1         -1         -1         guibtact   
+Left       64         65         -1         -1         -1         guibtact
+Right      66         67         -1         -1         -1         guibtact

--- a/gemrb/unhardcoded/how/guibtact.2da
+++ b/gemrb/unhardcoded/how/guibtact.2da
@@ -33,5 +33,5 @@ Search     34         35         36         37         4927       guibtact
 29         *          *          *          *          *          *
 30         *          *          *          *          *          *
 QItem5     0          1          2          3          4937       guibtbut
-Left       44         45         -1         -1         -1         guibtact
-Right      42         43         -1         -1         -1         guibtact
+Left       64         65         -1         -1         -1         guibtact
+Right      66         67         -1         -1         -1         guibtact

--- a/gemrb/unhardcoded/iwd/guibtact.2da
+++ b/gemrb/unhardcoded/iwd/guibtact.2da
@@ -33,5 +33,5 @@ Search     34         35         36         37         4927       guibtact
 29         *          *          *          *          *          *
 30         *          *          *          *          *          *
 QItem5     0          1          2          3          4937       guibtbut
-Left       44         45         -1         -1         -1         guibtact
-Right      42         43         -1         -1         -1         guibtact
+Left       64         65         -1         -1         -1         guibtact
+Right      66         67         -1         -1         -1         guibtact


### PR DESCRIPTION
## Description
<!-- Describe the overall purpose of this pull request (PR). If applicable, also add bug references, relevant screenshots or any other justification.
If you've used AI tools to create the PR, there's no shame, just please be open about it. You are responsible for your contributions, so make sure you understand everything you are proposing. Otherwise you're creating an unfair review burden on the project. -->

This PR changes which frames the actionbar pulls from `GUIBTACT.BAM` for its left and right arrows. GemRB currently uses the slim arrow variants (unused by the originals), while this PR swaps these out for the wide variants. This fixes some alignment issues in the UI.

<details>
  <summary>Before / After:</summary>
  <img width="1207" height="945" alt="before" src="https://github.com/user-attachments/assets/4ac25217-b56d-4f31-87dc-73b2ce7d39c9" />
  <img width="1280" height="999" alt="after" src="https://github.com/user-attachments/assets/7adb51bb-283a-4d67-bfd8-3e20e7928a30" />
</details>

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] I used the same coding style as the surrounding code
- [X] I have tested the proposed changes
- [X] I extended the documentation, if necessary
- [X] The proposed change builds also on our build bots (check after submission)