### PR TITLE
Add GamepadSupport config option to skip slow joystick init on Windows

### DIFF
--- a/gemrb/GemRB.cfg.noinstall.sample
+++ b/gemrb/GemRB.cfg.noinstall.sample
@@ -153,6 +153,12 @@ Bpp=32
 
 #NumFingInfo=2
 
+# Set this to 0 to disable gamepad/joystick support entirely.
+# On some Windows systems, SDL's joystick subsystem initialization can hang
+# for 30+ seconds due to device enumeration issues (e.g. WMI timeouts).
+# If the game takes abnormally long to start, try disabling this.
+#GamepadSupport=1
+
 # Pointer speed and acceleration factor with thumbstick
 #GamepadPointerSpeed=10
 #GamepadPointerAccel=103

--- a/gemrb/GemRB.cfg.sample.in
+++ b/gemrb/GemRB.cfg.sample.in
@@ -153,6 +153,12 @@ Bpp=32
 
 #NumFingInfo=2
 
+# Set this to 0 to disable gamepad/joystick support entirely.
+# On some Windows systems, SDL's joystick subsystem initialization can hang
+# for 30+ seconds due to device enumeration issues (e.g. WMI timeouts).
+# If the game takes abnormally long to start, try disabling this.
+#GamepadSupport=1
+
 # Pointer speed and acceleration factor with thumbstick
 #GamepadPointerSpeed=10
 #GamepadPointerAccel=103

--- a/gemrb/core/InterfaceConfig.cpp
+++ b/gemrb/core/InterfaceConfig.cpp
@@ -184,6 +184,7 @@ CoreSettings LoadFromDictionary(InterfaceConfig cfg)
 	CONFIG_INT("NumFingScroll", config.NumFingScroll);
 	CONFIG_INT("NumFingKboard", config.NumFingKboard);
 	CONFIG_INT("NumFingInfo", config.NumFingInfo);
+	CONFIG_INT("GamepadSupport", config.GamepadSupport);
 	CONFIG_INT("GamepadPointerSpeed", config.GamepadPointerSpeed);
 	CONFIG_INT("GamepadPointerAccel", config.GamepadPointerAccel);
 	CONFIG_INT("GamepadLDeadZone", config.GamepadLDeadZone);

--- a/gemrb/core/InterfaceConfig.h
+++ b/gemrb/core/InterfaceConfig.h
@@ -83,6 +83,7 @@ struct CoreSettings {
 	std::string GameType = "auto";
 	std::string Encoding = "default";
 
+	int GamepadSupport = 1;
 	int GamepadPointerSpeed = 10;
 	int GamepadPointerAccel = 103;
 	int GamepadLDeadZone = 5000;

--- a/gemrb/plugins/SDLVideo/SDL20Video.cpp
+++ b/gemrb/plugins/SDLVideo/SDL20Video.cpp
@@ -106,16 +106,20 @@ int SDL20VideoDriver::Init()
 	int ret = SDLVideoDriver::Init();
 
 #ifdef USE_SDL_CONTROLLER_API
-	if (SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) == -1) {
-		Log(ERROR, "SDL2", "InitSubSystem failed: {}", SDL_GetError());
-		return ret;
-	}
+	if (!core->config.GamepadSupport) {
+		Log(MESSAGE, "SDL2", "Gamepad support disabled via config (GamepadSupport=0)");
+	} else {
+		if (SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) == -1) {
+			Log(ERROR, "SDL2", "InitSubSystem failed: {}", SDL_GetError());
+			return ret;
+		}
 
-	for (int i = 0; i < SDL_NumJoysticks(); ++i) {
-		if (SDL_IsGameController(i)) {
-			gameController = SDL_GameControllerOpen(i);
-			if (gameController != nullptr) {
-				break;
+		for (int i = 0; i < SDL_NumJoysticks(); ++i) {
+			if (SDL_IsGameController(i)) {
+				gameController = SDL_GameControllerOpen(i);
+				if (gameController != nullptr) {
+					break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description
On some Windows systems (specifically mine), `SDL_InitSubSystem(SDL_INIT_JOYSTICK)` hangs for ~30 seconds during startup due to WMI device enumeration timeouts. This happens even with 0 joysticks connected and is unaffected by SDL hints (`SDL_HINT_JOYSTICK_HIDAPI`, `SDL_HINT_JOYSTICK_RAWINPUT`, etc.).

This PR adds a `GamepadSupport` config option (enabled by default) that lets affected users skip gamepad/joystick initialization entirely by setting `GamepadSupport=0`.

Tested on Windows 11 with SDL2 2.32.10 — startup went from ~30s to almost instant.

AI (Claude 4.6) was used to help debug and implement this change. I'm a programmer, but I make no claims of understanding GemRB's huge codebase, so my role consisted mostly in testing.

I'm also making a [PR into the documentation project](https://github.com/gemrb/gemrb.github.io/pull/20).

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
