### PR TITLE
WorldMapControl: fix overlapping click hit-regions

### DIFF
--- a/gemrb/core/GUI/WorldMapControl.cpp
+++ b/gemrb/core/GUI/WorldMapControl.cpp
@@ -9,6 +9,7 @@
 
 #include "DisplayMessage.h"
 #include "Game.h"
+#include "Geometry.h"
 #include "Interface.h"
 #include "WorldMap.h"
 
@@ -204,6 +205,8 @@ bool WorldMapControl::OnMouseOver(const MouseEvent& me)
 	Area = nullptr;
 
 	unsigned int ec = worldmap->GetEntryCount();
+	WMPAreaEntry* closest = nullptr;
+	unsigned int closestDist = 0;
 	for (unsigned int i = 0; i < ec; i++) {
 		WMPAreaEntry* ae = worldmap->GetEntry(i);
 
@@ -222,23 +225,31 @@ bool WorldMapControl::OnMouseOver(const MouseEvent& me)
 		if (ftext) {
 			Size ts = ftext->StringSize(ae->GetCaption());
 			ts.w += 10;
-			if (rgn.h < ts.h)
-				rgn.h = ts.h;
-			if (rgn.w < ts.w)
+			if (ts.w > rgn.w) {
+				rgn.x -= (ts.w - rgn.w) / 2;
 				rgn.w = ts.w;
+			}
+			rgn.h += ts.h + ftext->LineHeight;
 		}
 		if (!rgn.PointInside(mapOff)) continue;
 
+		unsigned int dist = SquaredDistance(mapOff, ae->pos);
+		if (!closest || dist < closestDist) {
+			closest = ae;
+			closestDist = dist;
+		}
+	}
+
+	if (closest) {
 		SetCursor(core->Cursors[IE_CURSOR_NORMAL]);
-		Area = ae;
-		if (oldArea != ae) {
+		Area = closest;
+		if (oldArea != closest) {
 			const String str = core->GetString(HCStrings::TravelTime);
 			int hours = worldmap->GetDistance(Area->AreaName);
 			if (!str.empty() && hours >= 0) {
 				SetTooltip(fmt::format(u"{}: {}", str, hours));
 			}
 		}
-		break;
 	}
 	if (Area == nullptr) {
 		SetTooltip(u"");


### PR DESCRIPTION
Fixes #2498.

## Problem

`OnMouseOver()` grew each area's clickable region to include its
caption text, but the growth didn't match how the caption is actually
drawn: it took `max(icon, text)` for both width and height, anchored
at the icon's own top-left corner. The caption is centered under the
icon (extending both left and right when wider) and drawn below it,
not overlapping it - so a long caption only widened the region
rightward, and never extended it downward past the icon at all.
Neither matched the caption's real footprint, and the resulting
overlap between adjacent areas' regions is what let a click meant for
one district silently register as a neighboring one (eg. "Waukeen's
Promenade").

## Fix

- Grow the region to the union of the icon's rect and the caption's
  actual rect: widen symmetrically around the icon's center when the
  caption is wider (matching the existing centering math used to draw
  it), and extend the height downward by the caption's height plus
  one extra line-height of padding, since the caption sits below the
  icon rather than overlapping it.
- Regions can still legitimately overlap for closely-packed areas even
  with correct sizing, so when the cursor is inside more than one,
  pick whichever area's icon is closest to it instead of whichever
  happens to come first in the world map's area table.

## Screenshots

<img width="1200" height="600" alt="1-before-hitbox-overlap" src="https://github.com/user-attachments/assets/a8cfcfff-ff1b-4dcd-9c54-c1f8f5d7adca" />

<img width="149" height="165" alt="image" src="https://github.com/user-attachments/assets/6c2180c8-a60e-4a39-86f2-bb6f58936133" />
