### PR TITLE
Implement more pathfinding tests

### DIFF
--- a/gemrb/core/TraversabilityCache.cpp
+++ b/gemrb/core/TraversabilityCache.cpp
@@ -13,6 +13,13 @@ namespace GemRB {
 
 std::vector<std::vector<bool>> TraversabilityCache::BlockingShapeCache;
 
+// C++14 needs a definition for a static constexpr member that gets odr-used, which is
+// what happens as soon as one is bound to a reference outside this file;
+// could be removed when moving to C++17 with inlined static constexpr members
+constexpr TraversabilityCache::TraversabilityCellState TraversabilityCache::TraversabilityCellValueEmpty;
+constexpr TraversabilityCache::TraversabilityCellState TraversabilityCache::TraversabilityCellValueActor;
+constexpr TraversabilityCache::TraversabilityCellState TraversabilityCache::TraversabilityCellValueActorNonTraversable;
+
 size_t TraversabilityCache::CachedActorsState::AddCachedActorState(Actor* inActor)
 {
 	if (!inActor) {

--- a/gemrb/core/TraversabilityCache.h
+++ b/gemrb/core/TraversabilityCache.h
@@ -6,6 +6,8 @@
 #define TRAVERSABILITY_CACHE_H
 
 
+#include "exports.h"
+
 #include "FixedSizePool.h"
 #include "PagedSparseArray.h"
 #include "Region.h"
@@ -27,7 +29,7 @@ class Actor;
 /**
  * This class manages the cached data of actors on a navmap, to be used for speed up the FindPath implementation.
  */
-class TraversabilityCache {
+class GEM_EXPORT TraversabilityCache {
 public:
 	// There can be more than one actor occupying a navmap cell, the cache must be able
 	// to represent more than one traversability value per cell at a time.

--- a/gemrb/tests/core/SearchMapBuilder.h
+++ b/gemrb/tests/core/SearchMapBuilder.h
@@ -5,8 +5,11 @@
 #ifndef TESTS_SEARCHMAPBUILDER_H
 #define TESTS_SEARCHMAPBUILDER_H
 
+#include "../../core/PathFinder.h"
 #include "../../core/Region.h"
+#include "../../core/Scriptable/Selectable.h"
 #include "../../core/TileProps.h"
+#include "../../core/TraversabilityCache.h"
 
 #include <gtest/gtest.h>
 #include <initializer_list>
@@ -19,30 +22,48 @@ namespace test {
 	/**
 	 * Define ASCII glyphs for terrain and actors, so that pathfinding tests
 	 * won't need real data, and instead define their cases in-place.
-	 *
-	 * Glyphs accepted by TestSearchMap, and produced back by RenderSearchMapChar().
-	 *
-	 * Terrain, round-trips both ways:
-	 *   '.'        passable floor
-	 *   '#'        wall - impassable and blocks line of sight (SIDEWALL)
-	 *   'X'        impassable, but not a sight blocker (plain IMPASSABLE)
-	 *   'T'        passable travel trigger
-	 *   'D'        passable floor with a closed door on it
-	 *   'O'        as 'D', but the door is opaque too
-	 *
-	 * Actors, input only. The glyph says how big the actor is, because the footprint
-	 * PaintSearchMap() stamps is a circle of radius circleSize-1 around the glyph:
-	 *   '1'..'8'   a party member of that circleSize
-	 *   'a'..'h'   an NPC of circleSize 1..8
-	 * The tile under an actor is passable floor. Footprints are painted in reading order, so a
-	 * later actor overwrites the marks of an earlier one where they overlap, same as in game.
-	 *
-	 * Actor footprints render back as:
-	 *   'P' / 'N'  a PC / NPC mark on floor
-	 *   'p' / 'n'  a PC / NPC mark on a travel tile
-	 *   '!'        an actor mark on terrain that cannot be walked on - should point at bug
-	 *   '?'        a flag combination with no glyph, so an unexpected one
 	 */
+	namespace Glyph {
+		// Terrain, input and rendered output
+		constexpr char Floor = '.'; // passable floor
+		constexpr char Wall = '#'; // impassable and blocks line of sight (SIDEWALL)
+		constexpr char Blocked = 'X'; // impassable, but not a sight blocker (plain IMPASSABLE)
+		constexpr char Travel = 'T'; // passable travel trigger
+		constexpr char Door = 'D'; // passable floor with a closed door on it
+		constexpr char OpaqueDoor = 'O'; // as Door, but the door is opaque too
+
+		// Actors, input only. The glyph says how big the actor is, because the footprint
+		// PaintSearchMap() stamps is a circle of radius circleSize-1 around the glyph.
+		// The tile under an actor is passable floor. Footprints are painted in reading order, so a
+		// later actor overwrites the marks of an earlier one where they overlap, same as in game.
+		// The same glyphs also populate TestTraversability.
+		constexpr char FirstPC = '1'; // '1'..'8', a party member of that circleSize
+		constexpr char LastPC = '8';
+		constexpr char FirstNPC = 'a'; // 'a'..'h', an NPC of circleSize 1..8
+		constexpr char LastNPC = 'h';
+
+		// Special waypoint, which name a spot so a test need not spell out raw coordinates.
+		// Both sit on passable floor and carry no searchmap state of their own;
+		// at most one of each per map.
+		// Render() draws them back, but only over plain floor: over anything else the
+		// terrain wins, so a real state is never hidden behind a marker.
+		constexpr char Start = 'S'; // where a walk starts, read back with Start()
+		constexpr char End = 'E'; // where it should end, read back with End()
+
+		// Output only, how an actor footprint renders back
+		constexpr char PCMark = 'P'; // a PC mark on floor
+		constexpr char NPCMark = 'N'; // an NPC mark on floor
+		constexpr char PCOnTravel = 'p'; // a PC mark on a travel tile
+		constexpr char NPCOnTravel = 'n'; // an NPC mark on a travel tile
+		constexpr char Bug = '!'; // an actor mark on terrain that cannot be walked on
+		constexpr char Unknown = '?'; // a flag combination with no glyph, so an unexpected one
+
+		// Output only, drawn by MatchesWithPath() over everything else, waypoints included.
+		// The two are split so a drawing shows what the pathfinder actually decided: it returns
+		// only the corners, and everything between them is the line walk filling in.
+		constexpr char PathWaypoint = '@'; // a waypoint the pathfinder returned
+		constexpr char PathStep = '*'; // a tile walked between two waypoints
+	}
 
 	/**
 	 * A map drawing, one string per row.
@@ -51,37 +72,45 @@ namespace test {
 
 	inline bool IsActorGlyph(const char c)
 	{
-		return (c >= '1' && c <= '8') || (c >= 'a' && c <= 'h');
+		return (c >= Glyph::FirstPC && c <= Glyph::LastPC) || (c >= Glyph::FirstNPC && c <= Glyph::LastNPC);
+	}
+
+	/** Waypoints mark spots for the test to read back; they are not terrain of their own. */
+	inline bool IsWaypointGlyph(const char c)
+	{
+		return c == Glyph::Start || c == Glyph::End;
 	}
 
 	inline PathMapFlags ActorGlyphFlag(const char c)
 	{
-		return (c >= '1' && c <= '8') ? PathMapFlags::PC : PathMapFlags::NPC;
+		return (c >= Glyph::FirstPC && c <= Glyph::LastPC) ? PathMapFlags::PC : PathMapFlags::NPC;
 	}
 
 	inline uint16_t ActorGlyphCircleSize(const char c)
 	{
-		return (c >= '1' && c <= '8') ? uint16_t(c - '0') : uint16_t(c - 'a' + 1);
+		return (c >= Glyph::FirstPC && c <= Glyph::LastPC) ? uint16_t(c - Glyph::FirstPC + 1) : uint16_t(c - Glyph::FirstNPC + 1);
 	}
 
 	inline PathMapFlags ParseSearchMapChar(const char c)
 	{
 		switch (c) {
-			case '.':
+			case Glyph::Floor:
 				return PathMapFlags::PASSABLE;
-			case '#':
+			case Glyph::Wall:
 				return PathMapFlags::SIDEWALL;
-			case 'X':
+			case Glyph::Blocked:
 				return PathMapFlags::IMPASSABLE;
-			case 'T':
+			case Glyph::Travel:
 				return PathMapFlags::PASSABLE | PathMapFlags::TRAVEL;
-			case 'D':
+			case Glyph::Door:
 				return PathMapFlags::PASSABLE | PathMapFlags::DOOR_IMPASSABLE;
-			case 'O':
+			case Glyph::OpaqueDoor:
 				return PathMapFlags::PASSABLE | PathMapFlags::DOOR_IMPASSABLE | PathMapFlags::DOOR_OPAQUE;
 			default:
 				// actors stand on plain floor; their footprint is painted afterwards
 				if (IsActorGlyph(c)) return PathMapFlags::PASSABLE;
+				// so do waypoints, which are only markers for the test to read back
+				if (IsWaypointGlyph(c)) return PathMapFlags::PASSABLE;
 
 				// anything else is a typo in the literal, not terrain - report test failure
 				ADD_FAILURE() << "unknown searchmap glyph '" << c << "'";
@@ -99,23 +128,36 @@ namespace test {
 		if (actor != PathMapFlags::UNMARKED) {
 			// an actor mark only belongs on walkable terrain; anywhere else it should be a bug
 			if (door != PathMapFlags::UNMARKED || !bool(terrain & PathMapFlags::PASSABLE)) {
-				return '!';
+				return Glyph::Bug;
 			}
 			const bool travel = bool(terrain & PathMapFlags::TRAVEL);
-			if (actor == PathMapFlags::PC) return travel ? 'p' : 'P';
-			if (actor == PathMapFlags::NPC) return travel ? 'n' : 'N';
-			return '!'; // both actor bits at once, which nothing ever paints
+			if (actor == PathMapFlags::PC) return travel ? Glyph::PCOnTravel : Glyph::PCMark;
+			if (actor == PathMapFlags::NPC) return travel ? Glyph::NPCOnTravel : Glyph::NPCMark;
+			return Glyph::Bug; // both actor bits at once, which nothing ever paints
 		}
 
 		if (bool(door & PathMapFlags::DOOR_IMPASSABLE)) {
-			return bool(door & PathMapFlags::DOOR_OPAQUE) ? 'O' : 'D';
+			return bool(door & PathMapFlags::DOOR_OPAQUE) ? Glyph::OpaqueDoor : Glyph::Door;
 		}
 
-		if (terrain == PathMapFlags::IMPASSABLE) return 'X';
-		if (terrain == PathMapFlags::PASSABLE) return '.';
-		if (terrain == PathMapFlags::SIDEWALL) return '#';
-		if (terrain == (PathMapFlags::PASSABLE | PathMapFlags::TRAVEL)) return 'T';
-		return '?'; // any unhandled above combination is treated as unknown and should be investigated
+		if (terrain == PathMapFlags::IMPASSABLE) return Glyph::Blocked;
+		if (terrain == PathMapFlags::PASSABLE) return Glyph::Floor;
+		if (terrain == PathMapFlags::SIDEWALL) return Glyph::Wall;
+		if (terrain == (PathMapFlags::PASSABLE | PathMapFlags::TRAVEL)) return Glyph::Travel;
+		return Glyph::Unknown; // any unhandled above combination is treated as unknown and should be investigated
+	}
+
+	/**
+	 * A stand-in for an actor, for the cache's identity slot and ActorPathContext. FindPath()
+	 * only ever compares these pointers - never dereferences them - so any distinct address
+	 * will do. Use MakeActorIdentity() to get one.
+	 */
+	using ActorIdentity = const Movable*;
+
+	/** A distinct, never-dereferenced actor identity. Pass the same tag to keep the same one. */
+	inline ActorIdentity MakeActorIdentity(const char& tag)
+	{
+		return reinterpret_cast<ActorIdentity>(&tag);
 	}
 
 	/**
@@ -127,6 +169,12 @@ namespace test {
 	 */
 	class TestSearchMap {
 	public:
+		struct DrawnActor {
+			SearchmapPoint tile;
+			uint16_t circleSize;
+			PathMapFlags flag; // PC or NPC
+		};
+
 		TestSearchMap(const MapRows inMapRows)
 		{
 			const int rowCount = static_cast<int>(inMapRows.size());
@@ -145,7 +193,6 @@ namespace test {
 			width = rowWidth;
 
 			props = OwningTileProps::MakeEmpty(Size(width, height));
-			std::vector<std::pair<SearchmapPoint, char>> actors;
 
 			int y = 0;
 			// parse chars one by one and write it as flags
@@ -156,16 +203,24 @@ namespace test {
 					props.SetTileProp(tile, TileProps::Property::SEARCH_MAP,
 							  uint8_t(ParseSearchMapChar(row[x])));
 					if (IsActorGlyph(row[x])) {
-						actors.emplace_back(tile, row[x]);
+						drawnActors.push_back({ tile, ActorGlyphCircleSize(row[x]),
+									ActorGlyphFlag(row[x]) });
+					} else if (row[x] == Glyph::Start) {
+						if (hasStart) ADD_FAILURE() << "a map can only carry one start point";
+						start = tile;
+						hasStart = true;
+					} else if (row[x] == Glyph::End) {
+						if (hasEnd) ADD_FAILURE() << "a map can only carry one end point";
+						end = tile;
+						hasEnd = true;
 					}
 				}
 				++y;
 			}
 
 			// only after the terrain is ready, mark the actors
-			for (const auto& actor : actors) {
-				props.PaintSearchMap(actor.first, ActorGlyphCircleSize(actor.second),
-						     ActorGlyphFlag(actor.second));
+			for (const DrawnActor& actor : drawnActors) {
+				props.PaintSearchMap(actor.tile, actor.circleSize, actor.flag);
 			}
 		}
 
@@ -180,6 +235,54 @@ namespace test {
 			return props.QuerySearchMap(SearchmapPoint(x, y));
 		}
 
+		/** Every actor glyph the drawing carried, in reading order. */
+		const std::vector<DrawnActor>& Actors() const noexcept { return drawnActors; }
+
+		/** Centre of the nth drawn actor's tile, in navmap coordinates. */
+		Point ActorPosOf(const size_t index) const
+		{
+			if (index >= drawnActors.size()) {
+				ADD_FAILURE() << "this map has no actor number " << index;
+				return {};
+			}
+			const SearchmapPoint& tile = drawnActors[index].tile;
+			return Nav(tile.x, tile.y);
+		}
+
+		/** Identity of the nth drawn actor */
+		ActorIdentity ActorIdentityOf(const size_t index) const
+		{
+			if (index >= drawnActors.size()) {
+				ADD_FAILURE() << "this map has no actor number " << index;
+				return nullptr;
+			}
+			return reinterpret_cast<ActorIdentity>(&drawnActors[index]);
+		}
+
+		/** Circle size of the nth drawn actor */
+		uint16_t ActorCircleSizeOf(const size_t index) const
+		{
+			if (index >= drawnActors.size()) {
+				ADD_FAILURE() << "this map has no actor number " << index;
+				return 1;
+			}
+			return drawnActors[index].circleSize;
+		}
+
+		/** Centre of the start point tile, in navmap coordinates. */
+		Point Start() const
+		{
+			if (!hasStart) ADD_FAILURE() << "this map has no start point defined";
+			return Nav(start.x, start.y);
+		}
+
+		/** Centre of the end point tile, in navmap coordinates. */
+		Point End() const
+		{
+			if (!hasEnd) ADD_FAILURE() << "this map has no end point defined";
+			return Nav(end.x, end.y);
+		}
+
 		/** The map as it stands now, one string per row, in the glyphs listed above. */
 		std::vector<std::string> Render() const
 		{
@@ -189,7 +292,14 @@ namespace test {
 				std::string row;
 				row.reserve(width);
 				for (int x = 0; x < width; ++x) {
-					row.push_back(RenderSearchMapChar(At(x, y)));
+					char glyph = RenderSearchMapChar(At(x, y));
+					// waypoints are drawn back in, but only over plain floor: real
+					// searchmap state must never hide behind a marker
+					if (glyph == Glyph::Floor) {
+						if (hasStart && start == SearchmapPoint(x, y)) glyph = Glyph::Start;
+						if (hasEnd && end == SearchmapPoint(x, y)) glyph = Glyph::End;
+					}
+					row.push_back(glyph);
 				}
 				out.push_back(std::move(row));
 			}
@@ -204,6 +314,15 @@ namespace test {
 		 */
 		testing::AssertionResult Matches(MapRows expected) const;
 
+		/**
+		 * As Matches(), but with the walked route drawn over the terrain: Glyph::PathWaypoint on
+		 * waypoints pathfinder returned, Glyph::PathStep on the tiles the line walk crosses
+		 * to get between them.
+		 * This allows to state the route test expects as a picture instead of a
+		 * list of coordinates, and shows at a glance how much of it the pathfinder chose.
+		 */
+		testing::AssertionResult MatchesWithPath(const Point& from, const Path& path, MapRows expected) const;
+
 		// centre of a tile in navmap coordinates, which is what the Point-taking overloads want
 		static Point Nav(int x, int y) noexcept
 		{
@@ -211,14 +330,198 @@ namespace test {
 		}
 
 	private:
+		testing::AssertionResult CompareRows(const std::vector<std::string>& actual, MapRows expected) const;
+
 		OwningTileProps props;
+		std::vector<DrawnActor> drawnActors;
 		int width = 0;
 		int height = 0;
+		SearchmapPoint start;
+		SearchmapPoint end;
+		bool hasStart = false;
+		bool hasEnd = false;
 	};
+
+	/**
+	 * The traversability cache mockup for test, constructed from a drawn map.
+	 * Needed for FindPath().
+	 *
+	 * Mimics token count mechanic for cells from real TraversabilityCache.
+	 * For simplicity owns the pool its pages come from, so it can be neither copied nor moved.
+	 */
+	class TestTraversability {
+	public:
+		/**
+		 * Populated from the map's own actor glyphs, so a drawing states the actors once and
+		 * both layers agree on them. Bumpability is not something a glyph carries, so it is
+		 * given here for all of them at once; AddActor() still covers anything finer.
+		 */
+		explicit TestTraversability(const TestSearchMap& map, bool actorsAreBumpable = true)
+			: navWidth(map.Width() * 16),
+			  navHeight(map.Height() * 12),
+			  // the trailing spare cell matches TraversabilityCache::ValidateTraversabilityCacheSize(),
+			  // which keeps one as a dumpster for out-of-range writes
+			  data(pool, size_t(navWidth) * navHeight + 1)
+		{
+			for (size_t i = 0; i < map.Actors().size(); ++i) {
+				const auto& drawn = map.Actors()[i];
+				AddActor(map.ActorPosOf(i), drawn.circleSize, actorsAreBumpable, map.ActorIdentityOf(i));
+			}
+		}
+
+		TestTraversability(const TestTraversability&) = delete;
+		TestTraversability& operator=(const TestTraversability&) = delete;
+
+		/**
+		 * Stamps an actor's ground circle into the cache, the same footprint and token value
+		 * TraversabilityCache::Update() would give it.
+		 */
+		void AddActor(const Point& pos, int circleSize, bool bumpable, ActorIdentity who = nullptr)
+		{
+			const int baseSize = Selectable::CircleSize2Radius(circleSize);
+			const Size shape(baseSize * 8, baseSize * 6);
+			const Point origin = pos - shape.Center();
+			const auto token = bumpable ? TraversabilityCache::TraversabilityCellValueActor : TraversabilityCache::TraversabilityCellValueActorNonTraversable;
+
+			for (int y = 0; y < shape.h; ++y) {
+				for (int x = 0; x < shape.w; ++x) {
+					const Point cell(origin.x + x, origin.y + y);
+					if (cell.x < 0 || cell.y < 0 || cell.x >= navWidth || cell.y >= navHeight) continue;
+					if (!Selectable::IsOverCircle(cell, pos, circleSize)) continue;
+
+					const size_t idx = size_t(cell.y) * navWidth + cell.x;
+					TraversabilityCache::TraversabilityCellData cellData = data[idx];
+					cellData.state += token;
+					cellData.occupyingActor = reinterpret_cast<Actor*>(const_cast<Movable*>(who));
+					data[idx] = cellData;
+				}
+			}
+		}
+
+		TraversabilityCache::TraversabilityCellState StateAt(const Point& navPoint) const
+		{
+			return data[size_t(navPoint.y) * navWidth + navPoint.x].state;
+		}
+
+		/** Who the cache has standing on that navmap pixel, which is what FindPath() compares. */
+		ActorIdentity ActorAt(const Point& navPoint) const
+		{
+			return reinterpret_cast<ActorIdentity>(data[size_t(navPoint.y) * navWidth + navPoint.x].occupyingActor);
+		}
+
+		const TraversabilityCache::Data_t& Data() const noexcept { return data; }
+
+	private:
+		int navWidth = 0;
+		int navHeight = 0;
+		FixedSizePool<TraversabilityCache::Data_t::TPage_t> pool;
+		TraversabilityCache::Data_t data;
+	};
+
+	/**
+	 * Runs the real FindPath() over a drawn map.
+	 *
+	 * Speed 0 keeps it clear of gamedata->GetStepTime(), so no Interface is needed.
+	 */
+	inline Path CallFindPath(const TestSearchMap& map, const TestTraversability& traversability,
+				 const Point& from, const Point& to, ActorIdentity self = nullptr,
+				 unsigned int circleSize = 1, int flags = PF_SIGHT)
+	{
+		ActorPathContext actor;
+		actor.circleSize = circleSize;
+		actor.identity = self;
+		return PathFinder::FindPath(traversability.Data(), map.Props(), from, to, actor, 0, flags);
+	}
+
+	/**
+	 * Finds a path from the nth drawn actor to `to`.
+	 */
+	inline Path PathDrawnActor(const TestSearchMap& map, const TestTraversability& traversability,
+				   size_t index, const Point& to, int flags = PF_SIGHT)
+	{
+		return CallFindPath(map, traversability, map.ActorPosOf(index), to,
+				    map.ActorIdentityOf(index), map.ActorCircleSizeOf(index), flags);
+	}
+
+	/**
+	 * Every tile a path passes through, source included, in walking order.
+	 */
+	inline std::vector<SearchmapPoint> PathTiles(const Point& from, const Path& path)
+	{
+		std::vector<SearchmapPoint> tiles;
+		auto appendIfNotPresent = [&tiles](const SearchmapPoint& tile) {
+			if (tiles.empty() || !(tiles.back() == tile)) tiles.push_back(tile);
+		};
+
+		Point p = from;
+		appendIfNotPresent(SearchmapPoint { p });
+		for (size_t i = 0; i < path.Size(); ++i) {
+			PathFinder::LineStepper<NavmapPoint> walk { p, path.GetStep(i).point };
+			while (walk.Step()) {
+				if (walk.Current() == p) {
+					// a step should always moves, bail out if that ever stops holding
+					ADD_FAILURE() << "LineStepper makes no progress for point " << i << "  at ("
+						      << p.x << ',' << p.y << ')';
+					return tiles;
+				}
+				p = walk.Current();
+				appendIfNotPresent(SearchmapPoint { p });
+			}
+		}
+		return tiles;
+	}
+
+	/**
+	 * Checks a path can actually be walked: no leg crosses a wall or a shut door.
+	 */
+	inline testing::AssertionResult PathAvoidsWalls(const TestSearchMap& map, const Point& from, const Path& path)
+	{
+		if (path.Empty()) {
+			return testing::AssertionFailure() << "path is empty";
+		}
+
+		Point previous = from;
+		for (size_t i = 0; i < path.Size(); ++i) {
+			const Point step = path.GetStep(i).point;
+			const PathMapFlags leg = PathFinder::GetBlockedInLine(map.Props(), previous, step, false, 0, 0);
+			if (bool(leg & (PathMapFlags::SIDEWALL | PathMapFlags::DOOR_IMPASSABLE))) {
+				return testing::AssertionFailure()
+					<< "leg " << i << ", (" << previous.x << ',' << previous.y << ") -> ("
+					<< step.x << ',' << step.y << "), crosses a wall";
+			}
+			previous = step;
+		}
+		return testing::AssertionSuccess();
+	}
+
+	inline testing::AssertionResult TestSearchMap::MatchesWithPath(const Point& from, const Path& path,
+								       const MapRows expected) const
+	{
+		std::vector<std::string> drawn = Render();
+		auto plot = [&drawn, this](const SearchmapPoint& tile, char glyph) {
+			if (tile.x >= 0 && tile.x < width && tile.y >= 0 && tile.y < height) {
+				drawn[tile.y][tile.x] = glyph;
+			}
+		};
+
+		// the walked tiles first, so that a waypoint is never buried under one of them
+		for (const SearchmapPoint& tile : PathTiles(from, path)) {
+			plot(tile, Glyph::PathStep);
+		}
+		for (size_t i = 0; i < path.Size(); ++i) {
+			plot(SearchmapPoint { path.GetStep(i).point }, Glyph::PathWaypoint);
+		}
+		return CompareRows(drawn, expected);
+	}
 
 	inline testing::AssertionResult TestSearchMap::Matches(const MapRows expected) const
 	{
-		const std::vector<std::string> actual = Render();
+		return CompareRows(Render(), expected);
+	}
+
+	inline testing::AssertionResult TestSearchMap::CompareRows(const std::vector<std::string>& actual,
+								   const MapRows expected) const
+	{
 		const std::vector<std::string> want(expected.begin(), expected.end());
 
 		if (want.size() != actual.size()) {
@@ -246,15 +549,14 @@ namespace test {
 		bool sawBug = false;
 		bool sawUnknown = false;
 		for (const std::string& row : actual) {
-			sawBug = sawBug || row.find('!') != std::string::npos;
-			sawUnknown = sawUnknown || row.find('?') != std::string::npos;
+			sawBug = sawBug || row.find(Glyph::Bug) != std::string::npos;
+			sawUnknown = sawUnknown || row.find(Glyph::Unknown) != std::string::npos;
 		}
 		if (sawBug) msg += "  '!' = actor mark on terrain that cannot be walked on\n";
 		if (sawUnknown) msg += "  '?' = unexpected flag combination, needs investigation\n";
 
 		return testing::AssertionFailure() << msg;
 	}
-
 }
 }
 

--- a/gemrb/tests/core/SearchMapBuilder.h
+++ b/gemrb/tests/core/SearchMapBuilder.h
@@ -157,7 +157,9 @@ namespace test {
 	/** A distinct, never-dereferenced actor identity. Pass the same tag to keep the same one. */
 	inline ActorIdentity MakeActorIdentity(const char& tag)
 	{
-		return reinterpret_cast<ActorIdentity>(&tag);
+		// deliberate unsafe cast - in tests we don't use real actor instances,
+		// we just need a number for the sake of identity comparison
+		return reinterpret_cast<ActorIdentity>(&tag); // NOSONAR
 	}
 
 	/**
@@ -256,7 +258,9 @@ namespace test {
 				ADD_FAILURE() << "this map has no actor number " << index;
 				return nullptr;
 			}
-			return reinterpret_cast<ActorIdentity>(&drawnActors[index]);
+			// deliberate unsafe cast - in tests we don't use real actor instances,
+			// we just need a number for the sake of identity comparison
+			return reinterpret_cast<ActorIdentity>(&drawnActors[index]); // NOSONAR
 		}
 
 		/** Circle size of the nth drawn actor */
@@ -392,7 +396,9 @@ namespace test {
 					const size_t idx = size_t(cell.y) * navWidth + cell.x;
 					TraversabilityCache::TraversabilityCellData cellData = data[idx];
 					cellData.state += token;
-					cellData.occupyingActor = reinterpret_cast<Actor*>(const_cast<Movable*>(who));
+					// deliberate unsafe cast - in tests we don't use real actor instances,
+					// we just need a number for the sake of identity comparison
+					cellData.occupyingActor = reinterpret_cast<Actor*>(const_cast<Movable*>(who)); // NOSONAR
 					data[idx] = cellData;
 				}
 			}
@@ -406,7 +412,10 @@ namespace test {
 		/** Who the cache has standing on that navmap pixel, which is what FindPath() compares. */
 		ActorIdentity ActorAt(const Point& navPoint) const
 		{
-			return reinterpret_cast<ActorIdentity>(data[size_t(navPoint.y) * navWidth + navPoint.x].occupyingActor);
+			const auto actorPtr = data[size_t(navPoint.y) * navWidth + navPoint.x].occupyingActor;
+			// deliberate unsafe cast - in tests we don't use real actor instances,
+			// we just need a number for the sake of identity comparison
+			return reinterpret_cast<ActorIdentity>(actorPtr); // NOSONAR
 		}
 
 		const TraversabilityCache::Data_t& Data() const noexcept { return data; }

--- a/gemrb/tests/core/SearchMapBuilder.h
+++ b/gemrb/tests/core/SearchMapBuilder.h
@@ -468,7 +468,7 @@ namespace test {
 			PathFinder::LineStepper<NavmapPoint> walk { p, path.GetStep(i).point };
 			while (walk.Step()) {
 				if (walk.Current() == p) {
-					// a step should always moves, bail out if that ever stops holding
+					// a step should always move, bail out if that ever stops holding
 					ADD_FAILURE() << "LineStepper makes no progress for point " << i << "  at ("
 						      << p.x << ',' << p.y << ')';
 					return tiles;

--- a/gemrb/tests/core/Test_PathFinder.cpp
+++ b/gemrb/tests/core/Test_PathFinder.cpp
@@ -643,6 +643,33 @@ TEST(TraversabilityTest, BumpableActorBlocksOnlyWhenActorsAreBlocking)
 	EXPECT_TRUE(yielding.Empty()) << "a blocking actor plugs the only corridor, so there is no route";
 }
 
+TEST(TraversabilityTest, BumpableMultipleActorsBlocksOnlyWhenActorsAreBlocking)
+{
+	// a one tile corridor with a blocker standing in it, so it cannot be walked around
+	const TestSearchMap map {
+		"#########",
+		"#S.a1a.E#",
+		"#########"
+	};
+
+	constexpr char selfTag = 0;
+	const test::ActorIdentity self = test::MakeActorIdentity(selfTag);
+
+	const Point from = map.Start();
+	const Point to = map.End();
+
+	const test::TestTraversability traversability { map, true };
+
+	// intending to bump: all the blockers are transparent, so the route runs straight through them
+	const Path bumping = test::CallFindPath(map, traversability, from, to, self, 1, PF_SIGHT);
+	EXPECT_FALSE(bumping.Empty()) << "a bumpable actors must not stop a route that would bump it";
+
+	// treating actors as solid: there is no way past in a one tile corridor
+	const Path yielding = test::CallFindPath(map, traversability, from, to, self, 1,
+						 PF_SIGHT | PF_ACTORS_ARE_BLOCKING);
+	EXPECT_TRUE(yielding.Empty()) << "a blocking actors plugs the only corridor, so there is no route";
+}
+
 TEST(TraversabilityTest, UnbumpableActorAlwaysBlocks)
 {
 	const TestSearchMap map {

--- a/gemrb/tests/core/Test_PathFinder.cpp
+++ b/gemrb/tests/core/Test_PathFinder.cpp
@@ -186,6 +186,73 @@ TEST(SearchMapBuilderTest, RejectsDuplicateOrMissingWaypoints)
 	EXPECT_NONFATAL_FAILURE(noWaypoints.End(), "no end point defined");
 }
 
+// test map.Actor* accessors
+TEST(SearchMapBuilderTest, ReadsBackTheDrawnActors)
+{
+	const TestSearchMap map {
+		".................",
+		"..1......c.......",
+		".................",
+		".................",
+		".......4.........",
+		".................",
+		"................."
+	};
+
+	// reading order is row by row, left to right, whatever the glyph or its size
+	ASSERT_EQ(map.Actors().size(), 3);
+	EXPECT_EQ(map.Actors()[0].tile, SearchmapPoint(2, 1));
+	EXPECT_EQ(map.Actors()[1].tile, SearchmapPoint(9, 1));
+	EXPECT_EQ(map.Actors()[2].tile, SearchmapPoint(7, 4));
+
+	// ActorPosOf() is that tile's centre in navmap coordinates
+	EXPECT_EQ(map.ActorPosOf(0), TestSearchMap::Nav(2, 1));
+	EXPECT_EQ(map.ActorPosOf(1), TestSearchMap::Nav(9, 1));
+	EXPECT_EQ(map.ActorPosOf(2), TestSearchMap::Nav(7, 4));
+
+	// ActorCircleSizeOf() is what the glyph spelled, across both alphabets
+	EXPECT_EQ(map.ActorCircleSizeOf(0), 1);
+	EXPECT_EQ(map.ActorCircleSizeOf(1), 3);
+	EXPECT_EQ(map.ActorCircleSizeOf(2), 4);
+
+	// digits are party members, letters are NPCs
+	EXPECT_EQ(map.Actors()[0].flag, PathMapFlags::PC);
+	EXPECT_EQ(map.Actors()[1].flag, PathMapFlags::NPC);
+	EXPECT_EQ(map.Actors()[2].flag, PathMapFlags::PC);
+
+	// ActorIdentityOf() gives each actor one of its own, and the same one every time
+	EXPECT_NE(map.ActorIdentityOf(0), nullptr);
+	EXPECT_NE(map.ActorIdentityOf(1), nullptr);
+	EXPECT_NE(map.ActorIdentityOf(2), nullptr);
+	EXPECT_NE(map.ActorIdentityOf(0), map.ActorIdentityOf(1));
+	EXPECT_NE(map.ActorIdentityOf(1), map.ActorIdentityOf(2));
+	EXPECT_NE(map.ActorIdentityOf(0), map.ActorIdentityOf(2));
+	EXPECT_EQ(map.ActorIdentityOf(0), map.ActorIdentityOf(0)) << "an identity has to be stable";
+}
+
+// Asking for an actor a drawing does not have is a mistake in the test
+TEST(SearchMapBuilderTest, RejectsOutOfRangeActorIndex)
+{
+	const TestSearchMap map {
+		"...",
+		".1.",
+		"..."
+	};
+	ASSERT_EQ(map.Actors().size(), size_t(1));
+
+	EXPECT_NONFATAL_FAILURE(map.ActorPosOf(1), "no actor number 1");
+	EXPECT_NONFATAL_FAILURE(map.ActorCircleSizeOf(1), "no actor number 1");
+	EXPECT_NONFATAL_FAILURE(map.ActorIdentityOf(1), "no actor number 1");
+
+	const TestSearchMap noActors {
+		"...",
+		"...",
+		"..."
+	};
+	ASSERT_TRUE(noActors.Actors().empty());
+	EXPECT_NONFATAL_FAILURE(noActors.ActorPosOf(0), "no actor number 0");
+}
+
 // The glyphs have to reach the searchmap as the right actor bits over the right area.
 TEST(SearchMapBuilderTest, PaintsActorFootprintsFromGlyphs)
 {
@@ -695,12 +762,6 @@ TEST(FindPathTest, RoutesAroundABarrier)
 
 	// it has to come round the open bottom row, so it has to get more >1 waypoint
 	EXPECT_GT(path.Size(), 1u);
-
-	// it must never set foot on the barrier
-	for (const SearchmapPoint& tile : test::PathTiles(start, path)) {
-		EXPECT_NE(map.At(tile.x, tile.y), PathMapFlags::SIDEWALL)
-			<< "route enters the wall at (" << tile.x << ',' << tile.y << ')';
-	}
 }
 
 // A destination that cannot be reached at all must not produce a route into it.
@@ -743,9 +804,6 @@ TEST(FindPathTest, RespectsActorSize)
 
 	constexpr size_t smallActor = 0;
 	constexpr size_t bigActor = 1;
-	ASSERT_EQ(map.Actors().size(), 2);
-	ASSERT_EQ(map.ActorCircleSizeOf(smallActor), 1);
-	ASSERT_EQ(map.ActorCircleSizeOf(bigActor), 4);
 
 	// bumpable, so neither walker is stopped by the other's mark; only the terrain is in play
 	const test::TestTraversability traversability { map, true };

--- a/gemrb/tests/core/Test_PathFinder.cpp
+++ b/gemrb/tests/core/Test_PathFinder.cpp
@@ -625,7 +625,7 @@ TEST(TraversabilityTest, BumpableActorBlocksOnlyWhenActorsAreBlocking)
 		"#########"
 	};
 
-	const char selfTag = 0;
+	constexpr char selfTag = 0;
 	const test::ActorIdentity self = test::MakeActorIdentity(selfTag);
 
 	const Point from = map.Start();
@@ -794,7 +794,7 @@ TEST(FindPathTest, RespectsActorSize)
 		"#.........#.........#",
 		"#.........#.........#",
 		"#.........#.........#",
-		"#..1..4........E....#",
+		"#1...3.........E....#",
 		"#.........#.........#",
 		"#.........#.........#",
 		"#.........#.........#",

--- a/gemrb/tests/core/Test_PathFinder.cpp
+++ b/gemrb/tests/core/Test_PathFinder.cpp
@@ -10,12 +10,16 @@
 
 #include "../../core/PathFinder.h"
 
+#include <algorithm>
 #include <gtest/gtest-spi.h>
 #include <gtest/gtest.h>
+#include <map>
+#include <string>
 
 namespace GemRB {
 
 using test::TestSearchMap;
+namespace Glyph = test::Glyph;
 
 // Actor speed 0 keeps GetBlockedInLine() away from gamedata->GetStepTime(), which needs a
 // live Interface. It only sets the step length of the line walk, so a value of 0 (one navmap
@@ -51,7 +55,7 @@ TEST(SearchMapBuilderTest, ParsesTerrainCharacters)
 // A malformed literal is a mistake in the test, check if it correctly reports failure
 TEST(SearchMapBuilderTest, RejectsMalformedMaps)
 {
-	EXPECT_NONFATAL_FAILURE(test::ParseSearchMapChar('@'), "unknown searchmap glyph '@'");
+	EXPECT_NONFATAL_FAILURE(test::ParseSearchMapChar('{'), "unknown searchmap glyph '{'");
 
 	const test::MapRows raggedRows {
 		"###",
@@ -65,47 +69,121 @@ TEST(SearchMapBuilderTest, RejectsMalformedMaps)
 // An actor glyph carries two things: which side it belongs to and how big it is.
 TEST(SearchMapBuilderTest, ParsesActorCharacters)
 {
-	for (char g = '1'; g <= '8'; ++g) {
+	for (char g = Glyph::FirstPC; g <= Glyph::LastPC; ++g) {
 		EXPECT_TRUE(test::IsActorGlyph(g));
 	}
-	for (char g = 'a'; g <= 'h'; ++g) {
+	for (char g = Glyph::FirstNPC; g <= Glyph::LastNPC; ++g) {
 		EXPECT_TRUE(test::IsActorGlyph(g));
 	}
 
 	// terrain never counts as an actor
-	EXPECT_FALSE(test::IsActorGlyph('.'));
-	EXPECT_FALSE(test::IsActorGlyph('#'));
-	EXPECT_FALSE(test::IsActorGlyph('D'));
+	EXPECT_FALSE(test::IsActorGlyph(Glyph::Floor));
+	EXPECT_FALSE(test::IsActorGlyph(Glyph::Wall));
+	EXPECT_FALSE(test::IsActorGlyph(Glyph::Door));
 
 	// sanity: just outside either range
-	EXPECT_FALSE(test::IsActorGlyph('0'));
-	EXPECT_FALSE(test::IsActorGlyph('9'));
-	EXPECT_FALSE(test::IsActorGlyph('i'));
-	EXPECT_FALSE(test::IsActorGlyph('A'));
+	EXPECT_FALSE(test::IsActorGlyph(char(Glyph::FirstPC - 1)));
+	EXPECT_FALSE(test::IsActorGlyph(char(Glyph::LastPC + 1)));
+	EXPECT_FALSE(test::IsActorGlyph(char(Glyph::FirstNPC - 1)));
+	EXPECT_FALSE(test::IsActorGlyph(char(Glyph::LastNPC + 1)));
 
 	// digits are party members, letters are NPCs
-	EXPECT_EQ(test::ActorGlyphFlag('1'), PathMapFlags::PC);
-	EXPECT_EQ(test::ActorGlyphFlag('8'), PathMapFlags::PC);
-	EXPECT_EQ(test::ActorGlyphFlag('a'), PathMapFlags::NPC);
-	EXPECT_EQ(test::ActorGlyphFlag('h'), PathMapFlags::NPC);
-
+	for (char g = Glyph::FirstPC; g <= Glyph::LastPC; ++g) {
+		EXPECT_EQ(test::ActorGlyphFlag(g), PathMapFlags::PC);
+	}
+	for (char g = Glyph::FirstNPC; g <= Glyph::LastNPC; ++g) {
+		EXPECT_EQ(test::ActorGlyphFlag(g), PathMapFlags::NPC);
+	}
 	// both alphabets run over the same circleSize range of 1 to 8
 	uint16_t circleSize;
 	char glyph;
-	for (circleSize = 1, glyph = '1'; glyph <= '8'; ++glyph, ++circleSize) {
+	for (circleSize = 1, glyph = Glyph::FirstPC; glyph <= Glyph::LastPC; ++glyph, ++circleSize) {
 		EXPECT_EQ(test::ActorGlyphCircleSize(glyph), circleSize);
 	}
-	for (circleSize = 1, glyph = 'a'; glyph <= 'h'; ++glyph, ++circleSize) {
+	for (circleSize = 1, glyph = Glyph::FirstNPC; glyph <= Glyph::LastNPC; ++glyph, ++circleSize) {
 		EXPECT_EQ(test::ActorGlyphCircleSize(glyph), circleSize);
 	}
 
 	// the terrain an actor stands on is plain floor; the footprint is painted afterwards
-	for (char g = '1'; g <= '8'; ++g) {
+	for (char g = Glyph::FirstPC; g <= Glyph::LastPC; ++g) {
 		EXPECT_EQ(test::ParseSearchMapChar(g), PathMapFlags::PASSABLE);
 	}
-	for (char g = 'a'; g <= 'h'; ++g) {
+	for (char g = Glyph::FirstNPC; g <= Glyph::LastNPC; ++g) {
 		EXPECT_EQ(test::ParseSearchMapChar(g), PathMapFlags::PASSABLE);
 	}
+}
+
+// test named start and end waypoint glyphs
+TEST(SearchMapBuilderTest, ParsesWaypointGlyphs)
+{
+	const TestSearchMap map {
+		"#####",
+		"#S.E#",
+		"#####"
+	};
+
+	EXPECT_EQ(map.Start(), TestSearchMap::Nav(1, 1));
+	EXPECT_EQ(map.End(), TestSearchMap::Nav(3, 1));
+
+	// they are markers, not terrain: the tiles under them are plain floor
+	EXPECT_EQ(map.At(1, 1), PathMapFlags::PASSABLE);
+	EXPECT_EQ(map.At(3, 1), PathMapFlags::PASSABLE);
+	EXPECT_EQ(test::ParseSearchMapChar(Glyph::Start), PathMapFlags::PASSABLE);
+	EXPECT_EQ(test::ParseSearchMapChar(Glyph::End), PathMapFlags::PASSABLE);
+
+	// and they are drawn back in render
+	const test::MapRows expected {
+		"#####",
+		"#S.E#",
+		"#####"
+	};
+	EXPECT_TRUE(map.Matches(expected));
+}
+
+// A waypoint is an annotation, so it must never hide what the searchmap actually holds
+TEST(SearchMapBuilderTest, RealStateWinsOverWaypoints)
+{
+	// circleSize 2 footprint is a 3x3 block, so it should spill onto both waypoint tiles
+	const TestSearchMap map {
+		"#####",
+		"#S2E#",
+		"#####"
+	};
+	const test::MapRows expected {
+		"#####",
+		"#PPP#",
+		"#####"
+	};
+	EXPECT_TRUE(map.Matches(expected));
+
+	// the coordinates still read back, the drawing just does not show them
+	EXPECT_EQ(map.Start(), TestSearchMap::Nav(1, 1));
+	EXPECT_EQ(map.End(), TestSearchMap::Nav(3, 1));
+}
+
+TEST(SearchMapBuilderTest, RejectsDuplicateOrMissingWaypoints)
+{
+	const test::MapRows twoStarts {
+		"#####",
+		"#S.S#",
+		"#####"
+	};
+	EXPECT_NONFATAL_FAILURE(TestSearchMap { twoStarts }, "only carry one start point");
+
+	const test::MapRows twoEnds {
+		"#####",
+		"#E.E#",
+		"#####"
+	};
+	EXPECT_NONFATAL_FAILURE(TestSearchMap { twoEnds }, "only carry one end point");
+
+	const TestSearchMap noWaypoints {
+		"###",
+		"#.#",
+		"###"
+	};
+	EXPECT_NONFATAL_FAILURE(noWaypoints.Start(), "no start point defined");
+	EXPECT_NONFATAL_FAILURE(noWaypoints.End(), "no end point defined");
 }
 
 // The glyphs have to reach the searchmap as the right actor bits over the right area.
@@ -150,20 +228,47 @@ TEST(SearchMapBuilderTest, PaintsActorFootprintsFromGlyphs)
 	EXPECT_EQ(bigger.At(3, 4), PathMapFlags::PASSABLE);
 }
 
+// Check if we correctly render the path between waypoints
+TEST(SearchMapBuilderTest, DrawsWaypointsApartFromTheStepsBetweenThem)
+{
+	const TestSearchMap map {
+		".......",
+		".......",
+		".......",
+		".......",
+		"......."
+	};
+
+	Path path;
+	path.AppendStep(PathNode { TestSearchMap::Nav(5, 1), orient_t::E });
+	path.AppendStep(PathNode { TestSearchMap::Nav(5, 3), orient_t::S });
+
+	// two corners as PathWaypoint, everything the walk crosses to reach them as PathStep;
+	// the tile it starts on is not a waypoint, so it draws as a step too
+	const test::MapRows expected {
+		".......",
+		".****@.",
+		".....*.",
+		".....@.",
+		"......."
+	};
+	EXPECT_TRUE(map.MatchesWithPath(TestSearchMap::Nav(1, 1), path, expected));
+}
+
 TEST(SearchMapBuilderTest, RendersFlagsBackToGlyphs)
 {
-	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE), '.');
-	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::SIDEWALL), '#');
-	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::IMPASSABLE), 'X');
-	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE | PathMapFlags::TRAVEL), 'T');
-	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE | PathMapFlags::PC), 'P');
-	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE | PathMapFlags::NPC), 'N');
-	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE | PathMapFlags::TRAVEL | PathMapFlags::PC), 'p');
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE), Glyph::Floor);
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::SIDEWALL), Glyph::Wall);
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::IMPASSABLE), Glyph::Blocked);
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE | PathMapFlags::TRAVEL), Glyph::Travel);
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE | PathMapFlags::PC), Glyph::PCMark);
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE | PathMapFlags::NPC), Glyph::NPCMark);
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE | PathMapFlags::TRAVEL | PathMapFlags::PC), Glyph::PCOnTravel);
 
 	// an actor mark somewhere it can never legally be
