### PR TITLE
WorldMapControl: hover feedback for the click target (depends on #2505)

### DIFF
--- a/gemrb/core/GUI/WorldMapControl.cpp
+++ b/gemrb/core/GUI/WorldMapControl.cpp
@@ -99,7 +99,7 @@ void WorldMapControl::DrawSelf(const Region& rgn, const Region& /*clip*/)
 			if (!(worldmap->Flags & 1)) flags ^= BlitFlags::COLOR_MOD;
 			if (worldmap->Flags == 2) flags |= BlitFlags::GREY;
 		}
-		if (m == Area && m->HighlightSelected()) {
+		if (m == Area) {
 			VideoDriver->BlitGameSprite(icon, offset, flags, hoverAnim.Current());
 		} else if (!(m->GetAreaStatus() & WMP_ENTRY_VISITED)) {
 			VideoDriver->BlitGameSprite(icon, offset, flags, color_notvisited);
@@ -144,9 +144,7 @@ void WorldMapControl::DrawSelf(const Region& rgn, const Region& /*clip*/)
 		Region r2 = Region(MapToScreen(p), icon_frame.size);
 
 		Font::PrintColors colors;
-		if (Area == m) {
-			colors.fg = hoverAnim.Current();
-		} else if (!(m->GetAreaStatus() & WMP_ENTRY_VISITED)) {
+		if (!(m->GetAreaStatus() & WMP_ENTRY_VISITED)) {
 			colors.fg = color_notvisited;
 		} else {
 			colors.fg = color_normal;
@@ -253,6 +251,9 @@ bool WorldMapControl::OnMouseOver(const MouseEvent& me)
 	}
 	if (Area == nullptr) {
 		SetTooltip(u"");
+	}
+	if (Area != oldArea) {
+		MarkDirty();
 	}
 
 	return true;

--- a/gemrb/core/GUI/WorldMapControl.cpp
+++ b/gemrb/core/GUI/WorldMapControl.cpp
@@ -9,6 +9,7 @@
 
 #include "DisplayMessage.h"
 #include "Game.h"
+#include "Geometry.h"
 #include "Interface.h"
 #include "WorldMap.h"
 
@@ -204,6 +205,8 @@ bool WorldMapControl::OnMouseOver(const MouseEvent& me)
 	Area = nullptr;
 
 	unsigned int ec = worldmap->GetEntryCount();
+	WMPAreaEntry* closest = nullptr;
+	unsigned int closestDist = 0;
 	for (unsigned int i = 0; i < ec; i++) {
 		WMPAreaEntry* ae = worldmap->GetEntry(i);
 
@@ -222,23 +225,31 @@ bool WorldMapControl::OnMouseOver(const MouseEvent& me)
 		if (ftext) {
 			Size ts = ftext->StringSize(ae->GetCaption());
 			ts.w += 10;
-			if (rgn.h < ts.h)
-				rgn.h = ts.h;
-			if (rgn.w < ts.w)
+			if (ts.w > rgn.w) {
+				rgn.x -= (ts.w - rgn.w) / 2;
 				rgn.w = ts.w;
+			}
+			rgn.h += ts.h + ftext->LineHeight;
 		}
 		if (!rgn.PointInside(mapOff)) continue;
 
+		unsigned int dist = SquaredDistance(mapOff, ae->pos);
+		if (!closest || dist < closestDist) {
+			closest = ae;
+			closestDist = dist;
+		}
+	}
+
+	if (closest) {
 		SetCursor(core->Cursors[IE_CURSOR_NORMAL]);
-		Area = ae;
-		if (oldArea != ae) {
+		Area = closest;
+		if (oldArea != closest) {
 			const String str = core->GetString(HCStrings::TravelTime);
 			int hours = worldmap->GetDistance(Area->AreaName);
 			if (!str.empty() && hours >= 0) {
 				SetTooltip(fmt::format(u"{}: {}", str, hours));
 			}
 		}
-		break;
 	}
 	if (Area == nullptr) {
 		SetTooltip(u"");

--- a/gemrb/core/GUI/WorldMapControl.h
+++ b/gemrb/core/GUI/WorldMapControl.h
@@ -33,6 +33,7 @@ private:
 	/** Draws the Control on the Output Display */
 	void WillDraw(const Region& /*drawFrame*/, const Region& /*clip*/) override;
 	void DrawSelf(const Region& drawFrame, const Region&) override;
+	bool IsAnimated() const override { return Area != nullptr; }
 
 public:
 	WorldMapControl(const Region& frame, Holder<Font> font);


### PR DESCRIPTION
Depends on and is stacked on #2505 - please review/merge that first.

## Problem

Only single-frame icons had any hover feedback (a color pulse gated
on `HighlightSelected()`); multi-frame icons had none, making it easy
to misjudge which district's hitbox the mouse was actually over -
the same underlying confusion behind #2498.

## Fix

Extend the pulse to every icon on hover, mark the control dirty when
the hovered area changes so it redraws right away, and override
`IsAnimated()` so it keeps redrawing while hovered instead of only on
the next unrelated redraw.

## Screenshot

<img width="149" height="165" alt="image" src="https://github.com/user-attachments/assets/49bd1179-46c6-47ef-8793-b993f047eadc" />
