### PR TITLE
Fix segfault: defer resolving itm->Expired only after we already have save's GameTime

### DIFF
--- a/gemrb/core/Game.cpp
+++ b/gemrb/core/Game.cpp
@@ -289,6 +289,17 @@ int Game::DelNPC(unsigned int slot, bool autoFree)
 	return 0;
 }
 
+void Game::ResolveItemExpiry() const
+{
+	const ieDword hour = GameTime / core->Time.hour_size;
+	for (const Actor* pc : PCs) {
+		pc->inventory.ResolveItemExpiry(hour);
+	}
+	for (const Actor* npc : NPCs) {
+		npc->inventory.ResolveItemExpiry(hour);
+	}
+}
+
 //i'm sure this could be faster
 void Game::ConsolidateParty() const
 {

--- a/gemrb/core/Game.h
+++ b/gemrb/core/Game.h
@@ -445,6 +445,8 @@ public:
 	void AddGold(int add);
 	/** Adds ticks to game time */
 	void AdvanceTime(ieDword add, bool fatigue = true);
+	/** Converts item expiration delays that were still relative when the party was read */
+	void ResolveItemExpiry() const;
 	/** Runs the script engine on the global script and the area scripts
 	areas run scripts on door, infopoint, container, actors too */
 	void UpdateScripts();

--- a/gemrb/core/Interface.cpp
+++ b/gemrb/core/Interface.cpp
@@ -3232,9 +3232,11 @@ CREItem* Interface::ReadItem(DataStream* str, CREItem* itm) const
 {
 	str->ReadResRef(itm->ItemResRef);
 	str->ReadWord(itm->Expired);
-	if (itm->Expired != 0 && itm->Expired <= 255) {
-		// convert to absolute time, including forcing a 255 delay
-		itm->Expired = (GetGame()->GameTime / Time.hour_size) + itm->Expired * 24 + 255;
+	// if the party is read from the GAM while the Game isn't installed yet,
+	// later call to Game::ResolveItemExpiry will handle that
+	const Game* curGame = GetGame();
+	if (curGame) {
+		itm->ResolveExpiry(curGame->GameTime / Time.hour_size);
 	}
 
 	str->ReadWord(itm->Usages[0]);

--- a/gemrb/core/Inventory.cpp
+++ b/gemrb/core/Inventory.cpp
@@ -2206,6 +2206,13 @@ void Inventory::EnforceUsability()
 	}
 }
 
+void Inventory::ResolveItemExpiry(const ieDword hour) const
+{
+	for (CREItem* itm : Slots) {
+		if (itm) itm->ResolveExpiry(hour);
+	}
+}
+
 void Inventory::CheckExpiry(ieDword hour)
 {
 	size_t maxSlot = Slots.size();

--- a/gemrb/core/Inventory.h
+++ b/gemrb/core/Inventory.h
@@ -171,6 +171,13 @@ public:
 		Weight = item->Weight;
 		MaxStackAmount = item->MaxStackAmount;
 	};
+	// turns a still relative expiration delay in days into an absolute hour;
+	// the forced 255 also marks the value as already converted
+	void ResolveExpiry(ieDword hour)
+	{
+		if (Expired == 0 || Expired > 255) return;
+		Expired = hour + Expired * 24 + 255;
+	};
 };
 
 /**
@@ -346,6 +353,7 @@ public:
 	void CacheAllWeaponInfo() const;
 	void EnforceUsability();
 	void CheckExpiry(ieDword hour); // check if any item is past its expiration date
+	void ResolveItemExpiry(ieDword hour) const; // convert delays that were still relative when the item was read
 
 private:
 	void CalculateWeight(void);

--- a/gemrb/plugins/GAMImporter/GAMImporter.cpp
+++ b/gemrb/plugins/GAMImporter/GAMImporter.cpp
@@ -194,6 +194,10 @@ std::unique_ptr<Game> GAMImporter::LoadGame(std::unique_ptr<Game> newGame, GAMVe
 		newGame->AddNPC(actor);
 	}
 
+	// the actors above were read while this Game wasn't installed yet, so their items
+	// couldn't have their expiration delays converted to absolute time
+	newGame->ResolveItemExpiry();
+
 	// load initial values from var.var, but only for new games,
 	// since we need to maintain the order
 	if (GlobalCount == 0) {


### PR DESCRIPTION
Fix crash during loading particular BG2 save state.

Crash callstack:
```
  std::__atomic_base::load atomic_base.h:505
  GemRB::Interface::ReadItem Interface.cpp:3237
  GemRB::Interface::ReadItem Interface.cpp:3226
  GemRB::CREImporter::ReadInventory CREImporter.cpp:1128
  GemRB::CREImporter::GetActor CREImporter.cpp:922
  GemRB::GAMImporter::GetActor GAMImporter.cpp:461
  GemRB::GAMImporter::LoadGame GAMImporter.cpp:177
  GemRB::Interface::LoadGame Interface.cpp:2583
  GemRB::Interface::HandleFlags Interface.cpp:848
  GemRB::Interface::Main Interface.cpp:1042
  main GemRB.cpp:52
```