### PR TITLE
Add infrastructure for movement tests

### DIFF
--- a/demo/override/avatars.2da
+++ b/demo/override/avatars.2da
@@ -6,3 +6,10 @@
 0x1000     MWYV       MWYV       MWYV       MWYV       11         3          1          *
 0xc800     CHMB1      CHMB1      CHMB1      CHMB1      0          2          0          *
 0xd000     RABB       RABB       RABB       RABB       0          1          1          *
+# test-only rows for the pathfinder tests. Re-use CHMB1's art, differ on SPACE
+0x9003     CHMB1      CHMB1      CHMB1      CHMB1      0          3          0          *
+0x9004     CHMB1      CHMB1      CHMB1      CHMB1      0          4          0          *
+0x9005     CHMB1      CHMB1      CHMB1      CHMB1      0          5          0          *
+0x9006     CHMB1      CHMB1      CHMB1      CHMB1      0          6          0          *
+0x9007     CHMB1      CHMB1      CHMB1      CHMB1      0          7          0          *
+0x9008     CHMB1      CHMB1      CHMB1      CHMB1      0          8          0          *

--- a/gemrb/CMakeLists.txt
+++ b/gemrb/CMakeLists.txt
@@ -201,6 +201,7 @@ ENDIF(VITA)
 IF (BUILD_TESTING)
   ADD_EXECUTABLE(Test_gemrb_core
     tests/core/Test_Map.cpp
+    tests/core/Test_Movement.cpp
     tests/core/Test_MurmurHash.cpp
     tests/core/Test_Orient.cpp
     tests/core/Test_Palette.cpp

--- a/gemrb/core/PathFinderScheduler.h
+++ b/gemrb/core/PathFinderScheduler.h
@@ -5,6 +5,7 @@
 #ifndef PATHFINDERSCHEDULER_H
 #define PATHFINDERSCHEDULER_H
 
+#include "exports.h"
 #include "globals.h"
 
 #include "PathFinder.h"
@@ -91,7 +92,7 @@ struct FindPathRequestWorkerData {
  *  - DrainCompletedPathsEarly(): why results are collected twice per tick.
  *  - MovementState in Movable.h: how an actor's state tracks a request in flight.
  */
-class PathFinderScheduler {
+class GEM_EXPORT PathFinderScheduler {
 public:
 	/**
 	 *  Initializes and starts the pathfinder scheduler and worker threads.

--- a/gemrb/tests/core/LiveGameFixture.h
+++ b/gemrb/tests/core/LiveGameFixture.h
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the GemRB project <https://gemrb.org>
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// A headless Interface with the demo game loaded, for tests that need live engine state.
+
+#ifndef TESTS_LIVEGAMEFIXTURE_H
+#define TESTS_LIVEGAMEFIXTURE_H
+
+#include "../../core/GameData.h"
+#include "../../core/Interface.h"
+#include "../../core/InterfaceConfig.h"
+#include "../../core/Logging/Logging.h"
+#include "../../core/PathFinderScheduler.h"
+#include "../../core/PluginMgr.h"
+#include "../../core/SaveGameMgr.h"
+
+#include <clocale>
+#include <gtest/gtest.h>
+#include <memory>
+
+namespace GemRB {
+
+class LiveGameTest : public testing::Test {
+public:
+	/**
+	 * The engine, as a function-local static: a static data member would need an out-of-line
+	 * definition, which a header shared by several test files cannot have before C++17.
+	 */
+	static std::unique_ptr<Interface>& Engine()
+	{
+		static std::unique_ptr<Interface> engine;
+		return engine;
+	}
+
+	static void SetUpTestSuite()
+	{
+		setlocale(LC_ALL, "");
+		const char* argv[] = { "tester", "-c", "../../tester.cfg" };
+		auto cfg = LoadFromArgs(3, const_cast<char**>(argv));
+		ToggleLogging(true);
+		SetMainLogLevel(ERROR);
+		Engine() = std::make_unique<Interface>(std::move(cfg));
+
+		auto gamStream = gamedata->GetResourceStream("gem-demo", IE_GAM_CLASS_ID);
+		auto gamMgr = GetImporter<SaveGameMgr>(IE_GAM_CLASS_ID, gamStream);
+		auto gam = gamMgr->LoadGame(std::make_unique<Game>(), GAMVersion::GemRB);
+		core->SetGame(std::move(gam));
+
+		core->StartGameControl();
+
+		// a fresh GameControl comes up with DF_FREEZE_SCRIPTS set, which is the paused state.
+		// Map::UpdateScripts() returns immediately on it, so nothing at all runs until the
+		// game is unpaused. PF_QUIET keeps it away from displaymsg, PF_FORCED from the
+		// cutscene check.
+		core->SetPause(PauseState::Off, PF_QUIET | PF_FORCED);
+
+		// Interface::Init() has already started the PathFinderScheduler.
+		// Restart it explicitly in immediate mode here.
+		// The RequestPath() for most tests should compute synchronously on this
+		// thread, and a frame's movement never depends on when a worker happens to finish.
+		PathFinderScheduler::Stop();
+		PathFinderScheduler::Start(0, "immediate");
+	}
+
+	static void TearDownTestSuite()
+	{
+		core->SetGame(nullptr);
+		VideoDriver.reset();
+		Engine().reset();
+		PluginMgr::Get()->RunCleanup();
+	}
+};
+
+
+}
+
+#endif

--- a/gemrb/tests/core/SearchMapBuilder.h
+++ b/gemrb/tests/core/SearchMapBuilder.h
@@ -163,6 +163,17 @@ namespace test {
 	}
 
 	/**
+	 * Whether a drawing paints its actor glyphs into the searchmap.
+	 *
+	 * Paint is designed for a terrain-only test, where nothing else will ever mark those tiles.
+	 * Skip is intended for a live Map, where we expect the state to be driven by the actors in a game loop.
+	 */
+	enum class ActorPainting {
+		Paint,
+		Skip
+	};
+
+	/**
 	 * Builds TileProps out of an ASCII drawing, so pathfinder tests can state their terrain
 	 * inline instead of shipping a searchmap BMP. Only the searchmap byte is filled in; the
 	 * pathfinder never reads the material, height or light channels.
@@ -177,7 +188,7 @@ namespace test {
 			PathMapFlags flag; // PC or NPC
 		};
 
-		TestSearchMap(const MapRows inMapRows)
+		TestSearchMap(const MapRows inMapRows, const ActorPainting painting = ActorPainting::Paint)
 		{
 			const int rowCount = static_cast<int>(inMapRows.size());
 			const int rowWidth = rowCount ? static_cast<int>(inMapRows.begin()->size()) : 0;
@@ -221,8 +232,10 @@ namespace test {
 			}
 
 			// only after the terrain is ready, mark the actors
-			for (const DrawnActor& actor : drawnActors) {
-				props.PaintSearchMap(actor.tile, actor.circleSize, actor.flag);
+			if (painting == ActorPainting::Paint) {
+				for (const DrawnActor& actor : drawnActors) {
+					props.PaintSearchMap(actor.tile, actor.circleSize, actor.flag);
+				}
 			}
 		}
 

--- a/gemrb/tests/core/TestGameMap.h
+++ b/gemrb/tests/core/TestGameMap.h
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the GemRB project <https://gemrb.org>
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// A real Map built from an ASCII drawing, real Actors spawned from its glyphs, and the frame
+// loop that drives them. Sits on top of LiveGameFixture.h, which supplies the live engine.
+
+#ifndef TESTS_TESTGAMEMAP_H
+#define TESTS_TESTGAMEMAP_H
+
+#include "LiveGameFixture.h"
+#include "SearchMapBuilder.h"
+
+#include "../../core/Map.h"
+#include "../../core/PathFinder.h"
+#include "../../core/Scriptable/Actor.h"
+#include "../../core/TileMap.h"
+#include "../../includes/ie_stats.h"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace GemRB {
+
+using test::TestSearchMap;
+
+namespace TestGameLoop {
+	inline std::vector<Map*>& Maps();
+}
+
+/**
+ * The live counterpart of a TestSearchMap: it builds a real GemRB::Map from ASCII glyph drawing
+ * and spawns a real GemRB::Actor for every actor glyph.
+ * Indices match Drawing().Actors(), so ActorPosOf(i) and  ActorCircleSizeOf(i) describe the same
+ * actor ActorOf(i) returns.
+ *
+ * It owns the TestSearchMap and shares its TileProps with the map.
+ * It is built with ActorPainting::Skip so the searchmap holds only what the engine itself put there.
+ *
+ * Because the buffer is shared, Drawing().Matches() reads back the *live* searchmap, actor
+ * footprints and all.
+ */
+class TestGameMap {
+public:
+	TestGameMap(const test::MapRows rows)
+		: drawn(rows, test::ActorPainting::Skip), map(MakeMapFor(drawn))
+	{
+		for (size_t i = 0; i < drawn.Actors().size(); ++i) {
+			actors.push_back(Spawn(i));
+		}
+	}
+
+	const TestSearchMap& Drawing() const noexcept { return drawn; }
+	Map* GetMap() const noexcept { return map; }
+	size_t ActorCount() const noexcept { return actors.size(); }
+
+	/** The live actor for the nth glyph, in the drawing's reading order. */
+	Actor* ActorOf(const size_t index) const
+	{
+		if (index >= actors.size()) {
+			ADD_FAILURE() << "this map has no actor number " << index;
+			return nullptr;
+		}
+		return actors[index];
+	}
+
+	/** Token sum on that navmap pixel, as FindPath() reads it. */
+	TraversabilityCache::TraversabilityCellState StateAt(const Point& navPoint) const
+	{
+		return CellAt(navPoint).state;
+	}
+
+	/** Who the cache has standing there, for the ignore-myself comparison. */
+	const Movable* ActorAt(const Point& navPoint) const
+	{
+		return CellAt(navPoint).occupyingActor;
+	}
+
+	/**
+	 * Brings the cache up to date. A frame does this itself, so this is only for a test that
+	 * wants to read the cache before running any; it is a no-op once a frame has done it.
+	 */
+	void RefreshTraversability() const
+	{
+		map->UpdateTraversabilityCache();
+	}
+
+private:
+	static Map* MakeMapFor(const TestSearchMap& drawn)
+	{
+		auto* tileMap = new TileMap();
+		tileMap->XCellCount = drawn.Width() / 4;
+		tileMap->YCellCount = (drawn.Height() * 12) / 64 + 1;
+
+		Map* map = new Map(tileMap, drawn.Props(), nullptr);
+		core->GetGame()->AddMap(map);
+		// Game keeps its own map list private, so the frame loop needs its own record
+		TestGameLoop::Maps().push_back(map);
+		return map;
+	}
+
+
+	static constexpr unsigned int testAnimationIdBase = 0x9000;
+	/**
+	 * Sizes 1 and 2 are the demo's own creatures. Anything bigger re-points `protagon` at a
+	 * test-only row of avatars.2da (those rows have IDs equal to `testAnimationIdBase + circle_size`)
+	 */
+	Actor* Spawn(const size_t index)
+	{
+		const TestSearchMap::DrawnActor& glyph = drawn.Actors()[index];
+		Actor* actor = gamedata->GetCreature(glyph.circleSize == 1 ? ResRef("rabbit") : ResRef("protagon"));
+		if (!actor) {
+			ADD_FAILURE() << "the demo has to provide a creature to spawn";
+			return nullptr;
+		}
+		if (glyph.circleSize > 2) {
+			actor->SetBase(IE_ANIMATION_ID, testAnimationIdBase + glyph.circleSize);
+		}
+
+		actor->InParty = glyph.flag == PathMapFlags::PC ? 1 : 0;
+
+		// activate so that actor will get the RunScripts priority
+		actor->Activate();
+		actor->Pos = drawn.ActorPosOf(index);
+		map->AddActor(actor, true);
+
+		// the ASCII drawing promised a size and a live actor gets its circle size from
+		// the game data; ensure they agree
+		EXPECT_EQ(actor->circleSize, glyph.circleSize)
+			<< "actor " << index << " was drawn at circle size " << glyph.circleSize
+			<< " but its creature came up at " << actor->circleSize;
+		return actor;
+	}
+
+	TraversabilityCache::TraversabilityCellData CellAt(const Point& navPoint) const
+	{
+		const size_t idx = size_t(navPoint.y) * (drawn.Width() * 16) + navPoint.x;
+		return map->GetTraversabilityCacheData()[idx];
+	}
+
+	TestSearchMap drawn;
+	Map* map = nullptr;
+	std::vector<Actor*> actors;
+};
+
+
+/**
+ * One frame of the real engine loop.
+ *
+ * Game::UpdateScripts() is the frame in game, but it also runs things we don't want in the headless
+ * tests.
+ * Keep only what wee need in tests:
+ *
+ *   DrainCompletedPathsEarly()  collects what the workers published since the last Sync(), so an
+ *                               actor waiting on a path can claim it in this frame rather than
+ *                               the next. Must come before DoStep() consumes foundPaths.
+ *   Map::UpdateScripts()        the actor queues, per-actor update, and DoStepForActor with its
+ *                               bumping and backoff.
+ *   Sync(maps)                  hands new requests to the workers and takes back their results.
+ */
+namespace TestGameLoop {
+
+	/**
+	 * Every live map a test has built, in creation order. Sync() wants them all, and Game keeps
+	 * its own list private, so TestGameMap records them here as it creates them.
+	 */
+	inline std::vector<Map*>& Maps()
+	{
+		static std::vector<Map*> maps;
+		return maps;
+	}
+
+	inline void RunFrame()
+	{
+		Game* game = core->GetGame();
+
+		// Game::Ticks is what Game's own Scriptable::Update() would advance, and DoStep()
+		// returns on `time <= timeStartStep` without it
+		++game->Ticks;
+
+		PathFinderScheduler::DrainCompletedPathsEarly();
+		for (Map* map : Maps()) {
+			map->UpdateScripts();
+		}
+		PathFinderScheduler::Sync(Maps());
+
+		game->AdvanceTime(1);
+	}
+
+	inline void RunFrames(const int count)
+	{
+		for (int i = 0; i < count; ++i) {
+			RunFrame();
+		}
+	}
+
+}
+
+/**
+ * The fixture for anything using TestGameMap: it clears the frame loop's map list on the way
+ * out, so a later suite cannot drive frames over maps whose Game has already been destroyed.
+ */
+class GameMapTest : public LiveGameTest {
+public:
+	static void TearDownTestSuite()
+	{
+		TestGameLoop::Maps().clear();
+		LiveGameTest::TearDownTestSuite();
+	}
+};
+
+}
+
+#endif

--- a/gemrb/tests/core/Test_Map.cpp
+++ b/gemrb/tests/core/Test_Map.cpp
@@ -5,58 +5,30 @@
 // FIXME: remove once fixed, this is excluding non-linux build bots
 #if defined(USE_OPENGL_BACKEND) || (!defined(__APPLE__) && !defined(WIN32))
 
-	#include "../../core/GameData.h"
-	#include "../../core/Interface.h"
-	#include "../../core/InterfaceConfig.h"
-	#include "../../core/Logging/Loggers/Stdio.h"
-	#include "../../core/Logging/Logging.h"
+	#include "LiveGameFixture.h"
+
 	#include "../../core/Map.h"
 	#include "../../core/PathFinder.h"
-	#include "../../core/PluginMgr.h"
-	#include "../../core/SaveGameMgr.h"
 
 	#include <gtest/gtest.h>
 
 namespace GemRB {
 
-class MapTest : public testing::Test {
+class MapTest : public LiveGameTest {
 public:
-	static std::unique_ptr<Interface> gemrb;
 	static Map* map;
 
-	// set up core and the first map from the demo
+	// set up the first map from the demo
 	static void SetUpTestSuite()
 	{
-		setlocale(LC_ALL, "");
-		const char* argv[] = { "tester", "-c", "../../tester.cfg" };
-		auto cfg = LoadFromArgs(3, const_cast<char**>(argv));
-		ToggleLogging(true);
-		SetMainLogLevel(DEBUG);
-		AddLogWriter(createStdioLogWriter());
-		gemrb = std::make_unique<Interface>(std::move(cfg));
-
-		auto gamStream = gamedata->GetResourceStream("gem-demo", IE_GAM_CLASS_ID);
-		auto gamMgr = GetImporter<SaveGameMgr>(IE_GAM_CLASS_ID, gamStream);
-		auto gam = gamMgr->LoadGame(std::make_unique<Game>(), GAMVersion::GemRB);
-		core->SetGame(std::move(gam));
-		Game* game = core->GetGame();
+		LiveGameTest::SetUpTestSuite();
 
 		ResRef mapRef { "ar0100" };
-		map = game->GetMap(mapRef, false);
-	}
-
-	static void TearDownTestSuite()
-	{
-		// cleanup to prevent a delay and crash on exit
-		core->SetGame(nullptr);
-		VideoDriver.reset();
-		gemrb.reset();
-		PluginMgr::Get()->RunCleanup();
+		map = core->GetGame()->GetMap(mapRef, false);
 	}
 };
 
 Map* MapTest::map = nullptr;
-std::unique_ptr<Interface> MapTest::gemrb = nullptr;
 
 static Point badPaths[] = { Point(1270, 640), Point(1071, 699), Point(1170, 967), Point(1126, 601) };
 static Point goodPaths[] = { Point(1126, 601), Point(685, 655), Point(720, 496), Point(1056, 336) };

--- a/gemrb/tests/core/Test_Movement.cpp
+++ b/gemrb/tests/core/Test_Movement.cpp
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the GemRB project <https://gemrb.org>
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Movement tests: the real per-frame loop, with bumping, backoff and repathing.
+// The live-game scaffolding lives in TestGameFixture.h; what is here is movement specific.
+
+#if defined(USE_OPENGL_BACKEND) || (!defined(__APPLE__) && !defined(WIN32))
+
+	#include "TestGameMap.h"
+
+	#include <gtest/gtest.h>
+
+namespace GemRB {
+
+
+class MovementTest : public GameMapTest {
+};
+
+// === helpers ===
+
+// The invariant that catches tunnelling. One frame moves the actor a good fraction of a tile,
+// so it can stand on open floor before the frame and on open floor after it and still have
+// passed straight through a wall in between. Speed 0 samples the segment as finely as the
+// engine ever steps, so a wall cannot hide between two samples.
+static testing::AssertionResult StepStayedOffWalls(const TestSearchMap& drawn, const Point& from, const Point& to)
+{
+	constexpr int noSpeed = 0;
+	constexpr int noCircle = 0;
+	const PathMapFlags crossed = PathFinder::GetBlockedInLine(drawn.Props(), from, to, false, noSpeed, noCircle);
+	if (bool(crossed & (PathMapFlags::SIDEWALL | PathMapFlags::DOOR_IMPASSABLE))) {
+		return testing::AssertionFailure()
+			<< "step (" << from.x << ',' << from.y << ") -> (" << to.x << ',' << to.y << ") crosses a wall";
+	}
+	return testing::AssertionSuccess();
+}
+
+// Runs frames until the actor stops moving, checking every single step against a wall. Returns
+// how many frames it took, or the budget if it never arrived.
+static int WalkUntilStopped(const TestGameMap& live, Actor* actor, int frameBudget = 200)
+{
+	int frames = 0;
+	for (; frames < frameBudget && actor->InMove(); ++frames) {
+		const Point before = actor->Pos;
+		TestGameLoop::RunFrame();
+		EXPECT_TRUE(StepStayedOffWalls(live.Drawing(), before, actor->Pos)) << "on frame " << frames;
+	}
+	return frames;
+}
+
+// === TestGameMap infrastructure tests ===
+
+// A drawn map can carry a real actor, and the real pathfinder answers for it.
+TEST_F(MovementTest, DrawnMapCarriesARealActor)
+{
+	// '2' is a party member of circle size 2, standing where the glyph is
+	const TestGameMap live {
+		"##########",
+		"#........#",
+		"#..2....E#",
+		"#........#",
+		"##########"
+	};
+	const TestSearchMap& drawn = live.Drawing();
+
+	ASSERT_EQ(live.ActorCount(), 1);
+	Actor* actor = live.ActorOf(0);
+	ASSERT_NE(actor, nullptr) << "the demo has to provide a creature data to walk around";
+
+	EXPECT_NE(actor->GetAnims(), nullptr) << "UpdateScripts dereferences this for a moving actor";
+	EXPECT_EQ(actor->GetCurrentArea(), live.GetMap());
+	EXPECT_GT(actor->GetSpeed(), 0) << "a speed of 0 means DoStep() never moves it";
+	EXPECT_EQ(actor->Pos, drawn.ActorPosOf(0)) << "the glyph says where it stands";
+	EXPECT_EQ(actor->InParty, 1) << "a digit glyph is a party member";
+
+	actor->WalkTo(drawn.End(), 0, 0);
+	// the pathfiner scheduler runs in immediate mode, so above call is answered synchronously
+	EXPECT_TRUE(actor->InMove()) << "WalkTo() should have put the actor in a moving state";
+	EXPECT_FALSE(actor->GetPath().Empty()) << "WalkTo() should have produced a path";
+}
+
+// The glyph decides which creature is spawned, so a drawing gets the size it asked for
+// and it properly honours `InParty` value
+TEST_F(MovementTest, GlyphsDecideSizeAndParty)
+{
+	TestGameMap live {
+		"###################",
+		"#.................#",
+		"#.................#",
+		"#....1......b.....#",
+		"#.................#",
+		"#.................#",
+		"#.................#",
+		"###################"
+	};
+	const TestSearchMap& drawn = live.Drawing();
+
+	ASSERT_EQ(live.ActorCount(), 2);
+
+	// the small one is a party member, the letter is not
+	EXPECT_EQ(live.ActorOf(0)->circleSize, 1);
+	EXPECT_EQ(live.ActorOf(0)->InParty, 1);
+	EXPECT_EQ(live.ActorOf(1)->circleSize, 2);
+	EXPECT_EQ(live.ActorOf(1)->InParty, 0);
+
+	// and both stand where they were drawn
+	EXPECT_EQ(live.ActorOf(0)->Pos, drawn.ActorPosOf(0));
+	EXPECT_EQ(live.ActorOf(1)->Pos, drawn.ActorPosOf(1));
+
+	// the live actors reach the cache the pathfinder consults, each owning its own cell
+	live.RefreshTraversability();
+	EXPECT_GT(live.StateAt(drawn.ActorPosOf(0)), TraversabilityCache::TraversabilityCellValueEmpty);
+	EXPECT_EQ(live.ActorAt(drawn.ActorPosOf(0)), live.ActorOf(0));
+	EXPECT_EQ(live.ActorAt(drawn.ActorPosOf(1)), live.ActorOf(1));
+}
+
+// Every size the glyph alphabet allows, has a creature behind it.
+// Sizes 3 to 8 are the test-only creatures in demo/override.
+TEST_F(MovementTest, EveryDrawnSizeHasACreature)
+{
+	const TestGameMap live {
+		"###########################",
+		"#.1a.2b.3c.4d.5e.6f.7g.8h.#",
+		"###########################"
+	};
+
+	constexpr size_t sizeCount = 8;
+	ASSERT_EQ(live.ActorCount(), sizeCount * 2);
+	for (size_t i = 0; i < sizeCount; ++i) {
+		const uint16_t expectedCircleSize = i + 1;
+		const size_t numberGlyphIdx = i * 2;
+		const char numberGlyphChar = static_cast<char>(i) + test::Glyph::FirstPC;
+		const size_t letterGlyphIdx = i * 2 + 1;
+		const char letterGlyphChar = static_cast<char>(i) + test::Glyph::FirstNPC;
+		// test number
+		EXPECT_EQ(live.Drawing().ActorCircleSizeOf(numberGlyphIdx), expectedCircleSize) << "glyph " << numberGlyphChar;
+		EXPECT_EQ(live.ActorOf(numberGlyphIdx)->circleSize, expectedCircleSize) << "live actor " << numberGlyphChar;
+		// test letter
+		EXPECT_EQ(live.Drawing().ActorCircleSizeOf(letterGlyphIdx), expectedCircleSize) << "glyph " << letterGlyphChar;
+		EXPECT_EQ(live.ActorOf(letterGlyphIdx)->circleSize, expectedCircleSize) << "live actor " << letterGlyphChar;
+	}
+}
+
+// The plain case: an open corridor, walked end to end.
+// Test if basic assumptions about the simple walk hold.
+TEST_F(MovementTest, WalksToItsDestination)
+{
+	TestGameMap live {
+		"##########",
+		"#........#",
+		"#2......E#",
+		"#........#",
+		"##########"
+	};
+	const TestSearchMap& drawn = live.Drawing();
+	Actor* actor = live.ActorOf(0);
+	ASSERT_NE(actor, nullptr);
+
+	actor->WalkTo(drawn.End(), 0, 0);
+	ASSERT_FALSE(actor->GetPath().Empty()) << "the walk needs a path to follow";
+
+	const int frames = WalkUntilStopped(live, actor);
+	EXPECT_LT(frames, 200) << "the walk has to finish inside the frame budget";
+	EXPECT_GT(frames, 1) << "arriving in one frame would mean it teleported, not walked";
+	EXPECT_EQ(actor->Pos, drawn.End()) << "and it has to end up where it was sent";
+}
+
+// Live map uses as its searchmap the drawing's own buffer, so a drawing reads back the
+// live state: in consequence the whole glyph vocabulary should work on live state.
+// Test if simple walk can be asserted with ASCII map and actor doesn't leave any stale
+// footprints on the searchmap.
+TEST_F(MovementTest, LeavesNoStaleFootprintWhereItStarted)
+{
+	const TestGameMap live {
+		"##########",
+		"#........#",
+		"#2......E#",
+		"#........#",
+		"##########"
+	};
+	const TestSearchMap& drawn = live.Drawing();
+	Actor* actor = live.ActorOf(0);
+
+	actor->WalkTo(drawn.End(), 0, 0);
+	ASSERT_GT(WalkUntilStopped(live, actor), 1);
+
+	// only the footprint it is standing in now, nothing left behind at the start
+	const test::MapRows expected {
+		"##########",
+		"#......PP#",
+		"#......PP#",
+		"#......PP#",
+		"##########"
+	};
+	EXPECT_TRUE(drawn.Matches(expected));
+}
+
+// The simple case of walk with obstacle: the direct line is blocked, so the route has to bend
+// around a barrier. Verify every frame if the actor hasn't tunneled through wall.
+TEST_F(MovementTest, WalksAroundABarrierWithoutCrossingIt)
+{
+	const TestGameMap live {
+		"###########",
+		"#2...#E...#",
+		"#....#....#",
+		"#....#....#",
+		"#.........#",
+		"###########"
+	};
+	const TestSearchMap& drawn = live.Drawing();
+	Actor* actor = live.ActorOf(0);
+	ASSERT_NE(actor, nullptr);
+
+	// assert that the straight line between the two is blocked, so the per-frame check has something to
+	// catch and is not quietly passing on every input
+	ASSERT_FALSE(StepStayedOffWalls(drawn, drawn.ActorPosOf(0), drawn.End()))
+		<< "the barrier has to lie across the direct line, or this test proves nothing";
+
+	actor->WalkTo(drawn.End(), 0, 0);
+	ASSERT_FALSE(actor->GetPath().Empty());
+
+	const int frames = WalkUntilStopped(live, actor);
+	EXPECT_LT(frames, 200);
+	EXPECT_GT(frames, 1);
+	EXPECT_EQ(actor->Pos, drawn.End());
+}
+
+}
+
+#endif

--- a/gemrb/tests/core/Test_Movement.cpp
+++ b/gemrb/tests/core/Test_Movement.cpp
@@ -114,8 +114,7 @@ TEST_F(MovementTest, GlyphsDecideSizeAndParty)
 	EXPECT_EQ(live.ActorAt(drawn.ActorPosOf(1)), live.ActorOf(1));
 }
 
-// Every size the glyph alphabet allows, has a creature behind it.
-// Sizes 3 to 8 are the test-only creatures in demo/override.
+// Every size the glyph alphabet allows, has a creature with proper stats behind it.
 TEST_F(MovementTest, EveryDrawnSizeHasACreature)
 {
 	const TestGameMap live {
@@ -163,6 +162,43 @@ TEST_F(MovementTest, WalksToItsDestination)
 	EXPECT_LT(frames, 200) << "the walk has to finish inside the frame budget";
 	EXPECT_GT(frames, 1) << "arriving in one frame would mean it teleported, not walked";
 	EXPECT_EQ(actor->Pos, drawn.End()) << "and it has to end up where it was sent";
+}
+
+// The complementary to the walk above, for actor which needs to stand on more than one tile.
+TEST_F(MovementTest, StopsShortOfADestinationItDoesNotFitInto)
+{
+	TestGameMap live {
+		"###############",
+		"#.............#",
+		"#.............#",
+		"#...3........E#",
+		"#.............#",
+		"#.............#",
+		"###############"
+	};
+	const TestSearchMap& drawn = live.Drawing();
+	Actor* actor = live.ActorOf(0);
+	ASSERT_NE(actor, nullptr);
+	ASSERT_EQ(actor->circleSize, 3);
+
+	const SearchmapPoint endTile { drawn.End() };
+	// E lies against the wall: room enough for small actors, but not for this one:
+	EXPECT_TRUE(bool(PathFinder::GetBlockedInRadiusTile(drawn.Props(), endTile, 2) & PathMapFlags::PASSABLE))
+		<< "the size <=2 has to still fit";
+	ASSERT_FALSE(bool(PathFinder::GetBlockedInRadiusTile(drawn.Props(), endTile, 3) & PathMapFlags::PASSABLE))
+		<< "for this size the pathfinder should claim end position is not passable";
+
+	actor->WalkTo(drawn.End(), 0, 0);
+	ASSERT_FALSE(actor->GetPath().Empty()) << "an end it cannot stand on still has reachable neighbours";
+
+	const int frames = WalkUntilStopped(live, actor);
+	EXPECT_LT(frames, 200) << "the walk has to finish inside the frame budget";
+	EXPECT_GT(frames, 1);
+
+	// it stopped short of where it was sent
+	EXPECT_NE(actor->Pos, drawn.End()) << "the destination had to be pulled back off the wall";
+	EXPECT_LT(Distance(actor->Pos, drawn.End()), Distance(drawn.ActorPosOf(0), drawn.End()))
+		<< "stopping short still means walking towards the end, not giving up at the start";
 }
 
 // Live map uses as its searchmap the drawing's own buffer, so a drawing reads back the


### PR DESCRIPTION
Added test data to demo:
- avatars.2da - 6 rows giving circle sizes 3–8, reusing CHMB1 art,

Added GEM_EXPORT to PathFinderScheduler so tests can call Start/Stop.

New test infrastructure:
- LiveGameFixture.h - headless Interface + demo game; GameControl, unpause, pathfinder scheduler in immediate mode
- TestGameMap.h - real Map from an ASCII drawing, actors spawned from glyphs, TestGameLoop::RunFrame()
- Test_Movement.cpp - 6 basic movement tests: walking, wall-crossing per frame, sizes, party membership, no stale footprint

Changed test infrastructure:
- SearchMapBuilder.h - ActorPainting enum so we can skip painting actors 'by hand'
- Test_Map.cpp - migrated to use LiveGameTest,
- CMakeLists.txt - registers Test_Movement.cpp.