### PR TITLE
Fix compilation under g++ 11.5

### DIFF
--- a/gemrb/core/Strings/CString.h
+++ b/gemrb/core/Strings/CString.h
@@ -20,6 +20,8 @@
 #include <cstdio>
 #include <cstring>
 #include <cwctype>
+#include <iterator>
+#include <memory>
 
 #ifndef WIN32
 	#define stricmp  strcasecmp
@@ -87,6 +89,22 @@ class FixedSizeString {
 	static_assert(LEN < 255, "Cannot create FixedSizeString larger than 255 characters");
 	char str[LEN + 1] { '\0' };
 
+	template<typename STR>
+	void CopyFrom(const STR& s) noexcept
+	{
+		const auto src = std::begin(s);
+		const auto srcLen = static_cast<size_t>(std::distance(src, std::end(s)));
+		if (srcLen == 0) {
+			std::fill(begin(), bufend(), '\0');
+		} else {
+			size_t n = std::min(srcLen, LEN);
+			std::copy_n(std::addressof(*src), n, str);
+			if (n < LEN) {
+				std::fill_n(str + n, LEN - n, '\0');
+			}
+		}
+	}
+
 public:
 	using size_type = uint8_t;
 	using iterator = char*;
@@ -113,13 +131,13 @@ public:
 	template<typename STR, ENABLE_CHAR_RANGE(STR)>
 	FixedSizeString(const STR& s) noexcept
 	{
-		strncpy(str, &s[0], LEN);
+		CopyFrom(s);
 	}
 
 	template<typename STR, ENABLE_CHAR_RANGE(STR)>
 	FixedSizeString& operator=(const STR& s) noexcept
 	{
-		strncpy(str, &s[0], LEN);
+		CopyFrom(s);
 		return *this;
 	}
 

--- a/gemrb/tests/core/Strings/Test_CString.cpp
+++ b/gemrb/tests/core/Strings/Test_CString.cpp
@@ -7,6 +7,7 @@
 #include "Strings/CString.h"
 
 #include <gtest/gtest.h>
+#include <string>
 
 namespace GemRB {
 
@@ -23,6 +24,18 @@ TEST(CStringTest, IsASCII)
 
 	unit3 = FixedSizeString<3> { "ab\xFE" };
 	EXPECT_FALSE(unit3.IsASCII());
+}
+
+TEST(CStringTest, EmptyRangeAssign)
+{
+	auto unit = FixedSizeString<8> { "abc" };
+	std::string empty;
+	unit = empty;
+	EXPECT_TRUE(unit.empty());
+	EXPECT_STREQ("", unit.c_str());
+
+	auto fromEmpty = FixedSizeString<8> { "" };
+	EXPECT_TRUE(fromEmpty.empty());
 }
 
 TEST(CStringTest, Format)


### PR DESCRIPTION
The g++ 11.5 can't compile CREImporter.cpp:

```
88:/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:34: error: ‘char* __builtin_strncpy(char*, const
char*, long unsigned int)’ offset [0, 7] is out of the bounds [0, 0] [-Werror=array-bounds]
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘char* strncpy(char*, const char*, size_t)’,
    inlined from ‘GemRB::FixedSizeString<LEN, CMP>& GemRB::FixedSizeString<LEN, CMP>::operator=(const STR&) [
with STR = char [5]; typename std::enable_if<((((! std::is_enum<T>::value) && (! std::is_fundamental<STR>::
value)) && (! std::is_pointer<T>::value)) || std::is_same<STR, const char (&)[1]>::value), int>::type
<anonymous> = 0; long unsigned int LEN = 8; int (* CMP)(const char*, const char*, size_t) = strncasecmp]’ at
/tmp/opencode/gemrb-master/gemrb/core/Strings/CString.h:122:10,
    inlined from ‘virtual GemRB::Actor* GemRB::CREImporter::GetActor(unsigned char)’ at /tmp/opencode/gemrb-
master/gemrb/plugins/CREImporter/CREImporter.cpp:883:25:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:34: error: ‘char* __builtin_strncpy(char*, const
char*, long unsigned int)’ offset [0, 7] is out of the bounds [0, 0] [-Werror=array-bounds]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

Trigger line is CREImporter.cpp:883: `act->SmallPortrait = "NONE";` ("NONE" = char[5], target ResRef=FixedSizeString<8>).

The new `CopyFrom` helper first measures the actual length of the source range, then copies only `min(sourceLength, LEN)` characters into the fixed buffer and fills the rest of the buffer with zeros. 
Because the copy never asks to read more bytes than the source actually contains, GCC's bounds check passes. 
The buffer is still always zero-padded and NUL-terminated, the behavior is unchanged.