-	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::SIDEWALL | PathMapFlags::PC), '!');
-	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PC), '!');
-	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE | PathMapFlags::DOOR_IMPASSABLE | PathMapFlags::NPC), '!');
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::SIDEWALL | PathMapFlags::PC), Glyph::Bug);
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PC), Glyph::Bug);
+	EXPECT_EQ(test::RenderSearchMapChar(PathMapFlags::PASSABLE | PathMapFlags::DOOR_IMPASSABLE | PathMapFlags::NPC), Glyph::Bug);
 }
 
 TEST(SearchMapBuilderTest, TerrainRoundTrips)
@@ -185,6 +290,65 @@ TEST(SearchMapBuilderTest, TerrainRoundTrips)
 	EXPECT_TRUE(map.Matches(expected));
 }
 
+// === the traversability cache ===
+// The drawn actors have to reach the cache, not just the searchmap.
+TEST(TraversabilityTest, DrawnActorsPopulateTheCache)
+{
+	const TestSearchMap map {
+		"#######",
+		"#.1.a.#",
+		"#######"
+	};
+
+	ASSERT_EQ(map.Actors().size(), size_t(2));
+	EXPECT_EQ(map.Actors()[0].flag, PathMapFlags::PC);
+	EXPECT_EQ(map.Actors()[1].flag, PathMapFlags::NPC);
+
+	const test::TestTraversability bumpable { map, true };
+	EXPECT_EQ(bumpable.StateAt(map.ActorPosOf(0)), TraversabilityCache::TraversabilityCellValueActor);
+	EXPECT_EQ(bumpable.StateAt(map.ActorPosOf(1)), TraversabilityCache::TraversabilityCellValueActor);
+	EXPECT_EQ(bumpable.StateAt(TestSearchMap::Nav(3, 1)), TraversabilityCache::TraversabilityCellValueEmpty) << "the gap between them is clear";
+
+	// the same drawing, with nothing that can be shoved aside
+	const test::TestTraversability solid { map, false };
+	EXPECT_EQ(solid.StateAt(map.ActorPosOf(0)), TraversabilityCache::TraversabilityCellValueActorNonTraversable);
+	EXPECT_EQ(solid.StateAt(map.ActorPosOf(1)), TraversabilityCache::TraversabilityCellValueActorNonTraversable);
+
+	// each drawn actor gets its own identity, so they can tell each other apart
+	EXPECT_NE(map.ActorIdentityOf(0), map.ActorIdentityOf(1));
+	EXPECT_NE(map.ActorIdentityOf(0), nullptr);
+
+	// the identity belongs to the drawing rather than to a cache, so it is the one that lands
+	// in the cells and every cache built over this map names the same actor
+	EXPECT_EQ(bumpable.ActorAt(map.ActorPosOf(0)), map.ActorIdentityOf(0));
+	EXPECT_EQ(solid.ActorAt(map.ActorPosOf(0)), map.ActorIdentityOf(0));
+	EXPECT_EQ(bumpable.ActorAt(map.ActorPosOf(1)), map.ActorIdentityOf(1));
+}
+
+// The cache, not the searchmap, is what makes an actor stop a route. A bumpable one only
+// blocks while actors are blocking; a non-bumpable one always does.
+TEST(TraversabilityTest, ActorTokensLandOnTheActorsCircle)
+{
+	const TestSearchMap map {
+		"#####",
+		"#...#",
+		"#.1.#",
+		"#####"
+	};
+
+	// the drawn '1' populates the cache too, so it is stated once
+	test::TestTraversability traversability { map };
+	const Point where = map.ActorPosOf(0);
+
+	// the centre carries a bumpable actor's single token ...
+	EXPECT_EQ(traversability.StateAt(where), TraversabilityCache::TraversabilityCellValueActor);
+	// ... and somewhere well outside the circle carries none
+	EXPECT_EQ(traversability.StateAt(TestSearchMap::Nav(1, 1)), TraversabilityCache::TraversabilityCellValueEmpty);
+
+	// a second, non-bumpable actor on the same spot pushes it over the always-blocking mark
+	traversability.AddActor(where, 1, false);
+	EXPECT_GE(traversability.StateAt(where), TraversabilityCache::TraversabilityCellValueActorNonTraversable);
+}
 
 // === Actual useful pathfinding-related tests ===
 
