### PR TITLE
UTF-8 for EEs and text rendering resilience

### DIFF
--- a/gemrb/GemRB.cfg.noinstall.sample
+++ b/gemrb/GemRB.cfg.noinstall.sample
@@ -34,6 +34,7 @@ GamePath=../gemrb/tests/minimal
 GameType=test
 
 # Encoding [default|japanese|korean|chinese] Language used by game data.
+# Setting ignored for EE games.
 # Encoding=default
 
 ###############################################################################

--- a/gemrb/GemRB.cfg.sample.in
+++ b/gemrb/GemRB.cfg.sample.in
@@ -34,6 +34,7 @@
 GameType=auto
 
 # Encoding [default|japanese|korean|chinese] Language used by game data.
+# Setting ignored for EE games.
 # Encoding=default
 
 ###############################################################################

--- a/gemrb/core/GUI/TextSystem/Font.cpp
+++ b/gemrb/core/GUI/TextSystem/Font.cpp
@@ -446,6 +446,10 @@ size_t Font::RenderLine(const String& line, const Region& lineRgn,
 		for (; i < word.length(); i++) {
 			// process glyphs in word
 			currChar = word[i];
+			// for now, silently skip chars we cannot serve
+			if (currChar > AtlasIndex.size()) {
+				continue;
+			}
 			if (currChar == u'\r' || currChar == u'\n') {
 				continue;
 			}
@@ -454,6 +458,10 @@ size_t Font::RenderLine(const String& line, const Region& lineRgn,
 			}
 
 			const Glyph& curGlyph = GetGlyph(currChar);
+			if (!curGlyph.pixels) {
+				continue;
+			}
+
 			Point blitPoint = dp + lineRgn.origin + curGlyph.pos;
 			// use intersection because some rare glyphs can sometimes overlap lines
 			if (!lineRgn.IntersectsRegion(Region(blitPoint, curGlyph.size))) {

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -1602,6 +1602,13 @@ void Interface::LoadGemRBINI()
 /** Load the encoding table selected in gemrb.cfg */
 bool Interface::LoadEncoding()
 {
+	// EEs come with UTF-8 thankfully
+	if (config.GameType.substr(config.GameType.size() - 2, 2) == "ee") {
+		TLKEncoding.encoding = "UTF-8";
+		TLKEncoding.multibyte = true;
+		return true;
+	}
+
 	DataStream* inifile = gamedata->GetResourceStream(config.Encoding, IE_INI_CLASS_ID, true);
 	if (!inifile) {
 		return false;


### PR DESCRIPTION
Two patches on #2478 #1281 #1929

1. If we see an EE, we can probably skip any further encoding determination logic and set UTF-8 regardless, as BG1/2EE have all language TLKs in UTF-8.
2. Previously, when there was no suitable glyph found, the rendering aborted the rest. I changed that to skipping the character.

This makes us have this for now which should be an improvement, although still no proper dashes/bullet points:

<img width="272" height="273" alt="ee_utf8_nobreak" src="https://github.com/user-attachments/assets/46c38832-c2b9-4f31-847a-214602b37ed9" />

Non-latin chars of course still don't work but that's a different task.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I used the same coding style as the surrounding code
- [x] I have tested the proposed changes
- [x] I extended the documentation, if necessary
- [ ] The proposed change builds also on our build bots (check after submission)
