### PR TITLE
ResourceManager: BIFs by language

### DIFF
--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -384,6 +384,12 @@ Interface::Interface(CoreSettings&& cfg)
 		ThrowException("The path must point to a game directory with a readable chitin.key file.");
 	}
 
+	// Inject language specific data BIFs
+	auto languageDataPath = PathJoin(config.GamePath, config.GameLanguagePath, "data");
+	if (DirExists(languageDataPath)) {
+		gamedata->AddPathToSource(languageDataPath, "chitin.key");
+	}
+
 	// most of the old gemrb override files can be found here,
 	// so they have a lower priority than the game files and can more easily be modded
 	path = PathJoin(config.GemRBUnhardcodedPath, "unhardcoded", config.GameType);

--- a/gemrb/core/ResourceManager.cpp
+++ b/gemrb/core/ResourceManager.cpp
@@ -99,6 +99,16 @@ bool ResourceManager::AddSource(const path_t& path, const std::string& descripti
 	return true;
 }
 
+void ResourceManager::AddPathToSource(const path_t& path, const std::string& description)
+{
+	for (auto& path2 : searchPath) {
+		if (description == path2->GetDescription()) {
+			path2->MergeBifsFromPath(path);
+			break;
+		}
+	}
+}
+
 static void PrintPossibleFiles(std::string& buffer, StringView ResRef, const TypeID* type)
 {
 	const std::vector<ResourceDesc>& types = PluginMgr::Get()->GetResourceDesc(type);

--- a/gemrb/core/ResourceManager.h
+++ b/gemrb/core/ResourceManager.h
@@ -35,6 +35,7 @@ public:
 	 * @param[in] type Plugin type used for source.
 	 **/
 	bool AddSource(const path_t& path, const std::string& description, PluginID type, int flags = 0);
+	void AddPathToSource(const path_t& path, const std::string& description);
 
 	/** returns true if resource exists */
 	bool Exists(const String& resRef, SClass_ID type, bool silent = false) const;

--- a/gemrb/core/ResourceSource.h
+++ b/gemrb/core/ResourceSource.h
@@ -22,6 +22,7 @@ GEM_EXPORT path_t TypeExt(SClass_ID type);
 class GEM_EXPORT ResourceSource : public Plugin {
 public:
 	virtual bool Open(const path_t& filename, std::string description) = 0;
+	virtual void MergeBifsFromPath(const path_t&) {}
 	virtual bool HasResource(StringView resname, SClass_ID type) = 0;
 	virtual bool HasResource(StringView resname, const ResourceDesc& type) = 0;
 	virtual DataStream* GetResource(StringView resname, SClass_ID type) = 0;

--- a/gemrb/plugins/KEYImporter/KEYImporter.cpp
+++ b/gemrb/plugins/KEYImporter/KEYImporter.cpp
@@ -9,6 +9,7 @@
 
 #include "Logging/Logging.h"
 #include "Streams/FileStream.h"
+#include "System/FileFilters.h"
 
 using namespace GemRB;
 
@@ -162,6 +163,35 @@ bool KEYImporter::Open(const path_t& resfile, std::string desc)
 	Log(MESSAGE, "KEYImporter", "Resources Loaded...");
 	delete f;
 	return true;
+}
+
+// If we find BIFs with the same name in the given path, use
+// them instead. This allows language-aware overrides.
+void KEYImporter::MergeBifsFromPath(const path_t& path)
+{
+	DirectoryIterator dirIt { path };
+	dirIt.SetFilterPredicate(std::make_shared<ExtFilter>("bif"));
+
+	do {
+		BIFEntry bifEntry;
+		const path_t& name = dirIt.GetName();
+		bifEntry.found = true;
+		bifEntry.name = name;
+		bifEntry.path = PathJoin(path, name);
+
+		auto checkName = fmt::format("data/{}", name);
+		auto lookup =
+			std::find_if(biffiles.begin(), biffiles.end(), [&checkName](const BIFEntry& bif) {
+				// names in biffiles have a trailing NUL
+				auto bifName = bif.name;
+				bifName.resize(checkName.size());
+				return bifName == checkName;
+			});
+
+		if (lookup != biffiles.end()) {
+			*lookup = bifEntry;
+		}
+	} while (++dirIt);
 }
 
 bool KEYImporter::HasResource(StringView resname, SClass_ID type)

--- a/gemrb/plugins/KEYImporter/KEYImporter.h
+++ b/gemrb/plugins/KEYImporter/KEYImporter.h
@@ -21,9 +21,9 @@ class DataStream;
 
 struct BIFEntry {
 	path_t name;
-	ieWord BIFLocator;
+	ieWord BIFLocator = 0;
 	path_t path;
-	int cd;
+	int cd = 0;
 	bool found;
 };
 
@@ -73,6 +73,7 @@ private:
 
 public:
 	bool Open(const path_t& file, std::string desc) override;
+	void MergeBifsFromPath(const path_t& directory) override;
 	/* predicts the availability of a resource */
 	bool HasResource(StringView resname, SClass_ID type) override;
 	bool HasResource(StringView resname, const ResourceDesc& type) override;


### PR DESCRIPTION
A working approach how to tackle #2479, by looking for BIF files from the language's `data/` and replacing them by what is specified in the key file.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
