### PR TITLE
Fix dropping paths in tight places

### DIFF
--- a/gemrb/core/Map.cpp
+++ b/gemrb/core/Map.cpp
@@ -2326,8 +2326,7 @@ bool Map::IsWalkableTo(const Point& s, const Point& d, bool actorsAreBlocking, c
 bool Map::IsWalkableTo(const SearchmapPoint& s, const SearchmapPoint& d, bool actorsAreBlocking, const Actor* caller) const
 {
 	PathMapFlags ret = PathFinder::GetBlockedInLineTile(tileProps, s, d, true, caller);
-	PathMapFlags mask = PathMapFlags::PASSABLE | (actorsAreBlocking ? PathMapFlags::UNMARKED : PathMapFlags::ACTOR);
-	return bool(ret & mask);
+	return PathFinder::IsLineWalkable(ret, actorsAreBlocking);
 }
 
 void Map::RedrawScreenStencil(const Region& vp, const WallPolygonGroup& walls)

--- a/gemrb/core/PathFinder.cpp
+++ b/gemrb/core/PathFinder.cpp
@@ -674,18 +674,30 @@ bool PathFinder::IsVisibleLOS(const TileProps& tileProps, const SearchmapPoint& 
 }
 
 
+bool PathFinder::IsLineWalkable(const PathMapFlags accumulatedFlags, const bool areActorsBlocking)
+{
+	// Check the geometry first:
+	// `accumulatedFlags` is OR-accumulated over the whole line, so a single tile with ACTOR flag, sets ACTOR for
+	// all of it. Ignoring actors would cause ignore any wall on the line, so pathfinder could route a path
+	// going straight through a wall - and that's a pretty bad pathfinder's job if you ask me. Unless it's a pathfinder
+	// for ghosts.
+	if (static_cast<bool>(accumulatedFlags & (PathMapFlags::SIDEWALL | PathMapFlags::DOOR_IMPASSABLE))) {
+		return false;
+	}
+	const PathMapFlags mask = PathMapFlags::PASSABLE | (areActorsBlocking ? PathMapFlags::UNMARKED : PathMapFlags::ACTOR);
+	return static_cast<bool>(accumulatedFlags & mask);
+}
+
 bool PathFinder::IsWalkableTo(const TileProps& tileProps, const Point& s, const Point& d, bool actorsAreBlocking, const Actor* caller)
 {
 	PathMapFlags ret = GetBlockedInLine(tileProps, s, d, true, caller);
-	PathMapFlags mask = PathMapFlags::PASSABLE | (actorsAreBlocking ? PathMapFlags::UNMARKED : PathMapFlags::ACTOR);
-	return bool(ret & mask);
+	return IsLineWalkable(ret, actorsAreBlocking);
 }
 
 bool PathFinder::IsWalkableTo(const TileProps& tileProps, const Point& s, const Point& d, bool actorsAreBlocking, int actorSpeed, int actorCircleSize)
 {
 	PathMapFlags ret = GetBlockedInLine(tileProps, s, d, true, actorSpeed, actorCircleSize);
-	PathMapFlags mask = PathMapFlags::PASSABLE | (actorsAreBlocking ? PathMapFlags::UNMARKED : PathMapFlags::ACTOR);
-	return bool(ret & mask);
+	return IsLineWalkable(ret, actorsAreBlocking);
 }
 
 bool PathFinder::AdjustPositionX(const TileProps& tileProps, SearchmapPoint& goal, const Size& radius, int size)

--- a/gemrb/core/PathFinder.h
+++ b/gemrb/core/PathFinder.h
@@ -184,6 +184,7 @@ public:
 
 	static bool IsWalkableTo(const TileProps& tileProps, const Point& s, const Point& d, bool actorsAreBlocking, const Actor* caller);
 	static bool IsWalkableTo(const TileProps& tileProps, const Point& s, const Point& d, bool actorsAreBlocking, int actorSpeed, int actorCircleSize);
+	static bool IsLineWalkable(PathMapFlags accumulatedFlags, bool areActorsBlocking);
 
 	static bool AdjustPositionX(const TileProps& tileProps, SearchmapPoint& goal, const Size& radius, int size = -1);
 	static bool AdjustPositionY(const TileProps& tileProps, SearchmapPoint& goal, const Size& radius, int size = -1);

--- a/gemrb/core/TileProps.cpp
+++ b/gemrb/core/TileProps.cpp
@@ -148,8 +148,15 @@ void TileProps::PaintSearchMap(const SearchmapPoint& p, uint16_t blocksize, cons
 	// actor. This matches the behaviour of the original BG2.
 
 	auto PaintIfPassable = [this, value](const SearchmapPoint& pos) {
-		PathMapFlags mapval = QuerySearchMap(pos);
-		if (mapval != PathMapFlags::IMPASSABLE) {
+		const PathMapFlags mapval = QuerySearchMap(pos);
+		// Only walkable terrain should be able to carry actor marks.
+		// Marking a wall as occupied is wrong and buys us nothing
+		// (it is unwalkable already, regardless of whether an actor is bumped
+		// there or not).
+		// Readers that accept a tile based on its ACTOR bit would then see a hole
+		// in the wall wherever a circle spills onto it.
+		constexpr auto CanStoreActor = PathMapFlags::PASSABLE | PathMapFlags::TRAVEL;
+		if (static_cast<bool>(mapval & CanStoreActor)) {
 			PathMapFlags newVal = (mapval & PathMapFlags::NOTACTOR) | value;
 			uint32_t& pixel = propPtr[pos.y * size.w + pos.x];
 			pixel = (pixel & ~searchMapMask) | (uint32_t(newVal) << pixelFormat.Rshift);


### PR DESCRIPTION
When ordering to move the party while being in a thight spot, the ordered movement was often dropped after a while, before the characters arrive at their target goals.

This was a result of 2 compounding and kind-of similar bugs, both tied to ignoring actors.

1) Actor footprints were painted onto wall tiles.
`PaintIfPassable` accepted any tile that was not `IMPASSABLE`. Any actor standing next to the wall stamped `ACTOR` bits onto it. Then, if anyone reading the `TileProps` and passing the predicate for the `ACTOR` will see a hole in the wall.
Fixed that: allow painting actors only on walkable terrain.

2) `IsWalkableTo` were ignoring walls, if there was an actor in the line (if told to ignore actors).
Fixed that by checking the geometry first, before ignoring actors: if there is a wall on the line, it's obviously not walkable.

----

### State before the fix:
<details><summary>BG2, needed 5 clicks to complete this epic journey</summary>

https://github.com/user-attachments/assets/7858d2bf-add4-4266-a3ce-a1f01ece6eaf

</details>

<details><summary>The best Maze, cannot even go to neighboring corridor</summary>

https://github.com/user-attachments/assets/449b5744-89b8-4ddd-89f1-475b1399d891

</details>

### State with the fix:
<details><summary>BG2, now player will be bored I guess</summary>

https://github.com/user-attachments/assets/3f97f062-88b7-4d18-9ff0-a7a1af081965

</details>

<details><summary>The best Maze, could they go to the other side in one go?</summary>

https://github.com/user-attachments/assets/38cb7f1d-21ea-4fb0-aac0-ae7cbb337574

</details>