### PR TITLE
Implement proper comparator class for BasePoint

### DIFF
--- a/gemrb/core/PathFinder.cpp
+++ b/gemrb/core/PathFinder.cpp
@@ -32,6 +32,7 @@
 
 #include <array>
 #include <limits>
+#include <set>
 
 namespace GemRB {
 
@@ -773,8 +774,8 @@ void PathFinder::AdjustPositionDirected(const TileProps& tileProps, NavmapPoint&
 	// NOTE: OrientedOffset is wrong for radius > 1, ignoring the other 8 possible orientations
 	//       it's not really important, since we're usually checking circle sizes larger than 1
 	//       and there'd be overlaps for longer than it takes to find a good position
-	std::array<orient_t, 5> orients { direction, NextOrientation(direction, 2), PrevOrientation(direction, 2), NextOrientation(direction), PrevOrientation(direction) };
-	std::set<SearchmapPoint> baseOffsets; // OrientedOffset only offsets in 8 directions, so there will be duplicates
+	const std::array<orient_t, 5> orients { direction, NextOrientation(direction, 2), PrevOrientation(direction, 2), NextOrientation(direction), PrevOrientation(direction) };
+	std::set<SearchmapPoint, SearchmapPoint::Cmp> baseOffsets; // OrientedOffset only offsets in 8 directions, so there will be duplicates
 	for (size_t idx = 0; idx < orients.size(); idx++) {
 		Point p = OrientedOffset(orients[idx], 1);
 		baseOffsets.emplace(p.x, p.y);

--- a/gemrb/core/Region.h
+++ b/gemrb/core/Region.h
@@ -57,6 +57,16 @@ public:
 
 	int x = 0;
 	int y = 0;
+
+	/**
+	 *  Comparator functor for use with std::map and std::set.
+	 */
+	struct Cmp {
+		bool operator()(const BasePoint& P1, const BasePoint& P2) const
+		{
+			return P1.x < P2.x || (P1.x == P2.x && P1.y < P2.y);
+		}
+	};
 };
 
 class GEM_EXPORT Point : public BasePoint {


### PR DESCRIPTION
Fix debug assert from:
```
gemrb_core.dll!GemRB::PathFinder::AdjustPositionDirected(const GemRB::TileProps & tileProps, GemRB::Point & goal, GemRB::orient_t direction, int startingRadius, unsigned int minDistance) Line 780    C++
gemrb_core.dll!GemRB::PathFinder::FindPath(const GemRB::PagedSparseArray<GemRB::TraversabilityCache::TraversabilityCellData,1,6> & traversabilityCacheSnapshot, const GemRB::TileProps & tileProps, const GemRB::Point & source, const GemRB::Point & destination, const GemRB::ActorPathContext & actorContext, unsigned int minDistance, int pathfindingFlags) Line 215    C++
gemrb_core.dll!GemRB::PathFinderScheduler::PerformPathCalculation(const GemRB::PagedSparseArray<GemRB::TraversabilityCache::TraversabilityCellData,1,6> & currentTraversabilityCacheSnapshot, const GemRB::TileProps & currentTileProps, GemRB::FindPathRequestId currentRequestId, GemRB::FindPathRequestWorkerData & InOutCurrentRequest) Line 799    C++
gemrb_core.dll!GemRB::PathFinderScheduler::PathfinderThreadUpdate(unsigned __int64 workerIdx) Line 1032    C++
gemrb_core.dll!GemRB::PathFinderScheduler::WorkerThreadMainLoop(unsigned __int64 workerIdx) Line 1064    C++
```