@@ -290,34 +454,74 @@ TEST(PathFinderTest, WallStaysSolidWithActorsAlongIt)
 {
 	const TestSearchMap map {
 		"##########",
-		"#...##...#",
+		"#S..##...#",
 		"#..2##2..#",
-		"#...##...#",
+		"#E..##...#",
 		"##########"
 	};
 
 	// both actors press right up against the middle wall, and it stays a wall
 	const test::MapRows expected {
 		"##########",
+		"#SPP##PP.#",
 		"#.PP##PP.#",
-		"#.PP##PP.#",
-		"#.PP##PP.#",
+		"#EPP##PP.#",
 		"##########"
 	};
 	ASSERT_TRUE(map.Matches(expected));
 
-	const Point west = TestSearchMap::Nav(2, 2);
-	const Point east = TestSearchMap::Nav(7, 2);
+	// straight from one actor to the other, which is right across the wall
+	const Point west = map.ActorPosOf(0);
+	const Point east = map.ActorPosOf(1);
 
 	EXPECT_FALSE(PathFinder::IsWalkableTo(map.Props(), west, east, true, noSpeed, noCircle));
 	EXPECT_FALSE(PathFinder::IsWalkableTo(map.Props(), west, east, false, noSpeed, noCircle))
 		<< "ignoring actors must not ignore the wall between them";
 
 	// the wall also still blocks sight
-	EXPECT_FALSE(PathFinder::IsVisibleLOS(map.Props(), SearchmapPoint(2, 2), SearchmapPoint(7, 2), noSpeed, noCircle));
+	EXPECT_FALSE(PathFinder::IsVisibleLOS(map.Props(), SearchmapPoint(west), SearchmapPoint(east), noSpeed, noCircle));
 
-	// ... while the untouched column on the far side of the room is walkable
-	EXPECT_TRUE(PathFinder::IsWalkableTo(map.Props(), TestSearchMap::Nav(1, 1), TestSearchMap::Nav(1, 3), true, noSpeed, noCircle));
+	// ... while the untouched column on the far side of the room, S to E, is walkable
+	EXPECT_TRUE(PathFinder::IsWalkableTo(map.Props(), map.Start(), map.End(), true, noSpeed, noCircle));
+}
+
+// LineStepper tests
+TEST(PathFinderTest, LineStepperArrivesExactlyAndAlwaysMoves)
+{
+	const NavmapPoint from(56, 42);
+	const NavmapPoint to(248, 66);
+
+	PathFinder::LineStepper<NavmapPoint> walk { from, to };
+	Point previous = from;
+	size_t steps = 0;
+	while (walk.Step()) {
+		EXPECT_NE(walk.Current(), previous) << "a step must always move";
+		previous = walk.Current();
+		ASSERT_LT(++steps, 1000u) << "the walk has to terminate";
+	}
+	EXPECT_EQ(walk.Current(), to) << "it has to land exactly on the target";
+	EXPECT_FALSE(walk.Step()) << "and stay there once it has";
+
+	// the same in tile space, which is what GetBlockedInLineTile() walks
+	PathFinder::LineStepper<SearchmapPoint> tiles { SearchmapPoint(0, 0), SearchmapPoint(6, 0) };
+	while (tiles.Step()) {}
+	EXPECT_EQ(tiles.Current(), SearchmapPoint(6, 0));
+}
+
+TEST(PathFinderTest, LineStepperFactorScalesTheStep)
+{
+	auto stepsWith = [](float_t factor) {
+		PathFinder::LineStepper<NavmapPoint> walk { NavmapPoint(0, 0), NavmapPoint(100, 0), factor };
+		size_t n = 0;
+		while (walk.Step()) ++n;
+		return n;
+	};
+
+	// factor 1 is the shortest step: 2 pixels along the dominant axis, so 50 of them
+	EXPECT_EQ(stepsWith(1), 50u);
+	// a faster actor covers the same line in fewer, longer steps
+	EXPECT_EQ(stepsWith(4), 13u);
+	EXPECT_LT(stepsWith(8), stepsWith(4));
 }
 
 // An actor in the way is only an obstacle while actors are blocking; open floor beneath it
