### PR TITLE
Projectile: Fix invalid return value from iterator

### DIFF
--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -2845,8 +2845,7 @@ Projectile* Map::AddProjectile(std::unique_ptr<Projectile> pro)
 	for (iter = projectiles.begin(); iter != projectiles.end(); iter++) {
 		if ((*iter)->GetHeight() >= height) break;
 	}
-	projectiles.insert(iter, std::move(pro));
-	return iter->get();
+	return projectiles.insert(iter, std::move(pro))->get();
 }
 
 Projectile* Map::AddProjectile(std::unique_ptr<Projectile> pro, const Point& source, ieDword actorID, bool fake)


### PR DESCRIPTION
## Description
This PR fixes the following assert when casting a spell on the MSVC debug build:

```
---------------------------
Microsoft Visual C++ Runtime Library
---------------------------
Debug Assertion Failed!

Program: ...ames\Infinity-Engine\Installations\GemRB_Debug\gemrb_core.dll
File: C:\Program Files\Microsoft Visual Studio\18\Community\VC\Tools\MSVC\14.50.35717\include\list
Line: 147

Expression: cannot dereference end list iterator
```

The bug seems to stem from the function attempting to return the projectile it inserted by dereferencing `iter` – which actually points to the entry after the inserted element. The assert is thrown when `iter` points to the ending sentinel node of the list.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [x] The proposed change builds also on our build bots (check after submission)
