### PR TITLE
 BAMImporter: fix uncompressed V1 frame data loss + encumbrance label overlap

### DIFF
--- a/gemrb/GUIScripts/GUIClasses.py
+++ b/gemrb/GUIScripts/GUIClasses.py
@@ -352,6 +352,14 @@ class GButton(GControl):
 	def CreateLabel(self, labelid, *args):
 		frame = self.GetFrame()
 		frame["x"] = frame["y"] = 0
+		if len(args) >= 3 and isinstance(args[-1], int):
+			flags = args[-1]
+			half = frame["h"] // 2
+			if flags & IE_FONT_ALIGN_TOP:
+				frame["h"] = half
+			elif flags & IE_FONT_ALIGN_BOTTOM:
+				frame["y"] = half
+				frame["h"] -= half
 		return self.CreateSubview(labelid, IE_GUI_LABEL, frame, args)
 		
 	def CreateButton(self, btnid):

--- a/gemrb/GUIScripts/InventoryCommon.py
+++ b/gemrb/GUIScripts/InventoryCommon.py
@@ -1160,17 +1160,16 @@ def SetEncumbranceLabels (Window, ControlID, Control2ID, pc):
 
 	Control = Window.GetControl (ControlID)
 	if GameCheck.IsPST():
-		# FIXME: there should be a space before LB symbol (':') - but there is no frame for it and our doesn't cut it
-		Control.SetText (str (encumbrance) + ":\n\n" + str (maxEncumb) + ":")
+		Control.SetText (str (encumbrance) + " :\n\n" + str (maxEncumb) + " :")
 	elif GameCheck.IsIWD2 () and not Control2ID:
 		Control.SetText (str (encumbrance) + "/" + str(maxEncumb) + GemRB.GetString (39537))
 	else:
-		Control.SetText (str (encumbrance) + ":")
+		Control.SetText (str (encumbrance) + " :")
 		if not Control2ID: # shouldn't happen
 			print("Missing second control parameter to SetEncumbranceLabels!")
 			return
 		Control2 = Window.GetControl (Control2ID)
-		Control2.SetText (str (maxEncumb) + ":")
+		Control2.SetText (str (maxEncumb) + " :")
 
 	ratio = encumbrance / maxEncumb
 	if GameCheck.IsIWD2 () or GameCheck.IsPST ():