@@ -326,22 +530,321 @@ TEST(PathFinderTest, ActorBlocksOnlyWhenActorsAreBlocking)
 {
 	const TestSearchMap map {
 		"########",
-		"#..a...#",
+		"#S.a..E#",
 		"########"
 	};
 
 	const test::MapRows expected {
 		"########",
-		"#..N...#",
+		"#S.N..E#",
 		"########"
 	};
 	ASSERT_TRUE(map.Matches(expected));
 
-	const Point from = TestSearchMap::Nav(1, 1);
-	const Point to = TestSearchMap::Nav(6, 1);
+	const Point from = map.Start();
+	const Point to = map.End();
 
 	EXPECT_FALSE(PathFinder::IsWalkableTo(map.Props(), from, to, true, noSpeed, noCircle));
 	EXPECT_TRUE(PathFinder::IsWalkableTo(map.Props(), from, to, false, noSpeed, noCircle));
 }
 
+// traversability
+TEST(TraversabilityTest, BumpableActorBlocksOnlyWhenActorsAreBlocking)
+{
+	// a one tile corridor with a blocker standing in it, so it cannot be walked around
+	const TestSearchMap map {
+		"#########",
+		"#S..a..E#",
+		"#########"
+	};
+
+	const char selfTag = 0;
+	const test::ActorIdentity self = test::MakeActorIdentity(selfTag);
+
+	const Point from = map.Start();
+	const Point to = map.End();
+
+	const test::TestTraversability traversability { map, true };
+
+	// intending to bump: the blocker is transparent, so the route runs straight through it
+	const Path bumping = test::CallFindPath(map, traversability, from, to, self, 1, PF_SIGHT);
+	EXPECT_FALSE(bumping.Empty()) << "a bumpable actor must not stop a route that would bump it";
+
+	// treating actors as solid: there is no way past in a one tile corridor
+	const Path yielding = test::CallFindPath(map, traversability, from, to, self, 1,
+						 PF_SIGHT | PF_ACTORS_ARE_BLOCKING);
+	EXPECT_TRUE(yielding.Empty()) << "a blocking actor plugs the only corridor, so there is no route";
+}
+
+TEST(TraversabilityTest, UnbumpableActorAlwaysBlocks)
+{
+	const TestSearchMap map {
+		"#########",
+		"#S..a..E#",
+		"#########"
+	};
+
+	const char selfTag = 0;
+	const test::ActorIdentity self = test::MakeActorIdentity(selfTag);
+
+	// same drawing, but nothing here can be shoved aside
+	const test::TestTraversability traversability { map, false };
+
+	const Point from = map.Start();
+	const Point to = map.End();
+
+	EXPECT_TRUE(test::CallFindPath(map, traversability, from, to, self, 1, PF_SIGHT).Empty());
+	EXPECT_TRUE(test::CallFindPath(map, traversability, from, to, self, 1,
+				       PF_SIGHT | PF_ACTORS_ARE_BLOCKING)
+			    .Empty());
+}
+
+// An actor must not be stopped by the record of itself standing where it starts.
+TEST(TraversabilityTest, ActorIgnoresItsOwnCell)
+{
+	const TestSearchMap map {
+		"#########",
+		"#S..a..E#",
+		"#########"
+	};
+
+	// the drawn actor is the one doing the walking, so it starts inside its own footprint
+	const test::TestTraversability traversability { map, false };
+	const Point from = map.ActorPosOf(0);
+	const Point to = map.End();
+	const Path path = test::PathDrawnActor(map, traversability, 0, to,
+					       PF_SIGHT | PF_ACTORS_ARE_BLOCKING);
+	EXPECT_FALSE(path.Empty()) << "an actor must be able to walk out of its own footprint";
+	EXPECT_TRUE(test::PathAvoidsWalls(map, from, path));
+
+	// the counterpart, which is what proves the cell really is blocking and that the identity
+	// is what let the first route through: anyone else is stopped by the very same footprint
+	const char strangerTag = 0;
+	const Path stranger = test::CallFindPath(map, traversability, map.Start(), to,
+						 test::MakeActorIdentity(strangerTag), 1,
+						 PF_SIGHT | PF_ACTORS_ARE_BLOCKING);
+	EXPECT_TRUE(stranger.Empty()) << "another actor must still be blocked by that footprint";
+}
+
+
+// FindPath tests
+TEST(FindPathTest, WalksAnOpenCorridor)
+{
+	const TestSearchMap map {
+		"##########",
+		"#S......E#",
+		"##########"
+	};
+
+	const test::TestTraversability traversability { map };
+	const Path path = test::CallFindPath(map, traversability, map.Start(), map.End());
+
+	ASSERT_FALSE(path.Empty());
+	EXPECT_TRUE(test::PathAvoidsWalls(map, map.Start(), path));
+
+	// nothing to route around, so the pathfinder returns a single waypoint on E and the whole
+	// corridor between is the line walk getting there
+	const test::MapRows expected {
+		"##########",
+		"#*******@#",
+		"##########"
+	};
+	EXPECT_TRUE(map.MatchesWithPath(map.Start(), path, expected));
+}
+
+TEST(FindPathTest, FindPathOnStillSeesTheDrawnActors)
+{
+	// one tile wide, so the drawn NPC cannot be walked around
+	const TestSearchMap map {
+		"#########",
+		"#S..a..E#",
+		"#########"
+	};
+
+	const test::TestTraversability traversability { map };
+	ASSERT_EQ(traversability.StateAt(map.ActorPosOf(0)), TraversabilityCache::TraversabilityCellValueActor)
+		<< "the glyph has to reach the cache FindPathOn() will build";
+
+	EXPECT_FALSE(test::CallFindPath(map, traversability, map.Start(), map.End()).Empty())
+		<< "a bumpable actor is transparent under the default flags";
+
+	EXPECT_TRUE(test::CallFindPath(map, traversability, map.Start(), map.End(), nullptr, 1, PF_SIGHT | PF_ACTORS_ARE_BLOCKING).Empty())
+		<< "actor blocks the only corridor once actors are treated as blocking";
+}
+
+// a barrier between source and destination has to be walked around, never through
+TEST(FindPathTest, RoutesAroundABarrier)
+{
+	const TestSearchMap map {
+		"###########",
+		"#...2#...2#",
+		"#....#....#",
+		"#....#....#",
+		"#.........#",
+		"###########"
+	};
+
+	const Point start = map.ActorPosOf(0);
+	const Point dest = map.ActorPosOf(1);
+	// the walker is the drawn actor, so it is routed at the size its glyph gave it
+	const test::TestTraversability traversability { map };
+	const Path path = test::CallFindPath(map, traversability, start, dest, nullptr, map.ActorCircleSizeOf(0));
+
+	ASSERT_FALSE(path.Empty());
+	EXPECT_TRUE(test::PathAvoidsWalls(map, start, path));
+
+	// it has to come round the open bottom row, so it has to get more >1 waypoint
+	EXPECT_GT(path.Size(), 1u);
+
+	// it must never set foot on the barrier
+	for (const SearchmapPoint& tile : test::PathTiles(start, path)) {
+		EXPECT_NE(map.At(tile.x, tile.y), PathMapFlags::SIDEWALL)
+			<< "route enters the wall at (" << tile.x << ',' << tile.y << ')';
+	}
+}
+
+// A destination that cannot be reached at all must not produce a route into it.
+TEST(FindPathTest, WillNotEnterASealedRoom)
+{
+	const TestSearchMap map {
+		"###########",
+		"#....#....#",
+		"#.S..#..E.#",
+		"#....#....#",
+		"#....#....#",
+		"###########"
+	};
+
+	const Point from = map.Start();
+	const test::TestTraversability traversability { map };
+	const Path path = test::CallFindPath(map, traversability, from, map.End());
+
+	ASSERT_TRUE(path.Empty());
+}
+
+// A bigger actor cannot use a gap a small one fits through. Both walkers are drawn, so their
+// sizes are read off the map rather than passed in beside it.
+TEST(FindPathTest, RespectsActorSize)
+{
+	// two halls joined by a single one tile slit at (10,5), which is the only way across
+	const TestSearchMap map {
+		"#####################",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#..1..4........E....#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#####################"
+	};
+
+	constexpr size_t smallActor = 0;
+	constexpr size_t bigActor = 1;
+	ASSERT_EQ(map.Actors().size(), 2);
+	ASSERT_EQ(map.ActorCircleSizeOf(smallActor), 1);
+	ASSERT_EQ(map.ActorCircleSizeOf(bigActor), 4);
+
+	// bumpable, so neither walker is stopped by the other's mark; only the terrain is in play
+	const test::TestTraversability traversability { map, true };
+	const Point to = map.End();
+
+	const Path small = test::PathDrawnActor(map, traversability, smallActor, to);
+	ASSERT_FALSE(small.Empty()) << "a one tile wide actor fits through a one tile wide slit";
+	EXPECT_TRUE(test::PathAvoidsWalls(map, map.ActorPosOf(smallActor), small));
+
+	// and it really did go through the slit, since there is nowhere else to cross
+	const std::vector<SearchmapPoint> tiles = test::PathTiles(map.ActorPosOf(smallActor), small);
+	EXPECT_NE(std::find(tiles.begin(), tiles.end(), SearchmapPoint(10, 5)), tiles.end())
+		<< "the route must pass through the slit";
+
+	// the big one needs two clear tiles to either side of itself, which the slit cannot give
+	const Path large = test::PathDrawnActor(map, traversability, bigActor, to);
+	EXPECT_TRUE(large.Empty()) << "a wide actor must not squeeze through a one tile slit";
+
+	// ... and it is the slit that stopped it, not its own size: the same actor walks fine as
+	// long as it stays in the open hall it started in
+	const Path inHall = test::PathDrawnActor(map, traversability, bigActor, map.ActorPosOf(smallActor));
+	EXPECT_FALSE(inHall.Empty()) << "the wide actor must still be able to move within its hall";
+}
+
+// Test diagonal line, expect only one waypoint
+TEST(FindPathTest, PathLongDiagonal)
+{
+	// S to E is a very shallow diagonal: 12 tiles across for 2 tiles down, so the straight
+	// line between them clips the divider well above the slit
+	const TestSearchMap map {
+		"#####################",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#..S......#.........#",
+		"#.........#.........#",
+		"#..............E....#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#####################"
+	};
+	const test::MapRows expected {
+		"#####################",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#..**.....#.........#",
+		"#...**....#.........#",
+		"#....**********@....#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#####################"
+	};
+
+	const Point from = map.Start();
+	const test::TestTraversability traversability { map };
+	const Path path = test::CallFindPath(map, traversability, from, map.End());
+	EXPECT_EQ(path.Size(), 1) << "the leg has to stay long enough for the rounding to show";
+	EXPECT_TRUE(test::PathAvoidsWalls(map, from, path));
+	EXPECT_TRUE(map.MatchesWithPath(map.Start(), path, expected));
+}
+
+
+TEST(FindPathTest, PathUTurn)
+{
+	const TestSearchMap map {
+		"#####################",
+		"#.........#....E....#",
+		"#.........#.........#",
+		"#..S......#.........#",
+		"#.........#.........#",
+		"#...................#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#####################"
+	};
+	const test::MapRows expected {
+		"#####################",
+		"#.........#....@....#",
+		"#.........#...**....#",
+		"#..**.....#..**.....#",
+		"#...**....#.**......#",
+		"#....******@*.......#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#.........#.........#",
+		"#####################"
+	};
+
+	const Point from = map.Start();
+	const test::TestTraversability traversability { map };
+	const Path path = test::CallFindPath(map, traversability, from, map.End());
+	EXPECT_EQ(path.Size(), 2) << "expected 2 waypoints";
+	EXPECT_TRUE(test::PathAvoidsWalls(map, from, path));
+	EXPECT_TRUE(map.MatchesWithPath(map.Start(), path, expected));
+}
 }


### PR DESCRIPTION
Add GEM_EXPORT to TraversabilityCache, to use it in tests.

Add Glyphs as named constants.

Implement traversability cache mock.

Add ability to define actors from the glyps.

Add tests for asserting the infra added above behaves correctly.

Add tests for actual FindPath.