### PR TITLE
Fix clang compilation error

### DIFF
--- a/gemrb/core/GUI/TextSystem/Font.h
+++ b/gemrb/core/GUI/TextSystem/Font.h
@@ -165,6 +165,7 @@ public:
 	Font(Holder<Palette> pal, ieWord lineheight, ieWord baseline, bool bg);
 	Font(const Font&) = delete;
 	Font& operator=(const Font&) = delete;
+	virtual ~Font() = default;
 
 	const Glyph& CreateGlyphForCharSprite(ieWord chr, const Holder<Sprite2D>&);
 	// BAM fonts use alisases a lot so this saves quite a bit of space

--- a/gemrb/plugins/TTFImporter/TTFFont.h
+++ b/gemrb/plugins/TTFImporter/TTFFont.h
@@ -20,7 +20,7 @@ private:
 
 public:
 	TTFFont(Holder<Palette> pal, FT_Face face, int lineheight, int baseline);
-	~TTFFont(void);
+	~TTFFont(void) override;
 
 	const Glyph& GetGlyph(ieWord chr) const override;
 	int GetKerningOffset(ieWord leftChr, ieWord rightChr) const override;


### PR DESCRIPTION
Restore `Font`'s virtual destructor, to avoid:
`error: destructor called on non-final 'GemRB::Font' that has virtual functions but non-virtual destructor`