### PR TITLE
Pathfinding tests: insfrastructure and basics

### DIFF
--- a/gemrb/CMakeLists.txt
+++ b/gemrb/CMakeLists.txt
@@ -204,6 +204,7 @@ IF (BUILD_TESTING)
     tests/core/Test_MurmurHash.cpp
     tests/core/Test_Orient.cpp
     tests/core/Test_Palette.cpp
+    tests/core/Test_PathFinder.cpp
     tests/core/Test_SaveGame.cpp
     tests/core/Streams/Test_DataStream.cpp
     tests/core/Strings/Test_CString.cpp

--- a/gemrb/core/TileProps.cpp
+++ b/gemrb/core/TileProps.cpp
@@ -184,6 +184,11 @@ OwningTileProps OwningTileProps::CopyFrom(const TileProps& tileProps)
 	return OwningTileProps { tileProps };
 }
 
+OwningTileProps OwningTileProps::MakeEmpty(const Size& size)
+{
+	return OwningTileProps { size };
+}
+
 OwningTileProps::OwningTileProps(OwningTileProps&& other) noexcept
 {
 	*this = std::move(other);
@@ -223,6 +228,15 @@ OwningTileProps& OwningTileProps::operator=(OwningTileProps&& other) noexcept
 	other.propImage = nullptr;
 	other.size.reset();
 	return *this;
+}
+
+OwningTileProps::OwningTileProps(const Size& propSize)
+	// one uint32_t per cell, zeroed; an invalid size yields an empty instance
+	: ownedProps(propSize.IsInvalid() ? 0 : size_t(propSize.Area()), 0)
+{
+	size = ownedProps.empty() ? Size() : propSize;
+	propImage = nullptr;
+	RebindPropPtr();
 }
 
 OwningTileProps::OwningTileProps(const TileProps& tileProps)

