### PR TITLE
Refactor: extract `IsOverCircle` and `LineStepper`

### DIFF
--- a/gemrb/core/PathFinder.cpp
+++ b/gemrb/core/PathFinder.cpp
@@ -585,18 +585,13 @@ PathMapFlags PathFinder::GetBlockedInLine(const TileProps& tileProps, const Navm
 PathMapFlags PathFinder::GetBlockedInLine(const TileProps& tileProps, const NavmapPoint& s, const NavmapPoint& d, bool stopOnImpassable, int actorSpeed, int actorCircleSize)
 {
 	PathMapFlags ret = PathMapFlags::IMPASSABLE;
-	NavmapPoint p = s;
 	SearchmapPoint sms { s };
 	float_t factor = actorSpeed ? float_t(gamedata->GetStepTime()) / float_t(actorSpeed) : 1;
 
 	const auto getBlockedStatusFn = (stopOnImpassable && actorCircleSize) ? &PathFinder::GetChildBlockedStatusForBigSize : &PathFinder::GetChildBlockedStatusForSmallSize;
-	while (p != d) {
-		float_t dx = d.x - p.x;
-		float_t dy = d.y - p.y;
-		NormalizeDeltas(dx, dy, factor);
-		p.x += dx;
-		p.y += dy;
-		SearchmapPoint smp { p };
+	LineStepper<NavmapPoint> walk { s, d, factor };
+	while (walk.Step()) {
+		SearchmapPoint smp { walk.Current() };
 		if (sms == smp) continue;
 
 		// see note in GetBlockedInLineTile
@@ -626,16 +621,12 @@ PathMapFlags PathFinder::GetBlockedInLineTile(const TileProps& tileProps, const 
 PathMapFlags PathFinder::GetBlockedInLineTile(const TileProps& tileProps, const SearchmapPoint& s, const SearchmapPoint& d, bool stopOnImpassable, int actorSpeed, int actorCircleSize)
 {
 	PathMapFlags ret = PathMapFlags::IMPASSABLE;
-	SearchmapPoint p = s;
 	float_t factor = actorSpeed ? float_t(gamedata->GetStepTime()) / float_t(actorSpeed) / 16 : 1;
 
 	const auto getBlockedStatusFn = (stopOnImpassable && actorCircleSize) ? &PathFinder::GetChildBlockedStatusForBigSize : &PathFinder::GetChildBlockedStatusForSmallSize;
-	while (p != d) {
-		float_t dx = d.x - p.x;
-		float_t dy = d.y - p.y;
-		NormalizeDeltas(dx, dy, factor);
-		p.x += dx;
-		p.y += dy;
+	LineStepper<SearchmapPoint> walk { s, d, factor };
+	while (walk.Step()) {
+		const SearchmapPoint& p = walk.Current();
 		if (s == p) continue;
 
 		// do a wider check for bigger actors (for the common case it's the same)

--- a/gemrb/core/PathFinder.h
+++ b/gemrb/core/PathFinder.h
@@ -201,6 +201,41 @@ public:
 
 	static void NormalizeDeltas(float_t& dx, float_t& dy, float_t factor = 1);
 
+	/**
+	 * Walks a point towards a target one engine step at a time.
+	 *
+	 * The delta is renormalized on every step.
+	 * Movable::DoStep() runs one such step per frame.
+	 *
+	 * The point type picks the space: NavmapPoint steps in pixels, SearchmapPoint in tiles.
+	 */
+	template<typename PointType>
+	class LineStepper {
+	public:
+		LineStepper(const PointType& from, const PointType& to, float_t stepFactor = 1)
+			: p(from), d(to), factor(stepFactor) {}
+
+		/** Takes one step; false once the target is reached, leaving Current() on it. */
+		bool Step()
+		{
+			if (p == d) return false;
+
+			float_t dx = d.x - p.x;
+			float_t dy = d.y - p.y;
+			NormalizeDeltas(dx, dy, factor);
+			p.x += dx;
+			p.y += dy;
+			return true;
+		}
+
+		const PointType& Current() const { return p; }
+
+	private:
+		PointType p;
+		PointType d;
+		float_t factor;
+	};
+
 	/** Calculate a destination point for running away from a threat.
 	 * Returns false and leaves outPoint untouched if the actor is too slow or the deltas are
 	 * too small; on success outPoint holds the destination. */

--- a/gemrb/core/Scriptable/Selectable.cpp
+++ b/gemrb/core/Scriptable/Selectable.cpp
@@ -67,7 +67,11 @@ bool Selectable::IsOver(const Point& P) const
 
 bool Selectable::IsOver(const Point& P, const Point& CenterPos) const
 {
-	int csize = circleSize;
+	return IsOverCircle(P, CenterPos, circleSize);
+}
+
+bool Selectable::IsOverCircle(const Point& P, const Point& CenterPos, int csize)
+{
 	if (csize < 2) {
 		Point d = P - CenterPos;
 		if (d.x < -16 || d.x > 16) return false;

--- a/gemrb/core/Scriptable/Selectable.h
+++ b/gemrb/core/Scriptable/Selectable.h
@@ -30,6 +30,7 @@ public:
 	void DrawCircle(const Point& p) const;
 	bool IsOver(const Point& Pos) const;
 	bool IsOver(const Point& Pos, const Point& CenterPos) const;
+	static bool IsOverCircle(const Point& Pos, const Point& CenterPos, int circleSize);
 	void SetOver(bool over);
 	bool IsSelected() const;
 	void Select(int Value);


### PR DESCRIPTION
Prep work for more pathfinder tests. Introduced in a separate PR, as it touches a logic in the engine.

Extract `IsOverCircle` static method, so that it can be used without valid `Selectable` instance.

Extract `LineStepper` - code for stepping in a line between 2 points, which was duplicated in 2 places already. Adding this logic to tests would duplicate it 3rd time.