### PR TITLE
Add v0.9.5 release to `metainfo.xml`.

### DIFF
--- a/platforms/linux/org.gemrb.gemrb.metainfo.xml
+++ b/platforms/linux/org.gemrb.gemrb.metainfo.xml
@@ -77,6 +77,9 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="0.9.5" date="2026-03-23">
+      <url>https://gemrb.org/2026/03/23/gemrb-0-9-5-released.html</url>
+    </release>
     <release version="0.9.4" date="2025-01-16">
       <url>https://gemrb.org/2025/01/11/gemrb-0-9-4-released.html</url>
     </release>


### PR DESCRIPTION
## Description
Simple as that; the `metainfo.xml` is used by e.g. Flathub to determine the version number for the package, and by graphical package managers to display release information.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