--- a/gemrb/core/TileProps.h
+++ b/gemrb/core/TileProps.h
@@ -109,6 +109,9 @@ class GEM_EXPORT OwningTileProps : public TileProps {
 public:
 	static OwningTileProps CopyFrom(const TileProps& tileProps);
 
+	// creates tile props with all-zero buffer of the given tile size
+	static OwningTileProps MakeEmpty(const Size& size);
+
 	OwningTileProps() noexcept = default;
 	OwningTileProps(OwningTileProps&& other) noexcept;
 	OwningTileProps(const OwningTileProps& other) noexcept;
@@ -123,6 +126,7 @@ private:
 	std::vector<uint32_t> ownedProps;
 
 	explicit OwningTileProps(const TileProps& tileProps);
+	explicit OwningTileProps(const Size& size);
 
 	// repoints propPtr at the current storage; must run after anything that reallocates it
 	void RebindPropPtr() noexcept

--- a/gemrb/tests/core/SearchMapBuilder.h
+++ b/gemrb/tests/core/SearchMapBuilder.h
@@ -5,13 +5,9 @@
 #ifndef TESTS_SEARCHMAPBUILDER_H
 #define TESTS_SEARCHMAPBUILDER_H
 
-#include "../../core/Holder.h"
 #include "../../core/Region.h"
-#include "../../core/Sprite2D.h"
 #include "../../core/TileProps.h"
 
-#include <cstdlib>
-#include <cstring>
 #include <gtest/gtest.h>
 #include <initializer_list>
 #include <string>
@@ -51,7 +47,7 @@ namespace test {
 	/**
 	 * A map drawing, one string per row.
 	 */
-	using MapRows = std::initializer_list<const char*>;
+	using MapRows = std::initializer_list<std::string>;
 
 	inline bool IsActorGlyph(const char c)
 	{
@@ -86,8 +82,10 @@ namespace test {
 			default:
 				// actors stand on plain floor; their footprint is painted afterwards
 				if (IsActorGlyph(c)) return PathMapFlags::PASSABLE;
-				// anything else is a typo in the literal, not terrain
-				abort();
+
+				// anything else is a typo in the literal, not terrain - report test failure
+				ADD_FAILURE() << "unknown searchmap glyph '" << c << "'";
+				return PathMapFlags::IMPASSABLE;
 		}
 	}
 
@@ -126,38 +124,43 @@ namespace test {
 	 * pathfinder never reads the material, height or light channels.
 	 *
 	 * One character is one searchmap tile, which is 16x12 navmap pixels.
-	 *
-	 * Owns the pixel buffer behind the TileProps. Sprite2D free()s the buffer it is handed,
-	 * so it has to come from malloc().
 	 */
 	class TestSearchMap {
 	public:
 		TestSearchMap(const MapRows inMapRows)
 		{
-			height = static_cast<int>(inMapRows.size());
-			width = height ? static_cast<int>(strlen(*inMapRows.begin())) : 0;
+			const int rowCount = static_cast<int>(inMapRows.size());
+			const int rowWidth = rowCount ? static_cast<int>(inMapRows.begin()->size()) : 0;
 
-			auto* pixels = static_cast<uint32_t*>(calloc(size_t(width) * height, sizeof(uint32_t)));
+			// verify we have all lines the same length
+			for (const std::string& row : inMapRows) {
+				if (static_cast<int>(row.size()) != rowWidth) {
+					ADD_FAILURE() << "every map row must be " << rowWidth
+						      << " characters wide, got " << row;
+					return;
+				}
+			}
+
+			height = rowCount;
+			width = rowWidth;
+
+			props = OwningTileProps::MakeEmpty(Size(width, height));
 			std::vector<std::pair<SearchmapPoint, char>> actors;
 
 			int y = 0;
 			// parse chars one by one and write it as flags
 			// It builds the terrain first, actors are not marked here yet
-			for (const char* row : inMapRows) {
-				if (static_cast<int>(strlen(row)) != width) abort();
+			for (const std::string& row : inMapRows) {
 				for (int x = 0; x < width; ++x) {
-					const auto flags = uint32_t(ParseSearchMapChar(row[x]));
-					pixels[y * width + x] = flags << TileProps::pixelFormat.Rshift;
+					const SearchmapPoint tile(x, y);
+					props.SetTileProp(tile, TileProps::Property::SEARCH_MAP,
+							  uint8_t(ParseSearchMapChar(row[x])));
 					if (IsActorGlyph(row[x])) {
-						actors.emplace_back(SearchmapPoint(x, y), row[x]);
+						actors.emplace_back(tile, row[x]);
 					}
 				}
 				++y;
 			}
-
-			auto sprite = MakeHolder<Sprite2D>(Region(0, 0, width, height), pixels,
-							   TileProps::pixelFormat, uint16_t(width * 4));
-			props = TileProps(std::move(sprite));
 
 			// only after the terrain is ready, mark the actors
 			for (const auto& actor : actors) {
@@ -208,7 +211,7 @@ namespace test {
 		}
 
 	private:
-		TileProps props;
+		OwningTileProps props;
 		int width = 0;
 		int height = 0;
 	};

--- a/gemrb/tests/core/SearchMapBuilder.h
+++ b/gemrb/tests/core/SearchMapBuilder.h
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the GemRB project <https://gemrb.org>
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef TESTS_SEARCHMAPBUILDER_H
+#define TESTS_SEARCHMAPBUILDER_H
+
+#include "../../core/Holder.h"
+#include "../../core/Region.h"
+#include "../../core/Sprite2D.h"
+#include "../../core/TileProps.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+namespace GemRB {
+namespace test {
+
+	/**
+	 * Define ASCII glyphs for terrain and actors, so that pathfinding tests
+	 * won't need real data, and instead define their cases in-place.
+	 *
+	 * Glyphs accepted by TestSearchMap, and produced back by RenderSearchMapChar().
+	 *
+	 * Terrain, round-trips both ways:
+	 *   '.'        passable floor
+	 *   '#'        wall - impassable and blocks line of sight (SIDEWALL)
+	 *   'X'        impassable, but not a sight blocker (plain IMPASSABLE)
+	 *   'T'        passable travel trigger
+	 *   'D'        passable floor with a closed door on it
+	 *   'O'        as 'D', but the door is opaque too
+	 *
+	 * Actors, input only. The glyph says how big the actor is, because the footprint
+	 * PaintSearchMap() stamps is a circle of radius circleSize-1 around the glyph:
+	 *   '1'..'8'   a party member of that circleSize
+	 *   'a'..'h'   an NPC of circleSize 1..8
+	 * The tile under an actor is passable floor. Footprints are painted in reading order, so a
+	 * later actor overwrites the marks of an earlier one where they overlap, same as in game.
+	 *
+	 * Actor footprints render back as:
+	 *   'P' / 'N'  a PC / NPC mark on floor
+	 *   'p' / 'n'  a PC / NPC mark on a travel tile
+	 *   '!'        an actor mark on terrain that cannot be walked on - should point at bug
+	 *   '?'        a flag combination with no glyph, so an unexpected one
+	 */
+
+	/**
+	 * A map drawing, one string per row.
+	 */
+	using MapRows = std::initializer_list<const char*>;
+
+	inline bool IsActorGlyph(const char c)
+	{
+		return (c >= '1' && c <= '8') || (c >= 'a' && c <= 'h');
+	}
+
+	inline PathMapFlags ActorGlyphFlag(const char c)
+	{
+		return (c >= '1' && c <= '8') ? PathMapFlags::PC : PathMapFlags::NPC;
+	}
+
+	inline uint16_t ActorGlyphCircleSize(const char c)
+	{
+		return (c >= '1' && c <= '8') ? uint16_t(c - '0') : uint16_t(c - 'a' + 1);
+	}
+
+	inline PathMapFlags ParseSearchMapChar(const char c)
+	{
+		switch (c) {
+			case '.':
+				return PathMapFlags::PASSABLE;
+			case '#':
+				return PathMapFlags::SIDEWALL;
+			case 'X':
+				return PathMapFlags::IMPASSABLE;
+			case 'T':
+				return PathMapFlags::PASSABLE | PathMapFlags::TRAVEL;
+			case 'D':
+				return PathMapFlags::PASSABLE | PathMapFlags::DOOR_IMPASSABLE;
+			case 'O':
+				return PathMapFlags::PASSABLE | PathMapFlags::DOOR_IMPASSABLE | PathMapFlags::DOOR_OPAQUE;
+			default:
+				// actors stand on plain floor; their footprint is painted afterwards
+				if (IsActorGlyph(c)) return PathMapFlags::PASSABLE;
+				// anything else is a typo in the literal, not terrain
+				abort();
+		}
+	}
+
+	/** Inverse of ParseSearchMapChar(), so a whole map can be conveniently diffed as text. */
+	inline char RenderSearchMapChar(const PathMapFlags flags)
+	{
+		const PathMapFlags terrain = flags & PathMapFlags::AREAMASK;
+		const PathMapFlags actor = flags & PathMapFlags::ACTOR;
+		const PathMapFlags door = flags & PathMapFlags::DOOR;
+
+		if (actor != PathMapFlags::UNMARKED) {
+			// an actor mark only belongs on walkable terrain; anywhere else it should be a bug
+			if (door != PathMapFlags::UNMARKED || !bool(terrain & PathMapFlags::PASSABLE)) {
+				return '!';
+			}
+			const bool travel = bool(terrain & PathMapFlags::TRAVEL);
+			if (actor == PathMapFlags::PC) return travel ? 'p' : 'P';
+			if (actor == PathMapFlags::NPC) return travel ? 'n' : 'N';
+			return '!'; // both actor bits at once, which nothing ever paints
+		}
+
+		if (bool(door & PathMapFlags::DOOR_IMPASSABLE)) {
+			return bool(door & PathMapFlags::DOOR_OPAQUE) ? 'O' : 'D';
+		}
+
+		if (terrain == PathMapFlags::IMPASSABLE) return 'X';
+		if (terrain == PathMapFlags::PASSABLE) return '.';
+		if (terrain == PathMapFlags::SIDEWALL) return '#';
+		if (terrain == (PathMapFlags::PASSABLE | PathMapFlags::TRAVEL)) return 'T';
+		return '?'; // any unhandled above combination is treated as unknown and should be investigated
+	}
+
+	/**
+	 * Builds TileProps out of an ASCII drawing, so pathfinder tests can state their terrain
+	 * inline instead of shipping a searchmap BMP. Only the searchmap byte is filled in; the
+	 * pathfinder never reads the material, height or light channels.
+	 *
+	 * One character is one searchmap tile, which is 16x12 navmap pixels.
+	 *
+	 * Owns the pixel buffer behind the TileProps. Sprite2D free()s the buffer it is handed,
+	 * so it has to come from malloc().
+	 */
+	class TestSearchMap {
+	public:
+		TestSearchMap(const MapRows inMapRows)
+		{
+			height = static_cast<int>(inMapRows.size());
+			width = height ? static_cast<int>(strlen(*inMapRows.begin())) : 0;
+
+			auto* pixels = static_cast<uint32_t*>(calloc(size_t(width) * height, sizeof(uint32_t)));
+			std::vector<std::pair<SearchmapPoint, char>> actors;
+
+			int y = 0;
+			// parse chars one by one and write it as flags
+			// It builds the terrain first, actors are not marked here yet
+			for (const char* row : inMapRows) {
+				if (static_cast<int>(strlen(row)) != width) abort();
+				for (int x = 0; x < width; ++x) {
+					const auto flags = uint32_t(ParseSearchMapChar(row[x]));
+					pixels[y * width + x] = flags << TileProps::pixelFormat.Rshift;
+					if (IsActorGlyph(row[x])) {
+						actors.emplace_back(SearchmapPoint(x, y), row[x]);
+					}
+				}
+				++y;
+			}
+
+			auto sprite = MakeHolder<Sprite2D>(Region(0, 0, width, height), pixels,
+							   TileProps::pixelFormat, uint16_t(width * 4));
+			props = TileProps(std::move(sprite));
+
+			// only after the terrain is ready, mark the actors
+			for (const auto& actor : actors) {
+				props.PaintSearchMap(actor.first, ActorGlyphCircleSize(actor.second),
+						     ActorGlyphFlag(actor.second));
+			}
+		}
+
+		TileProps& Props() noexcept { return props; }
+		const TileProps& Props() const noexcept { return props; }
+
+		int Width() const noexcept { return width; }
+		int Height() const noexcept { return height; }
+
+		PathMapFlags At(int x, int y) const noexcept
+		{
+			return props.QuerySearchMap(SearchmapPoint(x, y));
+		}
+
+		/** The map as it stands now, one string per row, in the glyphs listed above. */
+		std::vector<std::string> Render() const
+		{
+			std::vector<std::string> out;
+			out.reserve(height);
+			for (int y = 0; y < height; ++y) {
+				std::string row;
+				row.reserve(width);
+				for (int x = 0; x < width; ++x) {
+					row.push_back(RenderSearchMapChar(At(x, y)));
+				}
+				out.push_back(std::move(row));
+			}
+			return out;
+		}
+
+		/**
+		 * Compares the current state against a drawing of the expected one. Meant for
+		 * EXPECT_TRUE(map.Matches({...})) - this allows to:
+		 * a) assert on expected ASCII drawing of the map, instead of series of asserts on coords,
+		 * b) print nice message on failure.
+		 */
+		testing::AssertionResult Matches(MapRows expected) const;
+
+		// centre of a tile in navmap coordinates, which is what the Point-taking overloads want
+		static Point Nav(int x, int y) noexcept
+		{
+			return Point(x * 16 + 8, y * 12 + 6);
+		}
+
+	private:
+		TileProps props;
+		int width = 0;
+		int height = 0;
+	};
+
+	inline testing::AssertionResult TestSearchMap::Matches(const MapRows expected) const
+	{
+		const std::vector<std::string> actual = Render();
+		const std::vector<std::string> want(expected.begin(), expected.end());
+
+		if (want.size() != actual.size()) {
+			return testing::AssertionFailure()
+				<< "expected " << want.size() << " rows, the map has " << actual.size();
+		}
+
+		std::vector<int> badRows;
+		for (size_t y = 0; y < want.size(); ++y) {
+			if (want[y] != actual[y]) badRows.push_back(static_cast<int>(y));
+		}
+		if (badRows.empty()) return testing::AssertionSuccess();
+
+		const size_t column = std::max<size_t>(size_t(width), 8) + 6;
+		std::string msg = "\nsearchmap mismatch on " + std::to_string(badRows.size()) + " row(s)\n";
+		msg += "  expected" + std::string(column - 8, ' ') + "actual\n";
+		for (size_t y = 0; y < want.size(); ++y) {
+			std::string line = "  " + want[y];
+			line.resize(column + 2, ' ');
+			line += actual[y];
+			if (want[y] != actual[y]) line += "   <-- differs";
+			msg += line + "\n";
+		}
+
+		bool sawBug = false;
+		bool sawUnknown = false;
+		for (const std::string& row : actual) {
+			sawBug = sawBug || row.find('!') != std::string::npos;
+			sawUnknown = sawUnknown || row.find('?') != std::string::npos;
+		}
+		if (sawBug) msg += "  '!' = actor mark on terrain that cannot be walked on\n";
+		if (sawUnknown) msg += "  '?' = unexpected flag combination, needs investigation\n";
+
+		return testing::AssertionFailure() << msg;
+	}
+
+}
+}
+
+#endif // TESTS_SEARCHMAPBUILDER_H

--- a/gemrb/tests/core/Test_PathFinder.cpp
+++ b/gemrb/tests/core/Test_PathFinder.cpp
@@ -10,6 +10,7 @@
 
 #include "../../core/PathFinder.h"
 
+#include <gtest/gtest-spi.h>
 #include <gtest/gtest.h>
 
 namespace GemRB {
@@ -45,6 +46,20 @@ TEST(SearchMapBuilderTest, ParsesTerrainCharacters)
 
 	// out of bounds should be impassable, not a crash
 	EXPECT_EQ(map.At(99, 99), PathMapFlags::IMPASSABLE);
+}
+
+// A malformed literal is a mistake in the test, check if it correctly reports failure
+TEST(SearchMapBuilderTest, RejectsMalformedMaps)
+{
+	EXPECT_NONFATAL_FAILURE(test::ParseSearchMapChar('@'), "unknown searchmap glyph '@'");
+
+	const test::MapRows raggedRows {
+		"###",
+		"#.#",
+		"##"
+	};
+	EXPECT_NONFATAL_FAILURE(TestSearchMap { raggedRows },
+				"every map row must be 3 characters wide");
 }
 
 // An actor glyph carries two things: which side it belongs to and how big it is.

--- a/gemrb/tests/core/Test_PathFinder.cpp
+++ b/gemrb/tests/core/Test_PathFinder.cpp
@@ -1,0 +1,332 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the GemRB project <https://gemrb.org>
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Terrain-level pathfinder tests. Everything here runs on a TileProps built from an ASCII
+// literal, so no game data, no Interface and no video driver are involved.
+// See SearchMapBuilder.h for the glyphs.
+
+#include "SearchMapBuilder.h"
+
+#include "../../core/PathFinder.h"
+
+#include <gtest/gtest.h>
+
+namespace GemRB {
+
+using test::TestSearchMap;
+
+// Actor speed 0 keeps GetBlockedInLine() away from gamedata->GetStepTime(), which needs a
+// live Interface. It only sets the step length of the line walk, so a value of 0 (one navmap
+// pixel per step).
+constexpr int noSpeed = 0;
+constexpr int noCircle = 0;
+
+// === TestSearchMap infrastructure tests ===
+// Tests below check the test infrastructure itself - defined ASCII layer against raw flags, so that everything
+// after them can be written and read as maps.
+TEST(SearchMapBuilderTest, ParsesTerrainCharacters)
+{
+	const TestSearchMap map {
+		"#.XT",
+		"#.DO"
+	};
+
+	EXPECT_EQ(map.At(0, 0), PathMapFlags::SIDEWALL);
+	EXPECT_EQ(map.At(1, 0), PathMapFlags::PASSABLE);
+	EXPECT_EQ(map.At(2, 0), PathMapFlags::IMPASSABLE);
+	EXPECT_EQ(map.At(3, 0), PathMapFlags::PASSABLE | PathMapFlags::TRAVEL);
+
+
+	EXPECT_EQ(map.At(0, 1), PathMapFlags::SIDEWALL);
+	EXPECT_EQ(map.At(1, 1), PathMapFlags::PASSABLE);
+	EXPECT_EQ(map.At(2, 1), PathMapFlags::PASSABLE | PathMapFlags::DOOR_IMPASSABLE);
+	EXPECT_EQ(map.At(3, 1), PathMapFlags::PASSABLE | PathMapFlags::DOOR_IMPASSABLE | PathMapFlags::DOOR_OPAQUE);
+
+	// out of bounds should be impassable, not a crash
+	EXPECT_EQ(map.At(99, 99), PathMapFlags::IMPASSABLE);
+}
+
+// An actor glyph carries two things: which side it belongs to and how big it is.
+TEST(SearchMapBuilderTest, ParsesActorCharacters)
+{
+	for (char g = '1'; g <= '8'; ++g) {
+		EXPECT_TRUE(test::IsActorGlyph(g));
+	}
+	for (char g = 'a'; g <= 'h'; ++g) {
+		EXPECT_TRUE(test::IsActorGlyph(g));
+	}
+
+	// terrain never counts as an actor
+	EXPECT_FALSE(test::IsActorGlyph('.'));
+	EXPECT_FALSE(test::IsActorGlyph('#'));
+	EXPECT_FALSE(test::IsActorGlyph('D'));
+
+	// sanity: just outside either range
+	EXPECT_FALSE(test::IsActorGlyph('0'));
+	EXPECT_FALSE(test::IsActorGlyph('9'));
+	EXPECT_FALSE(test::IsActorGlyph('i'));
+	EXPECT_FALSE(test::IsActorGlyph('A'));
+
+	// digits are party members, letters are NPCs
+	EXPECT_EQ(test::ActorGlyphFlag('1'), PathMapFlags::PC);
+	EXPECT_EQ(test::ActorGlyphFlag('8'), PathMapFlags::PC);
+	EXPECT_EQ(test::ActorGlyphFlag('a'), PathMapFlags::NPC);
+	EXPECT_EQ(test::ActorGlyphFlag('h'), PathMapFlags::NPC);
+
+	// both alphabets run over the same circleSize range of 1 to 8
+	uint16_t circleSize;
+	char glyph;
+	for (circleSize = 1, glyph = '1'; glyph <= '8'; ++glyph, ++circleSize) {
+		EXPECT_EQ(test::ActorGlyphCircleSize(glyph), circleSize);
+	}
+	for (circleSize = 1, glyph = 'a'; glyph <= 'h'; ++glyph, ++circleSize) {
+		EXPECT_EQ(test::ActorGlyphCircleSize(glyph), circleSize);
+	}
+
+	// the terrain an actor stands on is plain floor; the footprint is painted afterwards
+	for (char g = '1'; g <= '8'; ++g) {
+		EXPECT_EQ(test::ParseSearchMapChar(g), PathMapFlags::PASSABLE);
+	}
+	for (char g = 'a'; g <= 'h'; ++g) {
+		EXPECT_EQ(test::ParseSearchMapChar(g), PathMapFlags::PASSABLE);
+	}
+}
+
+// The glyphs have to reach the searchmap as the right actor bits over the right area.
+TEST(SearchMapBuilderTest, PaintsActorFootprintsFromGlyphs)
+{
+	const TestSearchMap map {
+		"........",
+		"..1..a..",
+		"........"
+	};
+
+	// circleSize 1 is a radius 0 circle, so each actor marks its own tile and nothing else
+	EXPECT_EQ(map.At(2, 1), PathMapFlags::PASSABLE | PathMapFlags::PC);
+	EXPECT_EQ(map.At(5, 1), PathMapFlags::PASSABLE | PathMapFlags::NPC);
+
+	EXPECT_EQ(map.At(1, 1), PathMapFlags::PASSABLE);
+	EXPECT_EQ(map.At(3, 1), PathMapFlags::PASSABLE);
+	EXPECT_EQ(map.At(2, 0), PathMapFlags::PASSABLE);
+	EXPECT_EQ(map.At(2, 2), PathMapFlags::PASSABLE);
+	EXPECT_EQ(map.At(4, 1), PathMapFlags::PASSABLE);
+	EXPECT_EQ(map.At(6, 1), PathMapFlags::PASSABLE);
+
+	// a letter one step up the alphabet is one circleSize bigger, same as the digits
+	const TestSearchMap bigger {
+		".......",
+		".......",
+		"...b...",
+		".......",
+		"......."
+	};
+
+	// circleSize 2 fills the 3x3 block around the glyph
+	for (int y = 1; y <= 3; ++y) {
+		for (int x = 2; x <= 4; ++x) {
+			EXPECT_EQ(bigger.At(x, y), PathMapFlags::PASSABLE | PathMapFlags::NPC)
+				<< "at (" << x << "," << y << ')';
+		}
+	}
+	EXPECT_EQ(bigger.At(1, 2), PathMapFlags::PASSABLE);
+	EXPECT_EQ(bigger.At(5, 2), PathMapFlags::PASSABLE);
+	EXPECT_EQ(bigger.At(3, 0), PathMapFlags::PASSABLE);
+	EXPECT_EQ(bigger.At(3, 4), PathMapFlags::PASSABLE);
+}
+
+TEST(SearchMapBuilderTest, RendersFlagsBackToGlyphs)
+{
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE), '.');
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::SIDEWALL), '#');
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::IMPASSABLE), 'X');
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE | PathMapFlags::TRAVEL), 'T');
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE | PathMapFlags::PC), 'P');
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE | PathMapFlags::NPC), 'N');
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE | PathMapFlags::TRAVEL | PathMapFlags::PC), 'p');
+
+	// an actor mark somewhere it can never legally be
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::SIDEWALL | PathMapFlags::PC), '!');
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PC), '!');
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE | PathMapFlags::DOOR_IMPASSABLE | PathMapFlags::NPC), '!');
+}
+
+TEST(SearchMapBuilderTest, TerrainRoundTrips)
+{
+	const TestSearchMap map {
+		"#######",
+		"#..X..#",
+		"#.TTT.#",
+		"#..D..#",
+		"#######"
+	};
+	const test::MapRows expected {
+		"#######",
+		"#..X..#",
+		"#.TTT.#",
+		"#..D..#",
+		"#######"
+	};
+	EXPECT_TRUE(map.Matches(expected));
+}
+
+
+// === Actual useful pathfinding-related tests ===
+
+// IsLineWalkable() decides on flags OR-accumulated over a whole line, so a single ACTOR tile
+// sets the bit for the entire line. Ignoring actors must not therefore ignore the walls.
+TEST(PathFinderTest, IsLineWalkableRespectsGeometry)
+{
+	constexpr bool ActorsAreBlocking = true;
+	constexpr bool ActorsAreNOTBlocking = false;
+	// plain floor
+	EXPECT_TRUE(PathFinder::IsLineWalkable(PathMapFlags::PASSABLE, ActorsAreBlocking));
+	EXPECT_TRUE(PathFinder::IsLineWalkable(PathMapFlags::PASSABLE, ActorsAreNOTBlocking));
+
+	// nothing walkable on the line at all
+	EXPECT_FALSE(PathFinder::IsLineWalkable(PathMapFlags::IMPASSABLE, ActorsAreBlocking));
+	EXPECT_FALSE(PathFinder::IsLineWalkable(PathMapFlags::IMPASSABLE, ActorsAreNOTBlocking));
+
+	// an actor blocks only while actors are blocking
+	EXPECT_FALSE(PathFinder::IsLineWalkable(PathMapFlags::ACTOR, ActorsAreBlocking));
+	EXPECT_TRUE(PathFinder::IsLineWalkable(PathMapFlags::ACTOR, ActorsAreNOTBlocking));
+	EXPECT_TRUE(PathFinder::IsLineWalkable(PathMapFlags::PC, ActorsAreNOTBlocking));
+	EXPECT_TRUE(PathFinder::IsLineWalkable(PathMapFlags::NPC, ActorsAreNOTBlocking));
+
+	// walls block regardless
+	EXPECT_FALSE(PathFinder::IsLineWalkable(PathMapFlags::SIDEWALL, ActorsAreBlocking));
+	EXPECT_FALSE(PathFinder::IsLineWalkable(PathMapFlags::SIDEWALL, ActorsAreNOTBlocking));
+	EXPECT_FALSE(PathFinder::IsLineWalkable(PathMapFlags::DOOR_IMPASSABLE, ActorsAreBlocking));
+	EXPECT_FALSE(PathFinder::IsLineWalkable(PathMapFlags::DOOR_IMPASSABLE, ActorsAreNOTBlocking));
+
+	// an actor standing next to a wall must not open a hole in it
+	EXPECT_FALSE(PathFinder::IsLineWalkable(PathMapFlags::SIDEWALL | PathMapFlags::ACTOR, ActorsAreNOTBlocking));
+	EXPECT_FALSE(PathFinder::IsLineWalkable(PathMapFlags::DOOR_IMPASSABLE | PathMapFlags::ACTOR, ActorsAreNOTBlocking));
+	EXPECT_FALSE(PathFinder::IsLineWalkable(PathMapFlags::SIDEWALL | PathMapFlags::PASSABLE, ActorsAreNOTBlocking));
+}
+
+// PaintSearchMap() paints a circle of radius circleSize-1.
+// Only walkable terrain may take the mark.
+TEST(TilePropsTest, PaintSearchMapKeepsActorsOffWalls)
+{
+	const TestSearchMap map {
+		"#######",
+		"#..X..#",
+		"#..3..#",
+		"#..T..#",
+		"#######"
+	};
+
+	// the wall above, the obstacle at (3,1) and the walls below are all inside the radius 2
+	// footprint and all have to come out of it unchanged; the travel tile takes the mark
+	const test::MapRows expected {
+		"#######",
+		"#PPXPP#",
+		"#PPPPP#",
+		"#PPpPP#",
+		"#######"
+	};
+	EXPECT_TRUE(map.Matches(expected));
+}
+
+TEST(TilePropsTest, PaintSearchMapClearsPreviousActorMark)
+{
+	TestSearchMap map {
+		"#####",
+		"#...#",
+		"#...#",
+		"#####"
+	};
+
+	const test::MapRows expectedNpc {
+		"#####",
+		"#NNN#",
+		"#NNN#",
+		"#####"
+	};
+	map.Props().PaintSearchMap(SearchmapPoint(2, 1), 2, PathMapFlags::NPC);
+	EXPECT_TRUE(map.Matches(expectedNpc));
+
+	// repainting replaces the actor bits rather than accumulating them
+	map.Props().PaintSearchMap(SearchmapPoint(2, 1), 2, PathMapFlags::PC);
+	const test::MapRows expectedPc {
+		"#####",
+		"#PPP#",
+		"#PPP#",
+		"#####"
+	};
+	EXPECT_TRUE(map.Matches(expectedPc));
+
+	// test clearing also work as expected
+	map.Props().PaintSearchMap(SearchmapPoint(2, 1), 2, PathMapFlags::UNMARKED);
+	const test::MapRows expectedCleared {
+		"#####",
+		"#...#",
+		"#...#",
+		"#####"
+	};
+	EXPECT_TRUE(map.Matches(expectedCleared));
+}
+
+// Test for specific regression: actors hugging a wall used to make the wall
+// disappear for any query that ignored actors, which is how a pathfinder routed actors
+// straight through it.
+TEST(PathFinderTest, WallStaysSolidWithActorsAlongIt)
+{
+	const TestSearchMap map {
+		"##########",
+		"#...##...#",
+		"#..2##2..#",
+		"#...##...#",
+		"##########"
+	};
+
+	// both actors press right up against the middle wall, and it stays a wall
+	const test::MapRows expected {
+		"##########",
+		"#.PP##PP.#",
+		"#.PP##PP.#",
+		"#.PP##PP.#",
+		"##########"
+	};
+	ASSERT_TRUE(map.Matches(expected));
+
+	const Point west = TestSearchMap::Nav(2, 2);
+	const Point east = TestSearchMap::Nav(7, 2);
+
+	EXPECT_FALSE(PathFinder::IsWalkableTo(map.Props(), west, east, true, noSpeed, noCircle));
+	EXPECT_FALSE(PathFinder::IsWalkableTo(map.Props(), west, east, false, noSpeed, noCircle))
+		<< "ignoring actors must not ignore the wall between them";
+
+	// the wall also still blocks sight
+	EXPECT_FALSE(PathFinder::IsVisibleLOS(map.Props(), SearchmapPoint(2, 2), SearchmapPoint(7, 2), noSpeed, noCircle));
+
+	// ... while the untouched column on the far side of the room is walkable
+	EXPECT_TRUE(PathFinder::IsWalkableTo(map.Props(), TestSearchMap::Nav(1, 1), TestSearchMap::Nav(1, 3), true, noSpeed, noCircle));
+}
+
+// An actor in the way is only an obstacle while actors are blocking; open floor beneath it
+// must stay walkable for the ignore-actors queries the pathfinder makes.
+TEST(PathFinderTest, ActorBlocksOnlyWhenActorsAreBlocking)
+{
+	const TestSearchMap map {
+		"########",
+		"#..a...#",
+		"########"
+	};
+
+	const test::MapRows expected {
+		"########",
+		"#..N...#",
+		"########"
+	};
+	ASSERT_TRUE(map.Matches(expected));
+
+	const Point from = TestSearchMap::Nav(1, 1);
+	const Point to = TestSearchMap::Nav(6, 1);
+
+	EXPECT_FALSE(PathFinder::IsWalkableTo(map.Props(), from, to, true, noSpeed, noCircle));
+	EXPECT_TRUE(PathFinder::IsWalkableTo(map.Props(), from, to, false, noSpeed, noCircle));
+}
+
+}


### PR DESCRIPTION
Implement basic infrastructure for pathfinding-related tests, so that they won't need any prepared game-ready data, the test cases could be defined in-place and stay readable.

Add basic tests covering the infra, the walkable and LOS, and also the actors' painting.