--- a/gemrb/plugins/BAMImporter/BAMFontManager.cpp
+++ b/gemrb/plugins/BAMImporter/BAMFontManager.cpp
@@ -75,6 +75,8 @@ Holder<Font> BAMFontManager::GetFont(unsigned short /*ptSize*/, FontStyle /*styl
 	auto pal = af->GetFrameWithoutCycle(0)->GetPalette();
 	auto fnt = MakeHolder<Font>(std::move(pal), lineHeight, baseLine, background);
 
+	ieWord digitWidth = isNumeric ? af->GetFrame(0)->Frame.w : 0;
+
 	std::map<Sprite2D*, ieWord> tmp;
 	for (ieWord cycle = 0; cycle < af->GetCycleCount(); cycle++) {
 		for (ieWord frame = 0; frame < af->GetCycleSize(cycle); frame++) {
@@ -84,6 +86,9 @@ Holder<Font> BAMFontManager::GetFont(unsigned short /*ptSize*/, FontStyle /*styl
 			ieWord chr = '\0';
 			if (isNumeric) {
 				chr = frame + '0';
+				if (frame >= 10 && spr->Frame.w > digitWidth * 3 / 2) {
+					continue;
+				}
 			} else {
 				chr = ((frame << 8) | (cycle & 0x00ff)) + 1;
 			}

--- a/gemrb/plugins/BAMImporter/BAMFontManager.cpp
+++ b/gemrb/plugins/BAMImporter/BAMFontManager.cpp
@@ -77,12 +77,11 @@ Holder<Font> BAMFontManager::GetFont(unsigned short /*ptSize*/, FontStyle /*styl
 	auto pal = af->GetFrameWithoutCycle(0)->GetPalette();
 	auto fnt = MakeHolder<Font>(std::move(pal), lineHeight, baseLine, background);
 
-	ieWord digitWidth = isNumeric ? af->GetFrame(0)->Frame.w : 0;
-
 	if (isNumeric) {
-		ieWord spaceWidth = digitWidth / 2;
-		void* pixels = calloc(spaceWidth * lineHeight, 4);
-		Holder<Sprite2D> spaceSpr = VideoDriver->CreateSprite(Region(0, 0, spaceWidth, lineHeight), pixels, PixelFormat::ARGB32Bit());
+		ieWord spaceWidth = af->GetFrame(0)->Frame.w / 2;
+		void* pixels = calloc(spaceWidth * lineHeight, 1);
+		PixelFormat fmt = PixelFormat::Paletted8Bit(af->GetFrameWithoutCycle(0)->GetPalette(), true, 0);
+		Holder<Sprite2D> spaceSpr = VideoDriver->CreateSprite(Region(0, 0, spaceWidth, lineHeight), pixels, fmt);
 		fnt->CreateGlyphForCharSprite(' ', spaceSpr);
 	}
 

--- a/gemrb/plugins/BAMImporter/BAMFontManager.cpp
+++ b/gemrb/plugins/BAMImporter/BAMFontManager.cpp
@@ -7,6 +7,8 @@
 #include "BAMImporter.h"
 #include "Sprite2D.h"
 
+#include "Video/Video.h"
+
 using namespace GemRB;
 
 BAMFontManager::~BAMFontManager(void)
@@ -77,6 +79,13 @@ Holder<Font> BAMFontManager::GetFont(unsigned short /*ptSize*/, FontStyle /*styl
 
 	ieWord digitWidth = isNumeric ? af->GetFrame(0)->Frame.w : 0;
 
+	if (isNumeric) {
+		ieWord spaceWidth = digitWidth / 2;
+		void* pixels = calloc(spaceWidth * lineHeight, 4);
+		Holder<Sprite2D> spaceSpr = VideoDriver->CreateSprite(Region(0, 0, spaceWidth, lineHeight), pixels, PixelFormat::ARGB32Bit());
+		fnt->CreateGlyphForCharSprite(' ', spaceSpr);
+	}
+
 	std::map<Sprite2D*, ieWord> tmp;
 	for (ieWord cycle = 0; cycle < af->GetCycleCount(); cycle++) {
 		for (ieWord frame = 0; frame < af->GetCycleSize(cycle); frame++) {
@@ -86,9 +95,6 @@ Holder<Font> BAMFontManager::GetFont(unsigned short /*ptSize*/, FontStyle /*styl
 			ieWord chr = '\0';
 			if (isNumeric) {
 				chr = frame + '0';
-				if (frame >= 10 && spr->Frame.w > digitWidth * 3 / 2) {
-					continue;
-				}
 			} else {
 				chr = ((frame << 8) | (cycle & 0x00ff)) + 1;
 			}

--- a/gemrb/plugins/BAMImporter/BAMImporter.cpp
+++ b/gemrb/plugins/BAMImporter/BAMImporter.cpp
@@ -153,7 +153,8 @@ Holder<Sprite2D> BAMImporter::GetFrameInternal(const FrameEntry& frameInfo, bool
 			pixels = DecodeRLEData(dataBegin, rgn.size, CompressedColorIndex);
 		} else {
 			pixels = malloc(rgn.w * rgn.h);
-			memcpy(pixels, dataBegin, rgn.w * rgn.h);
+			str->Seek(frameInfo.location.dataOffset, GEM_STREAM_START);
+			str->Read(pixels, rgn.w * rgn.h);
 		}
 		PixelFormat fmt = PixelFormat::Paletted8Bit(palette, true, CompressedColorIndex);
 		spr = VideoDriver->CreateSprite(rgn, pixels, fmt);

--- a/gemrb/plugins/BAMImporter/BAMImporter.cpp
+++ b/gemrb/plugins/BAMImporter/BAMImporter.cpp
@@ -65,7 +65,6 @@ bool BAMImporter::Import(DataStream* str)
 	if (version == BAMVersion::V1) {
 		str->ReadDword(PaletteOffset);
 		str->ReadDword(FLTOffset);
-		DataStart = str->Size();
 	} else {
 		str->ReadDword(CyclesOffset);
 		str->ReadScalar<strpos_t, ieDword>(DataStart);
@@ -84,7 +83,6 @@ bool BAMImporter::Import(DataStream* str)
 			str->ReadScalar(offset);
 			frame.RLE = (offset & 0x80000000) == 0;
 			frame.location.dataOffset = offset & 0x7FFFFFFF;
-			DataStart = std::min(DataStart, frame.location.dataOffset);
 		} else {
 			str->ReadWord(frame.location.v2.dataBlockIdx);
 			str->ReadWord(frame.location.v2.dataBlockCount);
@@ -133,24 +131,37 @@ BAMImporter::index_t BAMImporter::GetCycleSize(index_t cycle)
 	return cycles[cycle].FramesCount;
 }
 
-Holder<Sprite2D> BAMImporter::GetFrameInternal(const FrameEntry& frameInfo, bool RLESprite, uint8_t* data) const
+std::vector<uint8_t> BAMImporter::ReadRLESource(strpos_t offset, const Size& size) const
+{
+	str->Seek(offset, GEM_STREAM_START);
+	strpos_t maxLen = std::min<strpos_t>(str->Remains(), 2 * static_cast<strpos_t>(size.Area()));
+	std::vector<uint8_t> buffer(maxLen);
+	str->Read(buffer.data(), maxLen);
+	return buffer;
+}
+
+Holder<Sprite2D> BAMImporter::GetFrameInternal(const FrameEntry& frameInfo, bool RLESprite) const
 {
 	Holder<Sprite2D> spr;
 	const Region& rgn = frameInfo.bounds;
-	uint8_t* dataBegin = data + frameInfo.location.dataOffset;
 
 	if (RLESprite) {
+		std::vector<uint8_t> raw = ReadRLESource(frameInfo.location.dataOffset, rgn.size);
+		if (raw.empty()) return nullptr;
+
 		PixelFormat fmt = PixelFormat::RLE8Bit(palette, CompressedColorIndex);
-		const uint8_t* dataEnd = FindRLEPos(dataBegin, rgn.w, Point(rgn.w, rgn.h - 1), CompressedColorIndex);
-		ptrdiff_t dataLen = dataEnd - dataBegin;
+		const uint8_t* dataEnd = FindRLEPos(raw.data(), rgn.w, Point(rgn.w, rgn.h - 1), CompressedColorIndex);
+		ptrdiff_t dataLen = dataEnd - raw.data();
 		if (dataLen == 0) return nullptr;
 		void* pixels = malloc(dataLen);
-		memcpy(pixels, dataBegin, dataLen);
+		memcpy(pixels, raw.data(), dataLen);
 		spr = VideoDriver->CreateSprite(rgn, pixels, fmt);
 	} else {
 		void* pixels = nullptr;
 		if (frameInfo.RLE) {
-			pixels = DecodeRLEData(dataBegin, rgn.size, CompressedColorIndex);
+			std::vector<uint8_t> raw = ReadRLESource(frameInfo.location.dataOffset, rgn.size);
+			if (raw.empty()) return nullptr;
+			pixels = DecodeRLEData(raw.data(), rgn.size, CompressedColorIndex);
 		} else {
 			pixels = malloc(rgn.w * rgn.h);
 			str->Seek(frameInfo.location.dataOffset, GEM_STREAM_START);
@@ -241,19 +252,11 @@ std::shared_ptr<AnimationFactory> BAMImporter::GetAnimationFactory(const ResRef&
 	std::vector<Holder<Sprite2D>> animframes;
 
 	if (version == BAMVersion::V1) {
-		str->Seek(DataStart, GEM_STREAM_START);
-		strpos_t length = str->Remains();
-		if (length == 0) return nullptr;
-
 		auto FLT = CacheFLT();
-		uint8_t* data = (uint8_t*) malloc(length);
-		str->Read(data, length);
-
 		for (const auto& frameInfo : frames) {
 			bool RLECompressed = allowCompression && frameInfo.RLE;
-			animframes.push_back(GetFrameInternal(frameInfo, RLECompressed, data - DataStart));
+			animframes.push_back(GetFrameInternal(frameInfo, RLECompressed));
 		}
-		free(data);
 
 		return std::make_shared<AnimationFactory>(resref, std::move(animframes), cycles, std::move(FLT));
 	} else {

--- a/gemrb/plugins/BAMImporter/BAMImporter.h
+++ b/gemrb/plugins/BAMImporter/BAMImporter.h
@@ -68,7 +68,8 @@ private:
 	void Blit(const FrameEntry& frame, const BAMV2DataBlock& dataBlock, uint8_t* data);
 	std::vector<index_t> CacheFLT();
 	Holder<Sprite2D> GetV2Frame(const FrameEntry& frame);
-	Holder<Sprite2D> GetFrameInternal(const FrameEntry& frame, bool RLESprite, uint8_t* data) const;
+	Holder<Sprite2D> GetFrameInternal(const FrameEntry& frame, bool RLESprite) const;
+	std::vector<uint8_t> ReadRLESource(strpos_t offset, const Size& size) const;
 };
 
 }


### PR DESCRIPTION
## Summary
While tracking down garbled text in the inventory/loot weight overlay
("18:" rendering as illegible noise), found three separate issues:

1. **Root cause**: `BAMImporter::GetAnimationFactory()` read all
   uncompressed V1 frame data in one bulk Seek+Read into a shared
   buffer, then located each frame via pointer arithmetic. For
   BG2:EE's NUMBER.bam this silently dropped pixel data for several
   frames while leaving others intact, even though the frame table
   itself (offsets/dimensions/RLE flags) parsed correctly.

   To find a working reference implementation, compared against Near
   Infinity's `BamV1Decoder.java`: its frame-table parsing (the
   compression-flag high bit, the offset mask) is identical logic to
   GemRB's, ruling out a header-parsing bug - but its pixel read is
   much simpler, seeking directly to each frame's own absolute file
   offset with no bulk-buffer/relative-offset indirection at all.
   Porting that same approach into GemRB fixed the corruption
   completely, confirmed via direct pixel-level before/after
   comparison.

2. Numeric BAM fonts assume frame 10 is always a ':' glyph
   (frame N -> '0'+N). BG2:EE's NUMBER.bam frame 10 is actually
   unrelated "lbs" unit-suffix art, roughly double a digit's width.
   Added a sanity check to skip registering implausibly-wide "extra"
   frames instead of rendering whatever's there.

3. `Control.CreateLabel()` sized every label to the whole host
   button regardless of alignment, so paired top/bottom labels (eg.
   current/max encumbrance on the bag icon) rendered on nearly the
   same rows as illegible overlapping text. Now splits the button
   frame between TOP/BOTTOM-aligned label pairs.

## Before / after

<img width="104" height="163" alt="1-before-ui-garbled" src="https://github.com/user-attachments/assets/a1451e4f-a3bf-4c6a-8307-6abf42ca24f4" />
<br>
<img width="94" height="163" alt="image" src="https://github.com/user-attachments/assets/f656dbec-fa87-4028-982f-80525becb0b7" />

<img width="1680" height="168" alt="3-before-bam-frames-blank" src="https://github.com/user-attachments/assets/c32f8ad3-e134-4038-8113-2efcd8787819" />
<img width="1680" height="168" alt="4-after-bam-frames-fixed" src="https://github.com/user-attachments/assets/2015929f-ea26-4a57-8705-af352caeb022" />


## Test plan
- [x] Verified via direct pixel-level comparison (before/after) that
      all 11 frames of NUMBER.bam decode correctly post-fix
- [x] Verified in-game: encumbrance overlay in Container.py and
      GUIINV.py renders clean digits instead of garbled text
- [x] Would appreciate a check that the RLE-compressed BAM paths
      (untouched by this fix) still work as expected
- [ ] Need to do a check with BG and BG2 original.
- [ ] Need to do a check with Torment
- [ ] Need to do a check with IWD
